### PR TITLE
Fixes with ImageSource.cache

### DIFF
--- a/src/aspire/source/__init__.py
+++ b/src/aspire/source/__init__.py
@@ -417,6 +417,9 @@ class ArrayImageSource(ImageSource):
     An `ImageSource` object that holds a reference to an underlying `Image` object (a thin wrapper on an ndarray)
     representing images. It does not produce its images on the fly, but keeps them in memory. As such, it should not be
     used where large Image objects are involved, but can be used in situations where API conformity is desired.
+
+    Note that this class does not provide an `_images` method, since it populates the `_cached_im` attribute which,
+    if available, is consulted directly by the parent class, bypassing `_images`.
     """
     def __init__(self, im, metadata=None):
         """
@@ -426,8 +429,3 @@ class ArrayImageSource(ImageSource):
         """
         super().__init__(L=im.res, n=im.n_images, dtype=im.dtype, metadata=metadata, memory=None)
         self._cached_im = im
-
-    def _images(self, start=0, num=np.inf, indices=None):
-        if indices is None:
-            indices = np.arange(start, min(start + num, self.n))
-        return self._cached_im[indices]

--- a/src/aspire/source/xform.py
+++ b/src/aspire/source/xform.py
@@ -329,6 +329,13 @@ class Pipeline(Xform):
         """
         self.xforms.extend(xforms)
 
+    def reset(self):
+        """
+        Reset the pipeline by removing all `Xform`s.
+        :return: None
+        """
+        self.xforms = []
+
     def _forward(self, im, indices):
         memory = Memory(location=self.memory, verbose=0)
         _apply_transform_cached = memory.cache(_apply_xform)

--- a/tests/test_covar2d.py
+++ b/tests/test_covar2d.py
@@ -59,8 +59,6 @@ class Cov2DTestCase(TestCase):
 
         self.imgs_ctf_clean = sim.eval_filters(self.imgs_clean)
 
-        sim.cache(self.imgs_ctf_clean)
-
         power_clean = anorm(self.imgs_ctf_clean)**2/np.size(self.imgs_ctf_clean)
         self.noise_var = power_clean/SNR
         self.imgs_ctf_noise = self.imgs_ctf_clean + np.sqrt(self.noise_var)*randn(L, L, n, seed=0)

--- a/tutorials/examples/cov2d_simulation.py
+++ b/tutorials/examples/cov2d_simulation.py
@@ -94,7 +94,6 @@ h_ctf_fb = [filt.fb_mat(ffbbasis) for filt in filters]
 # Apply the CTF to the clean images.
 logger.info('Apply CTF filters to clean images.')
 imgs_ctf_clean = Image(sim.eval_filters(imgs_clean))
-sim.cache(imgs_ctf_clean)
 
 # imgs_ctf_clean is an Image object. Convert to numpy array for subsequent statements
 imgs_ctf_clean = imgs_ctf_clean.asnumpy()


### PR DESCRIPTION
Removed argument to `cache()` method since it doesn't really make sense coming from the caller. Removed two instances where this was used (with no reliance on its actual result, as turns out). (Issue #193)

`cache()` now resets the generation pipeline, so the user can do downstream operations after invoking cache(), with only newly added pipeline xforms considered. (Issue #206)

Methods like downsample/whiten were invalidating the cache, which they shouldn't have been doing, since cache() is a user-facing method, not an internal optimization.

Renamed _im to _cached_im to be more explicit on the variable's intention. (Issue #206)