### PR TITLE
Batched 2D covariance estimation

### DIFF
--- a/src/aspire/estimation/covar2d.py
+++ b/src/aspire/estimation/covar2d.py
@@ -303,3 +303,292 @@ class RotCov2D:
             coeffs_est[:, ctf_idx == k] = coeff_est_k
 
         return coeffs_est
+
+
+class BatchedRotCov2D(RotCov2D):
+    """
+    Perform batchwise rotationally equivariant 2D covariance estimation from an
+    `ImageSource` objects. This is done with a single pass through the data,
+    processing moderately-sized batches one at a time. The rotational
+    equivariance is achieved by decomposing images in a steerable Fourier–Bessel
+    basis. For more information, see
+
+        T. Bhamre, T. Zhang, and A. Singer, "Denoising and covariance estimation
+        of single particle cryo-EM images", J. Struct. Biol. 195, 27-81 (2016).
+        DOI: 10.1016/j.jsb.2016.04.013
+
+        :param src: The `ImageSource` object from which the sample images are to
+        be extracted.
+        :param basis: The `FBBasis2D` object used to decompose the images. By
+        default, this is set to `FFBBasis2D((src.L, src.L))`.
+        :param batch_size: The number of images to process at a time (default
+        8192).
+    """
+
+    def __init__(self, src, basis=None, batch_size=8192):
+        self.src = src
+        self.basis = basis
+        self.batch_size = batch_size
+
+        self.b_mean = None
+        self.b_covar = None
+        self.A_mean = None
+        self.A_covar = None
+        self.M_covar = None
+
+        self._build()
+
+    def _build(self):
+        src = self.src
+
+        if self.basis is None:
+            from aspire.basis.ffb_2d import FFBBasis2D
+            self.basis = FFBBasis2D((src.L, src.L))
+
+        unique_filters = list(set(src.filters))
+        ctf_idx = np.array([unique_filters.index(f) for f in src.filters])
+
+        ctf_fb = [f.fb_mat(self.basis) for f in unique_filters]
+
+        self.ctf_fb = ctf_fb
+        self.ctf_idx = ctf_idx
+
+    def _calc_rhs(self):
+        src = self.src
+        basis = self.basis
+
+        ctf_fb = self.ctf_fb
+        ctf_idx = self.ctf_idx
+
+        partition = blk_diag_partition(ctf_fb[0])
+
+        zero_coeff = np.zeros((basis.count,))
+
+        b_mean = [np.zeros(basis.count) for _ in ctf_fb]
+
+        b_covar = blk_diag_zeros(partition, dtype=src.dtype)
+
+        for start in range(0, src.n, self.batch_size):
+            batch = np.arange(start, min(start + self.batch_size, src.n))
+
+            im = src.images(batch[0], len(batch))
+            coeff = basis.evaluate_t(im.data)
+
+            for k in np.unique(ctf_idx[batch]):
+                coeff_k = coeff[:, ctf_idx[batch] == k]
+                weight = np.size(coeff_k, 1) / src.n
+
+                mean_coeff_k = self._get_mean(coeff_k)
+
+                ctf_fb_k = ctf_fb[k]
+                ctf_fb_k_t = blk_diag_transpose(ctf_fb_k)
+
+                b_mean_k = weight * blk_diag_apply(ctf_fb_k_t, mean_coeff_k)
+
+                b_mean[k] += b_mean_k
+
+                covar_coeff_k = self._get_covar(coeff_k, zero_coeff)
+
+                b_covar_k = blk_diag_mult(ctf_fb_k_t, covar_coeff_k)
+                b_covar_k = blk_diag_mult(b_covar_k, ctf_fb_k)
+                b_covar_k = blk_diag_mult(weight, b_covar_k)
+
+                b_covar = blk_diag_add(b_covar, b_covar_k)
+
+        self.b_mean = b_mean
+        self.b_covar = b_covar
+
+    def _calc_op(self):
+        src = self.src
+        basis = self.basis
+
+        ctf_fb = self.ctf_fb
+        ctf_idx = self.ctf_idx
+
+        partition = blk_diag_partition(ctf_fb[0])
+
+        A_mean = blk_diag_zeros(partition, dtype=src.dtype)
+        A_covar = [None for _ in ctf_fb]
+        M_covar = blk_diag_zeros(partition, dtype=src.dtype)
+
+        for k in np.unique(ctf_idx):
+            weight = np.count_nonzero(ctf_idx == k) / src.n
+
+            ctf_fb_k = ctf_fb[k]
+            ctf_fb_k_t = blk_diag_transpose(ctf_fb_k)
+
+            A_mean_k = blk_diag_mult(ctf_fb_k_t, ctf_fb_k)
+            A_mean_k = blk_diag_mult(weight, A_mean_k)
+
+            A_mean = blk_diag_add(A_mean, A_mean_k)
+
+            A_covar_k = blk_diag_mult(ctf_fb_k_t, ctf_fb_k)
+            A_covar_k = blk_diag_mult(np.sqrt(weight), A_covar_k)
+
+            A_covar[k] = A_covar_k
+
+            M_covar_k = A_covar_k
+
+            M_covar = blk_diag_add(M_covar, A_covar_k)
+
+        self.A_mean = A_mean
+        self.A_covar = A_covar
+        self.M_covar = M_covar
+
+    def _mean_correct_covar_rhs(self, b_covar, b_mean, mean_coeff):
+        src = self.src
+        basis = self.basis
+
+        ctf_fb = self.ctf_fb
+        ctf_idx = self.ctf_idx
+
+        partition = blk_diag_partition(ctf_fb[0])
+
+        # Note: If we don't do this, we'll be modifying the stored `b_covar`
+        # since the operations below are in-place.
+        b_covar = [blk.copy() for blk in b_covar]
+
+        for k in np.unique(ctf_idx):
+            weight = np.count_nonzero(ctf_idx == k) / src.n
+
+            ctf_fb_k = ctf_fb[k]
+            ctf_fb_k_t = blk_diag_transpose(ctf_fb_k)
+
+            mean_coeff_k = blk_diag_apply(ctf_fb_k, mean_coeff)
+            mean_coeff_k = blk_diag_apply(ctf_fb_k_t, mean_coeff_k)
+
+            mean_coeff_k = mean_coeff_k[:partition[0][0]]
+            b_mean_k = b_mean[k][:partition[0][0]]
+
+            correction = (np.outer(mean_coeff_k, b_mean_k)
+                          + np.outer(b_mean_k, mean_coeff_k)
+                          - weight * np.outer(mean_coeff_k, mean_coeff_k))
+
+            b_covar[0] -= correction
+
+        return b_covar
+
+    def _noise_correct_covar_rhs(self, b_covar, b_noise, noise_var, shrinker):
+        if shrinker == 'None':
+            b_noise = blk_diag_mult(-noise_var, b_noise)
+            b_covar = blk_diag_add(b_covar, b_noise)
+        else:
+            b_covar = self.shrink_covar_backward(b_covar, b_noise, self.src.n,
+                                                 noise_var, shrinker)
+
+        return b_covar
+
+    def _solve_covar(self, A_covar, b_covar, M, covar_est_opt):
+        ctf_fb = self.ctf_fb
+        ctf_idx = self.ctf_idx
+
+        partition = blk_diag_partition(ctf_fb[0])
+
+        def precond_fun(S, x):
+            p = np.size(S, 0)
+            ensure(np.size(x) == p*p, 'The sizes of S and x are not consistent.')
+            x = m_reshape(x, (p, p))
+            y = S @ x @ S
+            return y
+
+        def apply(A, x):
+            p = np.size(A[0], 0)
+            x = m_reshape(x, (p, p))
+            y = np.zeros_like(x)
+            for k in range(0, len(A)):
+                    y = y + A[k] @ x @ A[k].T
+            return y
+
+        cg_opt = covar_est_opt
+        covar_coeff = blk_diag_zeros(partition, dtype=b_covar[0].dtype)
+
+        for ell in range(0, len(b_covar)):
+            A_ell = []
+            for k in range(0, len(A_covar)):
+                A_ell.append(A_covar[k][ell])
+            b_ell = b_covar[ell]
+            S = inv(M[ell])
+            cg_opt['preconditioner'] = lambda x: precond_fun(S, x)
+            covar_coeff[ell], _, _ = conj_grad(lambda x: apply(A_ell, x), b_ell, cg_opt)
+
+        return covar_coeff
+
+    def get_mean(self):
+        """
+        Calculate the rotationally invariant mean image in the basis
+        coefficients.
+
+        :return: The mean coefficient vector in `self.basis`.
+        """
+
+        if not self.b_mean:
+            self._calc_rhs()
+
+        if not self.A_mean:
+            self._calc_op()
+
+        b_mean_all = np.stack(self.b_mean).sum(axis=0)
+        mean_coeff = blk_diag_solve(self.A_mean, b_mean_all)
+
+        return mean_coeff
+
+    def get_covar(self, noise_var=1, mean_coeff=None, covar_est_opt=None):
+        """
+        Calculate the block diagonal covariance matrix in the basis
+        coefficients.
+
+        :param noise_var: The variance of the noise in the images (default 1)
+        :param mean_coeff: If specified, overrides the mean coefficient vector
+        used to calculate the covariance (default `self.get_mean()`).
+        :param :covar_est_opt: The estimation parameters for obtaining the covariance
+        matrix in the form of a dictionary. Keys include:
+            - 'shrinker': The type of shrinkage we apply to the right-hand side
+              in the normal equations. Can be `'None'`, in which case no
+              shrinkage is performed. For a list of shrinkers, see the
+              documentation of `shrink_covar`.
+            - 'verbose': Verbosity (integer) of the conjugate gradient algorithm
+              (see documentation for `conj_grad`, default zero).
+            - 'max_iter': Maximum number of conjugate gradient iterations (see
+              documentation for `conj_grad`, default 250).
+            - 'iter_callback': Callback performed at the end of an iteration
+              (see documentation for `conj_grad`, default `[]`).
+            - 'store_iterates': Determines whether to store intermediate
+              iterates (see documentation for `conj_grad`, default `False`).
+            - 'rel_tolerance': Relative stopping tolerance of the conjugate
+              gradient algorithm (see documentation for `conj_grad`, default
+              `1e-12`).
+            - 'precision': Precision of conjugate gradient algorithm (see
+              documentation for `conj_grad`, default `'float64'`)
+        :return: The block diagonal matrix containing the basis coefficients (in
+        `self.basis`) for the estimated covariance matrix. These may be
+        manipulated using the `blk_diag_*` functions.
+        """
+
+        if not covar_est_opt:
+            covar_est_opt = {'shrinker': 'None',
+                             'verbose': 0,
+                             'max_iter': 250,
+                             'iter_callback': [],
+                             'store_iterates': False,
+                             'rel_tolerance': 1e-12,
+                             'precision': 'float64'}
+
+        if not self.b_covar:
+            self._calc_rhs()
+
+        if not self.A_covar or self.M_covar:
+            self._calc_op()
+
+        if mean_coeff is None:
+            mean_coeff = self.get_mean()
+
+        b_covar = self.b_covar
+
+        b_covar = self._mean_correct_covar_rhs(b_covar, self.b_mean, mean_coeff)
+        b_covar = self._noise_correct_covar_rhs(b_covar, self.A_mean, noise_var,
+                                                covar_est_opt['shrinker'])
+
+        covar_coeff = self._solve_covar(self.A_covar, b_covar, self.M_covar,
+                                        covar_est_opt)
+
+        return covar_coeff

