### PR TITLE
Fix pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,5 +75,5 @@ Once ASPIRE is installed, make sure the unit tests run correctly on your platfor
 
 ```
 cd /path/to/git/clone/folder
-pytest tests
+pytest
 ```

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ jobs:
   - bash: |
       source activate myEnvironment
       python setup.py install
-      pytest tests
+      pytest
     displayName: pytest
 
 - job:
@@ -52,7 +52,7 @@ jobs:
   - bash: |
       source activate myEnvironment
       python setup.py install
-      pytest tests
+      pytest
     displayName: pytest
 
 - job:
@@ -82,7 +82,7 @@ jobs:
   - bash: |
       source activate myEnvironment
       python setup.py install
-      pytest tests
+      pytest
     displayName: pytest
 
 - job:
@@ -112,7 +112,7 @@ jobs:
   - bash: |
       source activate myEnvironment
       python setup.py install
-      pytest tests
+      pytest
     displayName: pytest
 
 - job:
@@ -137,7 +137,7 @@ jobs:
   - script: |
       call activate myEnvironment
       python setup.py install
-      pytest tests
+      pytest
     displayName: pytest
 
 - job:
@@ -162,5 +162,5 @@ jobs:
   - script: |
       call activate myEnvironment
       python setup.py install
-      pytest tests
+      pytest
     displayName: pytest

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+testpaths = tests
 markers =
     expensive: mark a test as a long running test.
 


### PR DESCRIPTION
Closes #224 

This should hold us over until we fix offending code (clearly we punted way too long...).

Stops the following from coming up when a developer tries to run the `pytest` command as it was intended:

```
(aspire_foo_master) ➜  ASPIRE-Python.dev git:(develop) pytest              
========================================================================== test session starts ==========================================================================
platform linux -- Python 3.6.10, pytest-6.0.1, py-1.9.0, pluggy-0.13.1
rootdir: /home/garrett/Dropbox/PU/aspire/ASPIRE-Python.dev, configfile: pytest.ini
plugins: cov-2.10.0
collected 178 items / 1 error / 1 deselected / 176 selected                                                                                                             

================================================================================ ERRORS =================================================================================
________________________________________________ ERROR collecting src/aspire/aspire/em_classavg/test_forward_backward.py ________________________________________________
ImportError while importing test module '/home/garrett/Dropbox/PU/aspire/ASPIRE-Python.dev/src/aspire/aspire/em_classavg/test_forward_backward.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../../anaconda3/envs/aspire_foo_master/lib/python3.6/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
src/aspire/aspire/em_classavg/test_forward_backward.py:1: in <module>
    import data_utils
E   ModuleNotFoundError: No module named 'data_utils'
======================================================================== short test summary info ========================================================================
ERROR src/aspire/aspire/em_classavg/test_forward_backward.py
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
==================================================================== 1 deselected, 1 error in 1.15s =====================================================================
```