### PR TITLE
Make rolling behavior consistent for singletons

### DIFF
--- a/src/aspire/basis/__init__.py
+++ b/src/aspire/basis/__init__.py
@@ -182,6 +182,8 @@ class Basis:
         logger.info('Expanding array in basis')
         v, info = cg(operator, b, tol=tol)
 
+        v = v[..., np.newaxis]
+
         if info != 0:
             raise RuntimeError('Unable to converge!')
 

--- a/src/aspire/basis/fb_2d.py
+++ b/src/aspire/basis/fb_2d.py
@@ -272,6 +272,8 @@ class FBBasis2D(Basis):
         logger.info('Expanding array in dual basis')
         v, info = cg(operator, b, tol=tol)
 
+        v = v[..., np.newaxis]
+
         if info != 0:
             raise RuntimeError('Unable to converge!')
 

--- a/src/aspire/basis/fb_3d.py
+++ b/src/aspire/basis/fb_3d.py
@@ -257,6 +257,8 @@ class FBBasis3D(Basis):
         logger.info('Expanding array in dual basis')
         v, info = cg(operator, b, tol=tol)
 
+        v = v[..., np.newaxis]
+
         if info != 0:
             raise RuntimeError('Unable to converge!')
 

--- a/src/aspire/estimation/kernel.py
+++ b/src/aspire/estimation/kernel.py
@@ -81,26 +81,26 @@ class FourierKernel(Kernel):
         :return: The original volumes convolved by the kernel with the same dimensions as before.
         """
         N = x.shape[0]
-        kernel_f = self.kernel
+        kernel_f = self.kernel[..., np.newaxis]
         N_ker = kernel_f.shape[0]
 
         x, sz_roll = unroll_dim(x, 4)
         ensure(x.shape[0] == x.shape[1] == x.shape[2] == N, "Volumes in x must be cubic")
-        ensure(kernel_f.ndim == 3, "Convolution kernel must be cubic")
-        ensure(len(set(kernel_f.shape)) == 1, "Convolution kernel must be cubic")
+        ensure(kernel_f.shape[3] == 1, "Convolution kernel must be cubic")
+        ensure(len(set(kernel_f.shape[:3])) == 1, "Convolution kernel must be cubic")
 
-        is_singleton = x.ndim == 3
+        is_singleton = x.shape[3] == 1
 
         if is_singleton:
-            x = fftn(x, (N_ker, N_ker, N_ker))
+            x = fftn(x[..., 0], (N_ker, N_ker, N_ker))[..., np.newaxis]
         else:
             raise NotImplementedError('not yet')
 
         x = x * kernel_f
 
         if is_singleton:
-            x = np.real(ifftn(x))
-            x = x[:N, :N, :N]
+            x[..., 0] = np.real(ifftn(x[..., 0]))
+            x = x[:N, :N, :N, :]
         else:
             raise NotImplementedError('not yet')
 

--- a/src/aspire/utils/matrix.py
+++ b/src/aspire/utils/matrix.py
@@ -19,12 +19,11 @@ def unroll_dim(X, dim):
     dim = dim - 1
     old_shape = X.shape
     new_shape = old_shape[:dim]
-    if dim < len(old_shape):
-        new_shape += (-1, )
-    if old_shape != new_shape:
-        Y = m_reshape(X, new_shape)
-    else:
-        Y = X
+
+    new_shape += (-1, )
+
+    Y = m_reshape(X, new_shape)
+
     removed_dims = old_shape[dim:]
 
     return Y, removed_dims
@@ -32,13 +31,10 @@ def unroll_dim(X, dim):
 
 def roll_dim(X, dim):
     # TODO: dim is still 1-indexed like in MATLAB to reduce headaches for now
-    if len(dim) > 0:
-        old_shape = X.shape
-        new_shape = old_shape[:-1] + dim
-        Y = m_reshape(X, new_shape)
-        return Y
-    else:
-        return X
+    old_shape = X.shape
+    new_shape = old_shape[:-1] + dim
+    Y = m_reshape(X, new_shape)
+    return Y
 
 
 def im_to_vec(im):

--- a/tests/test_FFBbasis2D.py
+++ b/tests/test_FFBbasis2D.py
@@ -70,16 +70,17 @@ class FFBBasis2DTestCase(TestCase):
         result = self.basis.evaluate(v)
 
         self.assertTrue(np.allclose(
-            result[..., 0],
+            result,
             np.load(os.path.join(DATA_DIR, 'ffbbasis2d_xcoeff_out_8_8.npy'))
         ))
 
     def testFFBBasis2DEvaluate_t(self):
         x = np.load(os.path.join(DATA_DIR, 'ffbbasis2d_xcoeff_in_8_8.npy'))
         result = self.basis.evaluate_t(x)
+
         self.assertTrue(np.allclose(
             result,
-            np.load(os.path.join(DATA_DIR, 'ffbbasis2d_vcoeff_out_8_8.npy'))
+            np.load(os.path.join(DATA_DIR, 'ffbbasis2d_vcoeff_out_8_8.npy'))[..., 0]
         ))
 
     def testFFBBasis2DExpand(self):
@@ -87,6 +88,6 @@ class FFBBasis2DTestCase(TestCase):
         result = self.basis.expand(x)
         self.assertTrue(np.allclose(
             result,
-            np.load(os.path.join(DATA_DIR, 'ffbbasis2d_vcoeff_out_exp_8_8.npy'))
+            np.load(os.path.join(DATA_DIR, 'ffbbasis2d_vcoeff_out_exp_8_8.npy'))[..., 0]
         ))
 

--- a/tests/test_FFBbasis3D.py
+++ b/tests/test_FFBbasis3D.py
@@ -101,7 +101,7 @@ class FFBBasis3DTestCase(TestCase):
         result = self.basis.evaluate(coeffs)
 
         self.assertTrue(np.allclose(
-            result[..., 0],
+            result,
             np.load(os.path.join(DATA_DIR, 'ffbbasis3d_xcoeff_out_8_8_8.npy'))
         ))
 
@@ -110,7 +110,7 @@ class FFBBasis3DTestCase(TestCase):
         result = self.basis.evaluate_t(x)
         self.assertTrue(np.allclose(
             result,
-            np.load(os.path.join(DATA_DIR, 'ffbbasis3d_vcoeff_out_8_8_8.npy'))
+            np.load(os.path.join(DATA_DIR, 'ffbbasis3d_vcoeff_out_8_8_8.npy'))[..., 0]
         ))
 
     def testFFBBasis3DExpand(self):
@@ -118,6 +118,6 @@ class FFBBasis3DTestCase(TestCase):
         result = self.basis.expand(x)
         self.assertTrue(np.allclose(
             result,
-            np.load(os.path.join(DATA_DIR, 'ffbbasis3d_vcoeff_out_exp_8_8_8.npy'))
+            np.load(os.path.join(DATA_DIR, 'ffbbasis3d_vcoeff_out_exp_8_8_8.npy'))[..., 0]
         ))
 


### PR DESCRIPTION
In other words, if we call `unroll_dim` on an array that *doesn't* have
any extra dimensions (i.e., if `len(shape) == dim`), we want
`unroll_dim` to add an extra singleton dimension and return `sz_roll =
()`. Then, when we call `roll_dim`, that singleton dimension is removed
(effectively replaced by the empty tuple `sz_roll`). This will make it
easier to handle singleton inputs in the same manner as stacked arrays.