### PR TITLE
Add Volume Class Unit Tests

### DIFF
--- a/src/aspire/estimation/covar.py
+++ b/src/aspire/estimation/covar.py
@@ -91,7 +91,7 @@ class CovarianceEstimator(Estimator):
         logger.info('Running Covariance Estimator')
         b_coeff = self.src_backward(mean_vol, noise_variance)
         est_coeff = self.conj_grad(b_coeff, tol=tol)
-        covar_est = self.basis.mat_evaluate(est_coeff).T
+        covar_est = self.basis.mat_evaluate(est_coeff)
         covar_est = vecmat_to_volmat(
             make_symmat(
                 volmat_to_vecmat(covar_est)

--- a/src/aspire/source/simulation.py
+++ b/src/aspire/source/simulation.py
@@ -218,8 +218,7 @@ class Simulation(ImageSource):
 
         # Arrange in descending order (flip column order in eigenvector matrix)
         w = w[::-1]
-        # TODO: Implement flip for Volume class so we don't want to access _data.
-        eigs_true._data = np.flip(eigs_true, axis=0)
+        eigs_true = eigs_true.flip()
 
         return eigs_true, np.diag(w)
 

--- a/src/aspire/source/simulation.py
+++ b/src/aspire/source/simulation.py
@@ -10,7 +10,7 @@ from aspire.utils import ensure
 from aspire.utils.coor_trans import grid_3d, uniform_random_angles
 from aspire.utils.filters import ZeroFilter
 from aspire.utils.matlab_compat import Random, rand, randi, randn
-from aspire.utils.matrix import (acorr, ainner, anorm, make_symmat, vec_to_vol,
+from aspire.utils.matrix import (acorr, ainner, anorm, make_symmat,
                                  vecmat_to_volmat, vol_to_vec)
 from aspire.volume import Volume
 
@@ -188,7 +188,7 @@ class Simulation(ImageSource):
 
     def covar_true(self):
         eigs_true, lamdbas_true = self.eigs()
-        eigs_true = eigs_true.to_vec()
+        eigs_true = eigs_true.T.to_vec()
 
         covar_true = eigs_true.T @ lamdbas_true @ eigs_true
         covar_true = vecmat_to_volmat(covar_true)
@@ -214,16 +214,14 @@ class Simulation(ImageSource):
         R = R[:-1, :]
 
         w, v = eigh(make_symmat(R @ np.diag(p) @ R.T))
-        eigs_true = vec_to_vol(Q @ v)
+        eigs_true = Volume.from_vec((Q @ v).T)
 
         # Arrange in descending order (flip column order in eigenvector matrix)
         w = w[::-1]
-        eigs_true = np.flip(eigs_true, axis=-1)
+        # TODO: Implement flip for Volume class so we don't want to access _data.
+        eigs_true._data = np.flip(eigs_true, axis=0)
 
-        # RCOPT
-        eigs_true = np.moveaxis(eigs_true, -1, 0)
-
-        return Volume(eigs_true), np.diag(w)
+        return eigs_true, np.diag(w)
 
     # TODO: Too many eval_* methods doing similar things - encapsulate somehow?
 

--- a/src/aspire/utils/misc.py
+++ b/src/aspire/utils/misc.py
@@ -4,6 +4,7 @@ Miscellaneous Utilities that have no better place (yet).
 import logging
 
 import numpy as np
+from itertools import chain, combinations
 from numpy.linalg import qr, solve
 
 from aspire.utils.matrix import mat_to_vec, vec_to_mat
@@ -130,7 +131,7 @@ def qr_vols_forward(sim, s, n, vols, k):
 
     ims = np.swapaxes(ims, 1, 3)
     ims = np.swapaxes(ims, 0, 2)
-    
+
     Q_vecs = np.zeros((sim.L**2, k, n), dtype=vols.dtype)
     Rs = np.zeros((k, k, n), dtype=vols.dtype)
 
@@ -140,3 +141,15 @@ def qr_vols_forward(sim, s, n, vols, k):
     Qs = vec_to_mat(Q_vecs)
 
     return Qs, Rs
+
+def powerset(iterable):
+    """
+    Generate all subsets of an iterable. Example:
+
+    powerset([1,2,3]) --> () (1,) (2,) (3,) (1,2) (1,3) (2,3) (1,2,3)
+
+    :return: Generator covering all subsets of iterable.
+    """
+
+    s = list(iterable)
+    return chain.from_iterable(combinations(s, r) for r in range(len(s) + 1))

--- a/src/aspire/volume/__init__.py
+++ b/src/aspire/volume/__init__.py
@@ -173,6 +173,18 @@ class Volume:
 
         return self._data.flatten()
 
+    def flip(self, axis=0):
+        """
+        Flip volume stack data along axis using numpy.flip
+
+        :param axis: Optionally specify axis as integer or tuple.
+        Defaults to axis=0.
+
+        :return: Volume instance.
+        """
+
+        return Volume(np.flip(self._data, axis))
+
     def downsample(self, szout, mask=None):
         if isinstance(szout, int):
             szout = (szout,)*3

--- a/src/aspire/volume/__init__.py
+++ b/src/aspire/volume/__init__.py
@@ -69,6 +69,9 @@ class Volume:
 
         return res
 
+    def __radd__(self, otherL):
+        return self + otherL
+
     def __sub__(self, other):
         if isinstance(other, Volume):
             res = Volume(self._data - other.asnumpy())
@@ -77,6 +80,9 @@ class Volume:
 
         return res
 
+    def __rsub__(self, otherL):
+        return Volume(otherL - self._data)
+
     def __mul__(self, other):
         if isinstance(other, Volume):
             res = Volume(self._data * other.asnumpy())
@@ -84,6 +90,9 @@ class Volume:
             res = Volume(self._data * other)
 
         return res
+
+    def __rmul__(self, otherL):
+        return self * otherL
 
     def project(self, vol_idx, rot_matrices):
         data = self[vol_idx].T  #RCOPT
@@ -109,7 +118,7 @@ class Volume:
 
     def to_vec(self):
         """ Returns an N x resolution ** 3 array."""
-        return m_reshape(self._data, (self.n_vols,) + (self.resolution**3,))
+        return self._data.reshape((self.n_vols, self.resolution**3))
 
     @staticmethod
     def from_vec(vec):
@@ -123,12 +132,12 @@ class Volume:
         if vec.ndim ==1:
             vec = vec[np.newaxis, :]
 
-        N = vec.shape[0]
+        n_vols = vec.shape[0]
 
         resolution = round(vec.shape[1] ** (1/3))
-        assert resolution**3 == vec.shape[1]
+        assert resolution ** 3 == vec.shape[1]
 
-        data = m_reshape(vec, (N,) + (resolution,)*3)
+        data = vec.reshape((n_vols, resolution, resolution, resolution))
 
         return Volume(data)
 

--- a/tests/test_covar3d.py
+++ b/tests/test_covar3d.py
@@ -72,9 +72,7 @@ class Covar3DTestCase(TestCase):
         # In our case (in order) - the LinearOperator and 'b' (the RHS of the linear system)
         op, b = cg.call_args[0]
 
-        #  BUG?
-        #XXXX GBW, I'm not sure what happens here.... comment for now, maybe see if anyone remembers...
-        #self.assertTrue(np.allclose(b, op(cg_return_value), atol=1e-5))
+        self.assertTrue(np.allclose(b, op(cg_return_value), atol=1e-5))
 
         self.assertTrue(np.allclose(
             np.array([
@@ -87,7 +85,7 @@ class Covar3DTestCase(TestCase):
                 [0.00000000e+00, -2.60699879e-02, -1.84686293e-02,  1.30268283e-01,  1.36522253e-01,  8.11090183e-02,  3.50443711e-02, -1.21283276e-02],
                 [0.00000000e+00,  0.00000000e+00,  6.67517637e-02,  1.12721933e-01, -8.87693429e-03,  2.99613531e-02,  4.14024319e-02,  0.00000000e+00]
             ]),
-            covar_est[4, :, :, 4, 4, 4].T, # RCOPT
+            covar_est[4, 4, 4, :, :, 4], # RCOPT
             atol=1e-4
         ))
 
@@ -110,7 +108,7 @@ class Covar3DTestCase(TestCase):
                 [0.00000000e+00, -2.60699879e-02, -1.84686293e-02,  1.30268283e-01,  1.36522253e-01,  8.11090183e-02,  3.50443711e-02, -1.21283276e-02],
                 [0.00000000e+00,  0.00000000e+00,  6.67517637e-02,  1.12721933e-01, -8.87693429e-03,  2.99613531e-02,  4.14024319e-02,  0.00000000e+00]
             ]),
-            covar_est[4, :, :, 4, 4, 4].T, # RCOPT
+            covar_est[4, 4, 4, :, :, 4], # RCOPT
             atol=1e-4
         ))
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from aspire import __version__
 from aspire.utils import get_full_version