--- a/src/aspire/utils/blk_diag_func.py
+++ b/src/aspire/utils/blk_diag_func.py
@@ -125,6 +125,12 @@ def blk_diag_apply(blk_diag, x):
 
     if np.sum(cols) != np.size(x, 0):
         raise RuntimeError('Sizes of matrix `blk_diag` and `x` are not compatible.')
+
+    vector = False
+    if np.ndim(x) == 1:
+        x = x[:, np.newaxis]
+        vector = True
+
     rows = np.array([np.size(x, 1), ])
     cellarray = Cell2D(cols, rows, dtype=x.dtype)
     x_cell = cellarray.mat2cell(x, cols, rows)
@@ -133,6 +139,10 @@ def blk_diag_apply(blk_diag, x):
         mat = blk_diag[i] @ x_cell[i]
         y.append(mat)
     y = np.concatenate(y, axis=0)
+
+    if vector:
+        y = y[:, 0]
+
     return y
 
 
@@ -196,6 +206,12 @@ def blk_diag_solve(blk_diag, y):
     rows = np.array([np.size(mat_a, 0) for mat_a in blk_diag])
     if sum(rows) != np.size(y, 0):
         raise RuntimeError('Sizes of matrix `blk_diag` and `y` are not compatible.')
+
+    vector = False
+    if np.ndim(y) == 1:
+        y = y[:, np.newaxis]
+        vector = True
+
     cols = np.array([np.size(y, 1)])
     cellarray = Cell2D(rows, cols, dtype=y.dtype)
     y = cellarray.mat2cell(y, rows, cols)
