### PR TITLE
Hackathon 2020 many anufft cov2d

### DIFF
--- a/src/aspire/nfft/__init__.py
+++ b/src/aspire/nfft/__init__.py
@@ -136,8 +136,8 @@ class Plan:
             return super(Plan, cls).__new__(cls)
 
 
-def anufft3(vol_f, fourier_pts, sz, real=False):
-    plan = Plan(sz=sz, fourier_pts=fourier_pts)
+def anufft3(vol_f, fourier_pts, sz, real=False, many=None):
+    plan = Plan(sz=sz, fourier_pts=fourier_pts, many=many)
     adjoint = plan.adjoint(vol_f)
     return np.real(adjoint) if real else adjoint
 

--- a/src/aspire/nfft/finufft.py
+++ b/src/aspire/nfft/finufft.py
@@ -80,7 +80,11 @@ class FINufftPlan(Plan):
         # We form these function signatures here by tuple-unpacking
 
         # Note: Important to have order='F' here!
-        result = np.zeros(self.sz, order='F').astype('complex128')
+        res_shape = self.sz
+        if self.many:
+            res_shape = (*self.sz, self.ntransforms)
+
+        result = np.zeros(res_shape, order='F').astype('complex128')
 
         result_code = self.adjoint_function(
             *self.fourier_pts,


### PR DESCRIPTION
Adds the `many` plan argument for adjoint case so it can be used in cov2d performance measurements during hackathon.

On a batch of 1024 images, this shaves off about 1 second for me. YMMV of course, not sure what it will do on Ascent.

Note the unit test I added is not meant for production, it just supports adhoc testing for hackathon.