### PR TITLE
Replace Rotation.as_dcm with Rotation.as_matrix

### DIFF
--- a/src/aspire/source/__init__.py
+++ b/src/aspire/source/__init__.py
@@ -125,7 +125,7 @@ class ImageSource:
         """
         :return: Rotation matrices as a n x 3 x 3 array
         """
-        return self._rotations.as_dcm()
+        return self._rotations.as_matrix()
 
     @angles.setter
     def angles(self, values):


### PR DESCRIPTION
The former is deprecated, so it generates several warnings in recent
versions of SciPy.