@@ -203,6 +219,10 @@ def blk_diag_solve(blk_diag, y):
     for i in range(0,len(blk_diag)):
         x.append(solve(blk_diag[i], y[i]))
     x = np.concatenate(x, axis=0)
+
+    if vector:
+        x = x[:, 0]
+
     return x
 
 

--- a/tests/test_batched_covar2d.py
+++ b/tests/test_batched_covar2d.py
@@ -1,0 +1,125 @@
+import os
+import numpy as np
+from unittest import TestCase
+
+from aspire.source.simulation import Simulation
+from aspire.basis.ffb_2d import FFBBasis2D
+from aspire.utils.filters import RadialCTFFilter
+
+from aspire.estimation.covar2d import RotCov2D, BatchedRotCov2D
+
+
+class BatchedRotCov2DTestCase(TestCase):
+    def setUp(self):
+        n = 32
+        L = 8
+
+        noise_var = 0.1848
+
+        pixel_size = 5
+        voltage = 200
+        defocus_min = 1.5e4
+        defocus_max = 2.5e4
+        defocus_ct = 7
+        Cs = 2.0
+        alpha = 0.1
+
+        filters = [RadialCTFFilter(pixel_size, voltage, defocus=d, Cs=2.0, alpha=0.1)
+                   for d in np.linspace(defocus_min, defocus_max, defocus_ct)]
+
+        src = Simulation(L, n, filters=filters)
+
+        basis = FFBBasis2D((L, L))
+
+        unique_filters = list(set(src.filters))
+        ctf_idx = np.array([unique_filters.index(f) for f in src.filters])
+
+        ctf_fb = [f.fb_mat(basis) for f in unique_filters]
+
+        im = src.images(0, src.n)
+        coeff = basis.evaluate_t(im.data)
+
+        cov2d = RotCov2D(basis)
+        bcov2d = BatchedRotCov2D(src, basis, batch_size=7)
+
+        self.src = src
+        self.basis = basis
+        self.ctf_fb = ctf_fb
+        self.ctf_idx = ctf_idx
+
+        self.cov2d = cov2d
+        self.bcov2d = bcov2d
+
+        self.coeff = coeff
+
+    def tearDown(self):
+        pass
+
+    def blk_diag_allclose(self, blk_diag_a, blk_diag_b):
+        close = True
+        for blk_a, blk_b in zip(blk_diag_a, blk_diag_b):
+            close = (close and np.allclose(blk_a, blk_b))
+        return close
+
+    def test01(self):
+        # Test basic functionality again RotCov2D.
+        noise_var = 0.1848
+
+        mean_cov2d = self.cov2d.get_mean(self.coeff, ctf_fb=self.ctf_fb,
+                                         ctf_idx=self.ctf_idx)
+        covar_cov2d = self.cov2d.get_covar(self.coeff, mean_coeff=mean_cov2d,
+                                      ctf_fb=self.ctf_fb, ctf_idx=self.ctf_idx,
+                                      noise_var=noise_var)
+
+        mean_bcov2d = self.bcov2d.get_mean()
+        covar_bcov2d = self.bcov2d.get_covar(noise_var=noise_var)
+
+        self.assertTrue(np.allclose(mean_cov2d, mean_bcov2d))
+        self.assertTrue(self.blk_diag_allclose(covar_cov2d, covar_bcov2d))
+
+    def test02(self):
+        # Make sure it works with zero mean (pure second moment).
+        zero_coeff = np.zeros((self.basis.count,))
+
+        covar_cov2d = self.cov2d.get_covar(self.coeff, mean_coeff=zero_coeff,
+                                      ctf_fb=self.ctf_fb, ctf_idx=self.ctf_idx)
+
+        covar_bcov2d = self.bcov2d.get_covar(mean_coeff=zero_coeff)
+
+        self.assertTrue(self.blk_diag_allclose(covar_cov2d, covar_bcov2d))
+
+    def test03(self):
+        # Make sure it automatically calls get_mean if needed.
+        covar_cov2d = self.cov2d.get_covar(self.coeff, ctf_fb=self.ctf_fb,
+                                           ctf_idx=self.ctf_idx)
+
+        covar_bcov2d = self.bcov2d.get_covar()
+
+        self.assertTrue(self.blk_diag_allclose(covar_cov2d, covar_bcov2d))
+
+    def test04(self):
+        # Make sure it properly shrinks the right-hand side if specified.
+        covar_est_opt = {'shrinker': 'frobenius_norm',
+                         'verbose': 0,
+                         'max_iter': 250,
+                         'iter_callback': [],
+                         'store_iterates': False,
+                         'rel_tolerance': 1e-12,
+                         'precision': 'float64'}
+
+        covar_cov2d = self.cov2d.get_covar(self.coeff, ctf_fb=self.ctf_fb,
+                                           ctf_idx=self.ctf_idx,
+                                           covar_est_opt=covar_est_opt)
+
+        covar_bcov2d = self.bcov2d.get_covar(covar_est_opt=covar_est_opt)
+
+        self.assertTrue(self.blk_diag_allclose(covar_cov2d, covar_bcov2d))
+
+    def test05(self):
+        # Make sure basis is automatically created if not specified.
+        nbcov2d = BatchedRotCov2D(self.src)
+
+        covar_bcov2d = self.bcov2d.get_covar()
+        covar_nbcov2d = nbcov2d.get_covar()
+
+        self.assertTrue(self.blk_diag_allclose(covar_bcov2d, covar_nbcov2d))

