### PR TITLE
Incorporate readme feedback from Vineet

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ pip install -e .
 ```
 
 If you prefer not to use Anaconda, or want to manage environments yourself, you should be able to use `pip` with Python >= 3.6.
+Please see the full documentation for details.
 
 You may optionally install additional packages:
 

--- a/README.md
+++ b/README.md
@@ -36,29 +36,22 @@ Note that this step installs the base `aspire` package for you to work with, but
 For developers
 --------------
 
-After cloning this repo, the simplest option is to use Anaconda 64-bit for your platform, and use the provided `environment.yml` file to build a Conda environment to run ASPIRE. This is very similar to above except you will be based off of your local checkout.
+After cloning this repo, the simplest option is to use Anaconda 64-bit for your platform, and use the provided `environment.yml` file to build a Conda environment to run ASPIRE. This is very similar to above except you will be based off of your local checkout, and you are free to rename `aspire_dev` used in the commands below. The `pip` line will install aspire in a locally editable mode, and is equivalent to `python setup.py develop`:
 
 ```
 cd /path/to/git/clone/folder
+
+# Create's the conda environment and installs base dependencies.
 conda env create -f environment.yml --name aspire_dev
+
+# Enable the environment
 conda activate aspire_dev
-```
 
-If you prefer not to use Anaconda, or want to manage environments yourself, you can simply use `pip` with Python >= 3.6.
-
-To install in a locally editable mode, equivalent to `python setup.py develop`  (probably what you want):
-
-```
-cd /path/to/git/clone/folder
+# Install the aspire package in a locally editable way:
 pip install -e .
 ```
 
-To install into the currently active environment's site packages:
-
-```
-cd /path/to/git/clone/folder
-pip install .
-```
+If you prefer not to use Anaconda, or want to manage environments yourself, you should be able to use `pip` with Python >= 3.6.
 
 You may optionally install additional packages:
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -25,11 +25,14 @@ This does not require checking out source code.
 If you are interested in checking out and working with the source code, running tests, or a different flavor of install,
 then skip to the next section now instead.
 
-Once ``conda`` is installed and available on the path, create and activate the environment using:
+Once ``conda`` is installed and available on the path, we can create a fresh ``conda`` environment.
+Here we have chosen to name it ``aspire_env``, but you may choose any name you like so long as that name is used consistently in the following step.
+After creating the environment, we activate it.
+Finally, we install the ``aspire`` package inside the activated environment. This should install all supporting Python software required.
 
 ::
 
-   conda create -n aspire_env python=3.6 pip
+   conda create --name aspire_env python=3.6 pip
    conda activate aspire_env
    pip install aspire
 
@@ -44,20 +47,28 @@ Alternative Developer Installations
 
 Developers are expected to be able to manage their own code and environments.
 However, for consistency and newcomers, we recommend the following procedure using `conda`.
+Note that here the name ``aspire_dev`` was chosen, but you may chose any name for the ``conda`` environment.
+Some people use different environment names for different features,
+but this is personal preference and will largely depend on what type of changes you are making.
+For example, if you are making changes to dependent package versions for testing,
+you would probably want to keep that in a seperate environment.
 
 ::
 
    # Acquire the code.
-   git clone git@github.com:ComputationalCryoEM/ASPIRE-Python.git
+   git clone -b develop https://github.com/ComputationalCryoEM/ASPIRE-Python
    cd ASPIRE-Python
 
    # Create's the conda environment and installs base dependencies.
    conda env create -f environment.yml --name aspire_dev
 
+   # Activate the environment
+   conda activate aspire_dev
+
    # Command to install the aspire package in a locally editable way:
    pip install -e .
 
-We recommend using ``conda`` or a ``virutalenv`` environment managing solutions because ASPIRE may have conflicts or change installed versions of Python packages on your system.
+We recommend using ``conda`` or a ``virtualenv`` environment managing solutions because ASPIRE may have conflicts or change installed versions of Python packages on your system.
 
 Again, we recommend the above for consistency and safety.
 However, ASPIRE is a ``pip`` package,

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -19,13 +19,65 @@ distribution to view Conda's installation instructions.
 Install and Activate the environment
 ************************************
 
-Once `conda` is installed and available on the path, create and activate the environment using:
+For most end users, simply installing the package is sufficient to use ASPIRE.
+The commands in this section should install ASPIRE directly from the ``Python Package Index`` into your activated environment.
+This does not require checking out source code.
+If you are interested in checking out and working with the source code, running tests, or a different flavor of install,
+then skip to the next section now instead.
+
+Once ``conda`` is installed and available on the path, create and activate the environment using:
 
 ::
 
-    cd /path/to/git/clone/folder
-    conda env create -f environment.yml
-    conda activate aspire
+   conda create -n aspire_env python=3.6 pip
+   conda activate aspire_env
+   pip install aspire
+
+.. note::
+    Installing the package installs ASPIRE to the ``site-packages`` folder of your active environment.
+    This is only desirable if you are not going to be doing any development on ASPIRE,
+    but simply want to run scripts that depend on the ASPIRE package.
+
+
+Alternative Developer Installations
+************************************
+
+Developers are expected to be able to manage their own code and environments.
+However, for consistency and newcomers, we recommend the following procedure using `conda`.
+
+::
+
+   # Acquire the code.
+   git clone git@github.com:ComputationalCryoEM/ASPIRE-Python.git
+   cd ASPIRE-Python
+
+   # Create's the conda environment and installs base dependencies.
+   conda env create -f environment.yml --name aspire_dev
+
+   # Command to install the aspire package in a locally editable way:
+   pip install -e .
+
+We recommend using ``conda`` or a ``virutalenv`` environment managing solutions because ASPIRE may have conflicts or change installed versions of Python packages on your system.
+
+Again, we recommend the above for consistency and safety.
+However, ASPIRE is a ``pip`` package,
+so you can attempt to install it using standard ``pip`` or ``setup.py`` commands.
+ASPIRE should generally be compatible with newer version of Python,
+and newer dependent packages, but this is still being tested.
+There are a few known issues.
+While we can try to help,
+you may be on your own for support of this method of installation.
+
+::
+   # Standard pip site-packages installation command
+   cd path/to/aspire-repo
+   pip install .
+
+   # Standard pip developer installation
+   cd path/to/aspire-repo
+   pip install -e .
+
+Note that we hope to have a better automated coverage of ``pip`` installations on recent major Python versions for future releases.
 
 Test the package
 ****************
@@ -35,24 +87,10 @@ Make sure all unit tests run correctly by doing:
 ::
 
     cd /path/to/git/clone/folder
-    python setup.py test
+    pytest tests
 
-Tests currently take around 5 minutes to run. If some tests fail, you may realize that ``python setup.py test`` produces too much information. Re-running tests using ``py.test tests`` in ``/path/to/git/clone/folder`` may provide a cleaner output to analyze.
+Tests currently take around 5 minutes to run.
 
-Install the package
-*******************
-
-If the tests pass, install the ASPIRE package for the currently active Conda environment:
-
-::
-
-    cd /path/to/git/clone/folder
-    python setup.py install
-
-.. note::
-    Installing the package installs ASPIRE to the ``site-packages`` folder of your active environment.
-    This is only desirable if you are not going to be doing any development on ASPIRE,
-    but simply want to run scripts that depend on the ASPIRE package.
 
 Generating Documentation
 ************************


### PR DESCRIPTION
I patched a suggestion from Vineet about simplifying our README developer install section. I agree it is cleaner just having the one (most common) approach listed.