### PR TITLE
numpy norm

### DIFF
--- a/src/aspire/source/simulation.py
+++ b/src/aspire/source/simulation.py
@@ -164,7 +164,7 @@ class Simulation(ImageSource):
         vols = self.vols - np.expand_dims(mean_vol, 3)
         coords = vol_to_vec(eig_vols).T @ vol_to_vec(vols)
         res = vols - vec_to_vol(vol_to_vec(eig_vols) @ coords)
-        res_norms = np.diag(anorm(res, (0, 1, 2)))
+        res_norms = anorm(res, (0, 1, 2))
         res_inners = vol_to_vec(mean_vol).T @ vol_to_vec(res)
 
         return coords.squeeze(), res_norms, res_inners

--- a/src/aspire/utils/matrix.py
+++ b/src/aspire/utils/matrix.py
@@ -300,8 +300,11 @@ def anorm(x, axes=None):
     :return: The Euclidean (l^2) norm of x along specified axes.
     """
     if axes is None:
-        axes = range(x.ndim)
-    return np.sqrt(ainner(x, x, axes))
+        norm = np.linalg.norm(x)
+    else:
+        axes = tuple(axes)    # Unrolls any generators, like `range`.
+        norm = np.sqrt(np.sum(x * x, axis=axes))
+    return norm
 
 
 def acorr(x, y, axes=None):

--- a/src/aspire/utils/matrix.py
+++ b/src/aspire/utils/matrix.py
@@ -303,7 +303,7 @@ def anorm(x, axes=None):
         norm = np.linalg.norm(x)
     else:
         axes = tuple(axes)    # Unrolls any generators, like `range`.
-        norm = np.sqrt(np.sum(x * x, axis=axes))
+        norm = np.sqrt(ainner(x, x, axes=axes))
     return norm
 
 
@@ -331,10 +331,8 @@ def ainner(x, y, axes=None):
     :return:
     """
     ensure(x.shape == y.shape, "The shapes of the inputs have to match")
-
-    if axes is None:
-        axes = range(x.ndim)
-    return np.tensordot(x, y, axes=(axes, axes))
+    axes = tuple(axes)    # Unrolls any generators, like `range`.
+    return np.sum(x * y, axis=axes)
 
 
 def eigs(A, k):

--- a/src/aspire/utils/matrix.py
+++ b/src/aspire/utils/matrix.py
@@ -331,7 +331,10 @@ def ainner(x, y, axes=None):
     :return:
     """
     ensure(x.shape == y.shape, "The shapes of the inputs have to match")
-    axes = tuple(axes)    # Unrolls any generators, like `range`.
+
+    if axes is not None:
+        axes = tuple(axes)    # Unrolls any generators, like `range`.
+
     return np.sum(x * y, axis=axes)
 
 


### PR DESCRIPTION
First commit uses np.linalg.norm in place of anorm.

We can talk about what to do for the other cases (high dimensional F order, `ainner` and `acorr` at the dev meeting.

Partially Fixes #185 