+from aspire.utils.misc import powerset
 
 
 class UtilsTestCase(TestCase):
@@ -34,3 +35,8 @@ class UtilsTestCase(TestCase):
         p_mock.side_effect = RuntimeError
 
         self.assertTrue(get_full_version() == __version__ + '.x')
+
+    def testPowerset(self):
+        ref = sorted([(), (1,), (2,), (3,), (1,2), (1,3), (2,3), (1,2,3)])
+        s = range(1, 4)
+        self.assertTrue(sorted(list(powerset(s))) == ref)

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -1,0 +1,150 @@
+from unittest import TestCase
+
+import numpy as np
+import os
+
+from aspire.volume import Volume
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), 'saved_test_data')
+
+
+class VolumeTestCase(TestCase):
+
+    def setUp(self):
+        self.n = n = 3
+        self.res = res = 42
+        self.data_1 = np.arange(n * res ** 3, dtype=np.float64).reshape(
+            n, res, res, res)
+        self.data_2 = 123 * self.data_1.copy()
+        self.vols_1 = Volume(self.data_1)
+        self.vols_2 = Volume(self.data_2)
+        self.random_data = np.random.randn(res, res, res)
+        self.vec = self.data_1.reshape(n, res ** 3)
+
+    def tearDown(self):
+        pass
+
+    def testAsNumpy(self):
+        self.assertTrue(np.all(self.data_1 == self.vols_1.asnumpy()))
+
+    def testGetter(self):
+        k = np.random.randint(self.n)
+        self.assertTrue(np.all(self.vols_1[k] == self.data_1[k]))
+
+    def testSetter(self):
+        k = np.random.randint(self.n)
+        ref = self.vols_1.asnumpy().copy()
+        # Set one entry in the stack with new data
+        self.vols_1[k] = self.random_data
+
+        # Assert we have updated the kth volume
+        self.assertTrue(np.all(self.vols_1[k] == self.random_data))
+
+        # Assert the other volumes are not updated.
+        inds = np.arange(self.n) != k
+        self.assertTrue(np.all(self.vols_1[inds] == ref[inds]))
+
+    def testLen(self):
+        self.assertTrue(len(self.vols_1) == self.n)
+
+        # Also test a single volume
+        self.assertTrue(len(Volume(self.random_data)) == 1)
+
+    def testAdd(self):
+        result = self.vols_1 + self.vols_2
+        self.assertTrue(np.all(result == self.data_1 + self.data_2))
+        self.assertTrue(isinstance(result, Volume))
+
+    def testScalarAdd(self):
+        result = self.vols_1 + 42
+        self.assertTrue(np.all(result == self.data_1 + 42))
+        self.assertTrue(isinstance(result, Volume))
+
+    def testScalarRAdd(self):
+        result = 42 + self.vols_1
+        self.assertTrue(np.all(result == self.data_1 + 42))
+        self.assertTrue(isinstance(result, Volume))
+
+    def testSub(self):
+        result = self.vols_1 - self.vols_2
+        self.assertTrue(np.all(result == self.data_1 - self.data_2))
+        self.assertTrue(isinstance(result, Volume))
+
+    def testScalarSub(self):
+        result = self.vols_1 - 42
+        self.assertTrue(np.all(result == self.data_1 - 42))
+        self.assertTrue(isinstance(result, Volume))
+
+    def testScalarRSub(self):
+        result = 42 - self.vols_1
+        self.assertTrue(np.all(result == 42 - self.data_1))
+        self.assertTrue(isinstance(result, Volume))
+
+    def testScalarMul(self):
+        result = self.vols_1 * 123
+        self.assertTrue(np.all(result == self.data_2))
+        self.assertTrue(isinstance(result, Volume))
+
+    def testScalarRMul(self):
+        result = 123 * self.vols_1
+        self.assertTrue(np.all(result == self.data_2))
+        self.assertTrue(isinstance(result, Volume))
+
+    def testProject(self):
+        pass
+
+    def to_vec(self):
+        """ Compute the to_vec method and compare. """
+        result = self.vols_1.to_vec()
+        self.assertTrue(result == self.vec)
+        self.assertTrue(isinstance(result, np.ndarray))
+
+    def testFromVec(self):
+        """ Compute Volume from_vec method and compare. """
+        vol = Volume.from_vec(self.vec)
+        self.assertTrue(np.allclose(vol, self.vols_1))
+        self.assertTrue(isinstance(vol, Volume))
+
+    def testVecId1(self):
+        """ Test composition of from_vec(to_vec). """
+        # Construct vec
+        vec = self.vols_1.to_vec()
+
+        # Convert back to Volume and compare
+        self.assertTrue(np.allclose(Volume.from_vec(vec), self.vols_1))
+
+    def testVecId2(self):
+        """ Test composition of to_vec(from_vec). """
+        # Construct Volume
+        vol = Volume.from_vec(self.vec)
+
+        # # Convert back to vec and compare
+        self.assertTrue(np.all(vol.to_vec() == self.vec))
+
+    def testTranspose(self):
+        data_t = np.transpose(self.data_1, (0, 3, 2, 1))
+
+        result = self.vols_1.transpose()
+        self.assertTrue(np.all(result == data_t))
+        self.assertTrue(isinstance(result, Volume))
+
+        result = self.vols_1.T
+        self.assertTrue(np.all(result == data_t))
+        self.assertTrue(isinstance(result, Volume))
+
+    def testFlatten(self):
+        result = self.vols_1.flatten()
+        self.assertTrue(np.all(result == self.data_1.flatten()))
+        self.assertTrue(isinstance(result, np.ndarray))
+
+    def testDownsample(self):
+        # Data files re-used from test_preprocess
+        vols = Volume(
+            np.load(os.path.join(DATA_DIR, 'clean70SRibosome_vol.npy')))
+
+        resv = Volume(
+            np.load(os.path.join(DATA_DIR, 'clean70SRibosome_vol_down8.npy')))
+
+        result = vols.downsample((8, 8, 8))
+        self.assertTrue(np.allclose(result, resv))
+        self.assertTrue(isinstance(result, Volume))

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 import numpy as np
 import os
 
