### PR TITLE
Remove remaining non ascii chars in python files.

### DIFF
--- a/src/aspire/orientation/__init__.py
+++ b/src/aspire/orientation/__init__.py
@@ -147,7 +147,7 @@ class CLOrient3D:
         # Note that only use half of each ray
         pf = self._apply_filter_and_norm('ijk, i -> ijk', pf, r_max, h)
 
-        # change dimensions of axes to n_img × n_rad/2 × n_theta/2
+        # change dimensions of axes to (n_img, n_rad/2, n_theta/2)
         pf = pf.transpose((2, 1, 0))
 
         # Search for common lines between [i, j] pairs of images.

--- a/tutorials/examples/image_expansion.py
+++ b/tutorials/examples/image_expansion.py
@@ -25,7 +25,7 @@ logger.info('This script illustrates different image expansion methods in ASPIRE
 DATA_DIR = os.path.join(os.path.dirname(__file__), '../data')
 org_images = np.load(os.path.join(DATA_DIR, 'example_data_np_array.npy')).T
 
-# Set the sizes of images 129×129
+# Set the sizes of images (129, 129)
 img_size = 129
 
 # Specify the normal FB basis method for expanding the 2D image


### PR DESCRIPTION
The original issue was a crash trying to print a message on an OLCF machine.  I fixed that some time ago, but found these stragglers today.

If it comes up again should make an issue to add to CI. I don't think we need to do that.  An alternative is to be stricter about encoding etc, but again, I don't think it is important right now.

Closes #158.