### PR TITLE
Use precomputed values for FB expansion of filter objects

### DIFF
--- a/src/aspire/basis/ffb_2d.py
+++ b/src/aspire/basis/ffb_2d.py
@@ -36,6 +36,7 @@ class FFBBasis2D(FBBasis2D):
         # set cutoff values
         self.rcut = self.nres / 2
         self.kcut = 0.5
+        self.jv_norm = []
 
         # get upper bound of zeros, ells, and ks  of Bessel functions
         self._getfbzeros()
@@ -66,6 +67,7 @@ class FFBBasis2D(FBBasis2D):
         radial = np.zeros(shape=(np.sum(self.k_max), n_r))
         ind_radial = 0
         for ell in range(0, self.ell_max + 1):
+            jv_ell = []
             for k in range(1, self.k_max[ell] + 1):
                 radial[ind_radial] = jv(ell, self.r0[k - 1, ell] * r / self.kcut)
                 # NOTE: We need to remove the factor due to the discretization here
@@ -73,6 +75,8 @@ class FFBBasis2D(FBBasis2D):
                 nrm = 1 / (np.sqrt(np.prod(self.sz))) * self.basis_norm_2d(ell, k)
                 radial[ind_radial] /= nrm
                 ind_radial += 1
+            # Save precomputed jv values after normalization
+            self.jv_norm.append(jv_ell)
 
         n_theta = np.ceil(16 * self.kcut * self.rcut)
         n_theta = int((n_theta + np.mod(n_theta, 2)) / 2)

--- a/src/aspire/basis/ffb_2d.py
+++ b/src/aspire/basis/ffb_2d.py
@@ -36,6 +36,9 @@ class FFBBasis2D(FBBasis2D):
         # set cutoff values
         self.rcut = self.nres / 2
         self.kcut = 0.5
+        self.n_r = int(np.ceil(4 * self.rcut * self.kcut))
+        n_theta = np.ceil(16 * self.kcut * self.rcut)
+        self.n_theta = int((n_theta + np.mod(n_theta, 2)) / 2)
         self.jv_norm = []
 
         # get upper bound of zeros, ells, and ks  of Bessel functions
@@ -61,7 +64,8 @@ class FFBBasis2D(FBBasis2D):
         The sampling criterion requires n_r=4*c*R and n_theta= 16*c*R.
 
         """
-        n_r = int(np.ceil(4 * self.rcut * self.kcut))
+        n_r = self.n_r
+        n_theta = self.n_theta
         r, w = lgwt(n_r, 0.0, self.kcut)
 
         radial = np.zeros(shape=(np.sum(self.k_max), n_r))
@@ -77,9 +81,6 @@ class FFBBasis2D(FBBasis2D):
                 ind_radial += 1
             # Save precomputed jv values after normalization
             self.jv_norm.append(jv_ell)
-
-        n_theta = np.ceil(16 * self.kcut * self.rcut)
-        n_theta = int((n_theta + np.mod(n_theta, 2)) / 2)
 
         # Only calculate "positive" frequencies in one half-plane.
         freqs_x = m_reshape(r, (n_r, 1)) @ m_reshape(

--- a/src/aspire/basis/ffb_2d.py
+++ b/src/aspire/basis/ffb_2d.py
@@ -92,6 +92,12 @@ class FFBBasis2D(FBBasis2D):
             'freqs': freqs
         }
 
+    def get_radial(self):
+        """
+        Return precomputed radial part
+        """
+        return self._precomp['radial']
+
     def evaluate(self, v):
         """
         Evaluate coefficients in standard 2D coordinate basis from those in FB basis

--- a/src/aspire/basis/ffb_2d.py
+++ b/src/aspire/basis/ffb_2d.py
@@ -39,7 +39,6 @@ class FFBBasis2D(FBBasis2D):
         self.n_r = int(np.ceil(4 * self.rcut * self.kcut))
         n_theta = np.ceil(16 * self.kcut * self.rcut)
         self.n_theta = int((n_theta + np.mod(n_theta, 2)) / 2)
-        self.jv_norm = []
 
         # get upper bound of zeros, ells, and ks  of Bessel functions
         self._getfbzeros()
