### PR TITLE
Replace customized implementation of Legendre-Gauss quadrature

### DIFF
--- a/src/aspire/aspire/em_classavg/s_em.py
+++ b/src/aspire/aspire/em_classavg/s_em.py
@@ -6,22 +6,14 @@ is_load_large_images = True
 
 if is_load_large_images:
     images_large = data_utils.mat_to_npy('images_large')
-<<<<<<< Updated upstream
-    init_avg_image_large = data_utils.mat_to_npy('init_avg_image_large')
-=======
     init_avg_image_large = data_utils.mat_to_npy('init_avg_image_large').copy()
->>>>>>> Stashed changes
     images = images_large
     init_avg_image = init_avg_image_large
 else:
     images = data_utils.mat_to_npy('images')
     init_avg_image = data_utils.mat_to_npy('init_avg_image')
 
-<<<<<<< Updated upstream
-images = np.transpose(images, axes=(2, 0, 1))  # move to python convention
-=======
 images = np.transpose(images, axes=(2, 0, 1)).copy()  # move to python convention
->>>>>>> Stashed changes
 
 im_avg_est, im_avg_est_orig, log_lik, opt_latent, outlier_ims_inds = em.run(images, init_avg_image)
 

--- a/src/aspire/basis/fpswf_2d.py
+++ b/src/aspire/basis/fpswf_2d.py
@@ -9,7 +9,7 @@ from scipy.optimize import least_squares
 from aspire.nfft import nufft3
 from aspire.basis.basis_utils import t_x_mat, t_x_mat_dot
 from aspire.basis.pswf_2d import PSWFBasis2D
-from aspire.basis.basis_utils import leggauss_0_1
+from aspire.basis.basis_utils import lgwt
 
 logger = logging.getLogger(__name__)
 
@@ -182,7 +182,7 @@ class FPSWFBasis2D(PSWFBasis2D):
         """
         Generate Gaussian quadrature points and weights for the radical parts of 2D PSWFs
         """
-        x, w = leggauss_0_1(20 * n)
+        x, w = lgwt(20 * n, 0, 1)
 
         big_n = 0
 

--- a/src/aspire/basis/pswf_2d.py
+++ b/src/aspire/basis/pswf_2d.py
@@ -4,7 +4,7 @@ import numpy as np
 from aspire.basis import Basis
 from aspire.basis.pswf_utils import BNMatrix
 from aspire.basis.basis_utils import d_decay_approx_fun, t_radial_part_mat, t_x_mat, t_x_derivative_mat
-from aspire.basis.basis_utils import k_operator, leggauss_0_1
+from aspire.basis.basis_utils import k_operator, lgwt
 
 
 logger = logging.getLogger(__name__)
@@ -194,7 +194,7 @@ class PSWFBasis2D(Basis):
 
         m = 0
         n = int(np.ceil(2 * c / np.pi))
-        r, w = leggauss_0_1(n)
+        r, w = lgwt(n, 0, 1)
 
         cons = c / 2 / np.pi
         while True:
@@ -215,7 +215,7 @@ class PSWFBasis2D(Basis):
                 n = n_end + 1
             else:
                 n *= 2
-                r, w = leggauss_0_1(n)
+                r, w = lgwt(n, 0, 1)
 
         return d_vec_all, alpha_all, n_order_length_vec
 


### PR DESCRIPTION
This PR fixes the issue #128 for replacing the customized implementation of Legendre-Gauss quadrature with the numpy version  and the issue #98 for broken merging. 