--- a/tests/test_covar2d.py
+++ b/tests/test_covar2d.py
@@ -77,7 +77,7 @@ class Cov2DTestCase(TestCase):
         self.assertTrue(np.allclose(results, self.mean_coeff))
 
     def test02GetCovar(self):
-        results = np.load(os.path.join(DATA_DIR, 'clean70SRibosome_cov2d_covar.npy'))
+        results = np.load(os.path.join(DATA_DIR, 'clean70SRibosome_cov2d_covar.npy'), allow_pickle=True)
         self.covar_coeff = self.cov2d._get_covar(self.coeff_clean)
         im = 0
         for mat in results[0].tolist():
@@ -90,7 +90,7 @@ class Cov2DTestCase(TestCase):
         self.assertTrue(np.allclose(results, self.mean_coeff_ctf))
 
     def test04GetCovarCTF(self):
-        results = np.load(os.path.join(DATA_DIR, 'clean70SRibosome_cov2d_covarctf.npy'))
+        results = np.load(os.path.join(DATA_DIR, 'clean70SRibosome_cov2d_covarctf.npy'), allow_pickle=True)
         self.covar_coeff_ctf = self.cov2d.get_covar(self.coeff, self.h_ctf_fb, self.h_idx,
                                                     noise_var=self.noise_var)
         im = 0
@@ -99,7 +99,7 @@ class Cov2DTestCase(TestCase):
             im += 1
 
     def test05GetCovarCTFShrink(self):
-        results = np.load(os.path.join(DATA_DIR, 'clean70SRibosome_cov2d_covarctf_shrink.npy'))
+        results = np.load(os.path.join(DATA_DIR, 'clean70SRibosome_cov2d_covarctf_shrink.npy'), allow_pickle=True)
         covar_opt = {'shrinker': 'frobenius_norm', 'verbose': 0, 'max_iter': 250, 'iter_callback': [],
                      'store_iterates': False, 'rel_tolerance': 1e-12, 'precision': 'float64'}
         self.covar_coeff_ctf_shrink = self.cov2d.get_covar(self.coeff, self.h_ctf_fb, self.h_idx,


### PR DESCRIPTION
This PR introduces a new class, `BatchedRotCov2D`, which mimics the `RotCov2D` estimator, but does not require all the data in memory to compute the mean and covariance. Instead, it does one pass through the entire dataset (represented by an `ImageSource`), computes various intermediate quantities, and then uses those to estimate the mean and covariance. Ideally, we can incorporate this into the `DenoiserCov2D` class, which should let us run it for datasets that don't fit in memory.