@@ -71,7 +70,6 @@ class FFBBasis2D(FBBasis2D):
         radial = np.zeros(shape=(np.sum(self.k_max), n_r))
         ind_radial = 0
         for ell in range(0, self.ell_max + 1):
-            jv_ell = []
             for k in range(1, self.k_max[ell] + 1):
                 radial[ind_radial] = jv(ell, self.r0[k - 1, ell] * r / self.kcut)
                 # NOTE: We need to remove the factor due to the discretization here
@@ -79,8 +77,6 @@ class FFBBasis2D(FBBasis2D):
                 nrm = 1 / (np.sqrt(np.prod(self.sz))) * self.basis_norm_2d(ell, k)
                 radial[ind_radial] /= nrm
                 ind_radial += 1
-            # Save precomputed jv values after normalization
-            self.jv_norm.append(jv_ell)
 
         # Only calculate "positive" frequencies in one half-plane.
         freqs_x = m_reshape(r, (n_r, 1)) @ m_reshape(

--- a/src/aspire/utils/blk_diag_matrix.py
+++ b/src/aspire/utils/blk_diag_matrix.py
@@ -861,9 +861,7 @@ def filter_to_fb_mat(h_fun, fbasis):
         rmat = 2*k_vals.reshape(n_k, 1)*fbasis.r0[0:k_max, ell].T
         fb_vals = np.zeros_like(rmat)
         for ik in range(0, k_max):
-            fb_vals[:, ik] = jv(ell, rmat[:, ik])
-        fb_nrms = 1/np.sqrt(2)*abs(jv(ell+1, fbasis.r0[0:k_max, ell].T))/2
-        fb_vals = fb_vals/fb_nrms
+            fb_vals[:, ik] = fbasis.jv_norm[ell][ik]
         h_fb_vals = fb_vals*h_vals.reshape(n_k, 1)
         h_fb_ell = fb_vals.T @ (
             h_fb_vals * k_vals.reshape(n_k, 1) * wts.reshape(n_k, 1))

--- a/src/aspire/utils/blk_diag_matrix.py
+++ b/src/aspire/utils/blk_diag_matrix.py
@@ -854,20 +854,28 @@ def filter_to_fb_mat(h_fun, fbasis):
 
     # Represent 1D function values in fbasis
     h_fb = BlkDiagMatrix.empty(2 * fbasis.ell_max + 1, dtype=fbasis.dtype)
-    ind = 0
+    ind_ell = 0
+    ind_radial = 0
     for ell in range(0, fbasis.ell_max+1):
         k_max = fbasis.k_max[ell]
         rmat = 2*k_vals.reshape(n_k, 1)*fbasis.r0[0:k_max, ell].T
         fb_vals = np.zeros_like(rmat)
         for ik in range(0, k_max):
-            fb_vals[:, ik] = fbasis.jv_norm[ell][ik]
+            # filters use different normalized factors
+            if ell == 0:
+                fb_vals[:, ik] = fbasis._precomp['radial'][:,
+                                 ind_radial] * np.sqrt(2*np.pi)
+            else:
+                fb_vals[:, ik] = fbasis._precomp['radial'][:,
+                                 ind_radial]*np.sqrt(np.pi)
+            ind_radial += 1
         h_fb_vals = fb_vals*h_vals.reshape(n_k, 1)
         h_fb_ell = fb_vals.T @ (
             h_fb_vals * k_vals.reshape(n_k, 1) * wts.reshape(n_k, 1))
-        h_fb[ind] = h_fb_ell
-        ind += 1
+        h_fb[ind_ell] = h_fb_ell
+        ind_ell += 1
         if ell > 0:
-            h_fb[ind] = h_fb[ind-1]
-            ind += 1
+            h_fb[ind_ell] = h_fb[ind_ell-1]
+            ind_ell += 1
 
     return h_fb

--- a/src/aspire/utils/blk_diag_matrix.py
+++ b/src/aspire/utils/blk_diag_matrix.py
@@ -837,10 +837,9 @@ def filter_to_fb_mat(h_fun, fbasis):
     if not isinstance(fbasis, FFBBasis2D):
         raise NotImplementedError('Currently only fast FB method is supported')
     # Set same dimensions as basis object
-    n_k = int(np.ceil(4 * fbasis.rcut * fbasis.kcut))
-    n_theta = np.ceil(16 * fbasis.kcut * fbasis.rcut)
-    n_theta = int((n_theta + np.mod(n_theta, 2)) / 2)
-
+    n_k = fbasis.n_r
+    n_theta = fbasis.n_theta
+    
     # get 2D grid in polar coordinate
     k_vals, wts = lgwt(n_k, 0, 0.5)
     k, theta = np.meshgrid(

--- a/src/aspire/utils/blk_diag_matrix.py
+++ b/src/aspire/utils/blk_diag_matrix.py
@@ -855,20 +855,16 @@ def filter_to_fb_mat(h_fun, fbasis):
     # Represent 1D function values in fbasis
     h_fb = BlkDiagMatrix.empty(2 * fbasis.ell_max + 1, dtype=fbasis.dtype)
     ind_ell = 0
-    ind_radial = 0
     for ell in range(0, fbasis.ell_max+1):
         k_max = fbasis.k_max[ell]
         rmat = 2*k_vals.reshape(n_k, 1)*fbasis.r0[0:k_max, ell].T
         fb_vals = np.zeros_like(rmat)
-        for ik in range(0, k_max):
-            # filters use different normalized factors
-            if ell == 0:
-                fb_vals[:, ik] = fbasis._precomp['radial'][:,
-                                 ind_radial] * np.sqrt(2*np.pi)
-            else:
-                fb_vals[:, ik] = fbasis._precomp['radial'][:,
-                                 ind_radial]*np.sqrt(np.pi)
-            ind_radial += 1
+        ind_radial = np.sum(fbasis.k_max[0:ell])
+        fb_vals[:, 0:k_max] = fbasis._precomp['radial'][:,
+                              ind_radial:ind_radial + k_max] * np.sqrt(np.pi)
+        if ell == 0:
+            fb_vals *= np.sqrt(2)
+
         h_fb_vals = fb_vals*h_vals.reshape(n_k, 1)
         h_fb_ell = fb_vals.T @ (
             h_fb_vals * k_vals.reshape(n_k, 1) * wts.reshape(n_k, 1))

--- a/src/aspire/utils/blk_diag_matrix.py
+++ b/src/aspire/utils/blk_diag_matrix.py
@@ -839,6 +839,7 @@ def filter_to_fb_mat(h_fun, fbasis):
     # Set same dimensions as basis object
     n_k = fbasis.n_r
     n_theta = fbasis.n_theta
+    radial = fbasis.get_radial()
     
     # get 2D grid in polar coordinate
     k_vals, wts = lgwt(n_k, 0, 0.5)
@@ -860,8 +861,8 @@ def filter_to_fb_mat(h_fun, fbasis):
         rmat = 2*k_vals.reshape(n_k, 1)*fbasis.r0[0:k_max, ell].T
         fb_vals = np.zeros_like(rmat)
         ind_radial = np.sum(fbasis.k_max[0:ell])
-        fb_vals[:, 0:k_max] = fbasis._precomp['radial'][:,
-                              ind_radial:ind_radial + k_max] * np.sqrt(np.pi)
+        fb_vals[:, 0:k_max] = (radial[:, ind_radial:ind_radial + k_max]
+                               * np.sqrt(np.pi))
         if ell == 0:
             fb_vals *= np.sqrt(2)
 

--- a/src/aspire/utils/blk_diag_matrix.py
+++ b/src/aspire/utils/blk_diag_matrix.py
@@ -861,8 +861,8 @@ def filter_to_fb_mat(h_fun, fbasis):
         rmat = 2*k_vals.reshape(n_k, 1)*fbasis.r0[0:k_max, ell].T
         fb_vals = np.zeros_like(rmat)
         ind_radial = np.sum(fbasis.k_max[0:ell])
-        fb_vals[:, 0:k_max] = (radial[:, ind_radial:ind_radial + k_max]
-                               * np.sqrt(np.pi))
+        fb_vals[:, 0:k_max] = (radial[ind_radial:ind_radial + k_max]
+                               * np.sqrt(np.pi)).T
         if ell == 0:
             fb_vals *= np.sqrt(2)
 


### PR DESCRIPTION
This fixes the issue #199 using precomputed values for the FFB expansion of filter objects.