### PR TITLE
Add requirements.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,16 @@
+numpy==1.14.2
+scipy==1.3.0
+mrcfile
+finufftpy
+importlib_resources>=1.0.2
+matplotlib
+pyfftw
+scikit-image==0.14.0
+click
+pytest
+pytest-cov
+console_progressbar
+pandas>=0.23.4
+joblib
+tqdm
+scikit-learn

--- a/requirements_optional.txt
+++ b/requirements_optional.txt
@@ -1,0 +1,11 @@
+cython
+jupyter
+numpydoc
+pillow
+pip
+pybind11
+wheel
+coveralls
+python-box
+sphinxcontrib-bibtex
+sphinx-rtd-theme==0.4.2


### PR DESCRIPTION
These packages are extracted from the `environment.yml` file and
installing them using `pip` seems to allow all the tests to pass. Other
packages, which were listed in `environment.yml` but were not needed for
the tests to pass, are listed in `requirements_optional.txt`.

@vineetbansal was talking about some way to have the `environment.yml` file include `requirements.txt`. If we could do this, that would eliminate a lot of redundancy.