+from aspire.utils.misc import powerset
 from aspire.volume import Volume
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'saved_test_data')
@@ -136,6 +137,18 @@ class VolumeTestCase(TestCase):
         result = self.vols_1.flatten()
         self.assertTrue(np.all(result == self.data_1.flatten()))
         self.assertTrue(isinstance(result, np.ndarray))
+
+    def testFlip(self):
+        # Test over all sane axis.
+        for axis in powerset(range(4)):
+            if not axis:
+                # test default
+                result = self.vols_1.flip()
+                axis = 0
+            else:
+                result = self.vols_1.flip(axis)
+            self.assertTrue(np.all(result == np.flip(self.data_1, axis)))
+            self.assertTrue(isinstance(result, Volume))
 
     def testDownsample(self):
         # Data files re-used from test_preprocess


### PR DESCRIPTION
Closes #267 .

Relates to #268  (looks like removing some of the m_reshapes began sorting out some transpose issues relating to 3d covar arrays).  Also restores the cg mock test commented out in #231.

Adds `Volume.flip`, and a `poweset` util from itertools recipes.

Adds some missing arithmetic methods to Volume. Didn't go crazy here, we can always add things like `abs`, `neg`, `pow` if a use case comes up.

This is a draft so I can think on the transpose changes a little more, and discuss with @janden what a preferred way to test `project` would be.