### PR TITLE
Apple Picker dtype

### DIFF
--- a/src/aspire/apple/picking.py
+++ b/src/aspire/apple/picking.py
@@ -88,7 +88,8 @@ class Picker:
         im = im[:side_length, :side_length]
 
         size = tuple((np.array(im.shape) / config.apple.mrc_shrink_factor).astype(int))
-        im = np.array(Image.fromarray(im).resize(size, Image.BICUBIC))
+
+        im = np.array(Image.fromarray(im).resize(size, Image.BICUBIC), dtype=np.float64)
 
         im = signal.correlate(
             im,
@@ -99,7 +100,7 @@ class Picker:
             'same'
         )
 
-        return im.astype('double')
+        return im
 
     def query_score(self, show_progress=True):
         """Calculates score for each query image.


### PR DESCRIPTION
With newer numerical packages (scipy at 1.5.2, from scipy-1.3.0 for example), the results from `scipy.signal.correlate` no longer reproduce our unit test using float32 (on OSX and Linux).  Worked with Ayelet to confirm using float64 for that method returns original behavior for us on OSX.  I confirmed same for my linux box as well this morning. 

Also using the slower `direct` solving method suggests the doubles result is probably what we want.

Note this method was previously upcasting immediate after the `scipy.signal.correlate` call anyway.

Closes #217 