### PR TITLE
Remove global setting of random seed for Numpy in aspire.py

### DIFF
--- a/src/aspire/commands/aspire.py
+++ b/src/aspire/commands/aspire.py
@@ -3,7 +3,6 @@ import sys
 
 import click
 import mrcfile
-import numpy as np
 
 from aspire.aspire.abinitio import Abinitio
 from aspire.aspire.class_averaging import ClassAverages
@@ -15,9 +14,6 @@ from aspire.aspire.utils.data_utils import load_stack_from_file
 from aspire.aspire.utils.helpers import (red, requires_binaries,
                                          set_output_name, yellow)
 from aspire.aspire.utils.viewstack import view_stack
-
-# TODO: Setting the random seed for numpy should be made a globally available option for all commands.
-np.random.seed(1137)
 
 
 @click.command('abinitio', short_help='Abinitio algorithm')


### PR DESCRIPTION
Try to remove the global setting of numpy random seed in aspire.py as the part of issue #209  Numpy. After remove the global setting of random seed there is no effect on unit tests in the new framework. Individual commands or scripts need to read in the customized seed from user application. Probably through config.ini file or as an option.   