### PR TITLE
Refresh logging

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,11 +4,3 @@ markers =
     expensive: mark a test as a long running test.
 
 addopts = -m "not expensive"
-
-log_cli = true
-log_level = INFO
-log_cli_level = INFO
-log_format = %(asctime)s %(message)s
-log_cli_format = %(asctime)s %(message)s
-log_date_format = %Y/%m/%d %H:%M:%S
-log_cli_date_format = %Y/%m/%d %H:%M:%S

--- a/src/aspire/__init__.py
+++ b/src/aspire/__init__.py
@@ -1,5 +1,7 @@
+import os
 import logging.config
 
+from datetime import datetime
 from importlib_resources import read_text
 
 import aspire
@@ -9,31 +11,15 @@ from aspire.utils.config import Config
 # version in maj.min.bld format
 __version__ = '0.6.0'
 
-logging.config.dictConfig({
-    "version": 1,
-    "formatters": {
-        "simple_formatter": {
-            "format": "%(asctime)s %(message)s",
-            "datefmt": "%Y/%m/%d %H:%M:%S"
-        }
-    },
-    "handlers": {
-        "console": {
-            "class": "logging.StreamHandler",
-            "formatter": "simple_formatter",
-            "level": "DEBUG",
-            "stream": "ext://sys.stdout"
-        }
-    },
-    "loggers": {
-        "aspire": {
-            "level": "DEBUG",
-            "handlers": ["console"]
-        }
-    }
-})
+# Generates file name and opens log file defined in config file.
+# The default is to use the current time stamp provided in the dictionary,
+#   but that is not required if a user wishes to override filename.
+logging.config.fileConfig(
+    os.path.join(os.path.dirname(__file__), 'logging.conf'),
+    defaults={'dt_stamp': datetime.now().strftime('%Y-%m-%dT%H-%M-%S.%f')})
 
+# Implements some code that writes out exceptions to 'aspire.err.log'.
 config = Config(read_text(aspire, 'config.ini'))
-if config.common.log_errors:
+if config.common.log_exceptions:
     import sys
     sys.excepthook = handle_exception

--- a/src/aspire/__init__.py
+++ b/src/aspire/__init__.py
@@ -3,6 +3,7 @@ import logging.config
 
 from datetime import datetime
 from importlib_resources import read_text
+from pathlib import Path
 
 import aspire
 from aspire.exceptions import handle_exception
@@ -11,15 +12,19 @@ from aspire.utils.config import Config
 # version in maj.min.bld format
 __version__ = '0.6.0'
 
-# Generates file name and opens log file defined in config file.
-# The default is to use the current time stamp provided in the dictionary,
-#   but that is not required if a user wishes to override filename.
-logging.config.fileConfig(
-    os.path.join(os.path.dirname(__file__), 'logging.conf'),
-    defaults={'dt_stamp': datetime.now().strftime('%Y-%m-%dT%H-%M-%S.%f')})
-
 # Implements some code that writes out exceptions to 'aspire.err.log'.
 config = Config(read_text(aspire, 'config.ini'))
-if config.common.log_exceptions:
+if config.logging.log_exceptions:
     import sys
     sys.excepthook = handle_exception
+
+# Ensure the log_dir exists
+Path(config.logging.log_dir).mkdir(parents=True, exist_ok=True)
+
+# Generates file name details and opens log file defined in config file.
+# The default is to use the current time stamp provided in the dictionary,
+#   but that is not required if a user wishes to customize logging config.
+logging.config.fileConfig(
+    os.path.join(os.path.dirname(__file__), 'logging.conf'),
+    defaults={'dt_stamp': datetime.now().strftime('%Y-%m-%dT%H-%M-%S.%f'),
+              'log_dir': config.logging.log_dir})

--- a/src/aspire/basis/polar_2d.py
+++ b/src/aspire/basis/polar_2d.py
@@ -82,8 +82,10 @@ class PolarBasis2D(Basis):
             resolution of `self.sz`.
         """
         if self.dtype != real_type(v.dtype):
-            logger.error(f'Input data type, {v.dtype}, is not consistent with'
-                         f' the defined in the class.')
+            msg = (f'Input data type, {v.dtype}, is not consistent with'
+                   ' type defined in the class {self.dtype}.')
+            logger.error(msg)
+            raise TypeError(msg)
 
         v = v.reshape(-1, self.ntheta, self.nrad)
 
@@ -114,8 +116,10 @@ class PolarBasis2D(Basis):
         assert isinstance(x, Image)
 
         if self.dtype != x.dtype:
-            logger.error(f' Input data type, {x.dtype}, is not consistent with'
-                         f' the defined in the class.')
+            msg = (f'Input data type, {x.dtype}, is not consistent with'
+                   ' type defined in the class {self.dtype}.')
+            logger.error(msg)
+            raise TypeError(msg)
 
         nimgs = x.n_images
 

--- a/src/aspire/commands/cov3d.py
+++ b/src/aspire/commands/cov3d.py
@@ -8,7 +8,7 @@ from aspire.estimation.mean import MeanEstimator
 from aspire.estimation.noise import WhiteNoiseEstimator
 from aspire.source.relion import RelionSource
 
-logger = logging.getLogger('aspire')
+logger = logging.getLogger(__name__)
 
 
 @click.command()

--- a/src/aspire/commands/denoise.py
+++ b/src/aspire/commands/denoise.py
@@ -8,7 +8,7 @@ from aspire.estimation.noise import (AnisotropicNoiseEstimator,
                                      WhiteNoiseEstimator)
 from aspire.source.relion import RelionSource
 
-logger = logging.getLogger('aspire')
+logger = logging.getLogger(__name__)
 
 
 @click.command()

--- a/src/aspire/config.ini
+++ b/src/aspire/config.ini
@@ -1,8 +1,13 @@
 [common]
 cupy = 0
+
+[logging]
+# Set log_dir to a relative or absolute directory
+# Default is a subfolder `logs` in your current working directory.
+log_dir = logs
 # Whether to log any uncaught errors through a sys excepthook
-#  Generally logging config is found in logging.conf
 log_exceptions = 1
+# More detailed logging config is found in logging.conf
 
 [starfile]
 n_workers = -1

--- a/src/aspire/config.ini
+++ b/src/aspire/config.ini
@@ -1,7 +1,8 @@
 [common]
-# Whether to log any uncaught errors through a sys excepthook
-log_errors = 1
 cupy = 0
+# Whether to log any uncaught errors through a sys excepthook
+#  Generally logging config is found in logging.conf
+log_exceptions = 1
 
 [starfile]
 n_workers = -1

--- a/src/aspire/logging.conf
+++ b/src/aspire/logging.conf
@@ -2,14 +2,14 @@
 keys = root
 
 [handlers]
-keys = consoleHandler,fileHandler
+keys = consoleHandler, fileHandler
 
 [formatters]
 keys = simpleFormatter
 
 [logger_root]
 level = DEBUG
-handlers = consoleHandler,fileHandler
+handlers = consoleHandler, fileHandler
 
 [handler_consoleHandler]
 class = StreamHandler
@@ -22,7 +22,7 @@ class = FileHandler
 level = DEBUG
 formatter = simpleFormatter
 # You may set a custom filename here:
-args =('aspire-%(dt_stamp)s.log',)
+args =(os.path.join('%(log_dir)s', 'aspire-%(dt_stamp)s.log'),)
 
 [formatter_simpleFormatter]
 format = %(asctime)s %(levelname)s %(message)s

--- a/src/aspire/logging.conf
+++ b/src/aspire/logging.conf
@@ -1,0 +1,28 @@
+[loggers]
+keys = root
+
+[handlers]
+keys = consoleHandler,fileHandler
+
+[formatters]
+keys = simpleFormatter
+
+[logger_root]
+level = DEBUG
+handlers = consoleHandler,fileHandler
+
+[handler_consoleHandler]
+class = StreamHandler
+level = INFO
+formatter = simpleFormatter
+args = (sys.stdout,)
+
+[handler_fileHandler]
+class = FileHandler
+level = DEBUG
+formatter = simpleFormatter
+# You may set a custom filename here:
+args =('aspire-%(dt_stamp)s.log',)
+
+[formatter_simpleFormatter]
+format = %(asctime)s %(levelname)s %(message)s

--- a/src/aspire/nufft/cufinufft.py
+++ b/src/aspire/nufft/cufinufft.py
@@ -41,9 +41,8 @@ class CufinufftPlan(Plan):
 
         self.sz = sz
         self.dim = len(sz)
-        # TODO: Following the row major conversion, this should no longer happen.
-        if fourier_pts.flags.f_contiguous:
-            logger.warning('cufinufft has caught an F_CONTIGUOUS array,'
+        if not fourier_pts.flags.c_contiguous:
+            logger.debug('cufinufft has caught a non C_CONTIGUOUS array,'
                            ' `fourier_pts` will be copied to C_CONTIGUOUS.')
         # TODO: maybe replace with ascontiguousarray
         self.fourier_pts = np.asarray(np.mod(fourier_pts + np.pi, 2 * np.pi) - np.pi, order='C', dtype=self.dtype)

--- a/src/aspire/orientation/__init__.py
+++ b/src/aspire/orientation/__init__.py
@@ -62,7 +62,10 @@ class CLOrient3D:
         self.pf = self.pf.reshape(self.n_img, self.n_theta, self.n_rad).T # RCOPT
 
         if self.n_theta % 2 == 1:
-            logger.error('n_theta must be even')
+            msg = 'n_theta must be even'
+            logger.error(msg)
+            raise NotImplementedError(msg)
+
         n_theta_half = self.n_theta // 2
 
         # The first two dimension of pf is of size n_rad x n_theta. We will convert pf
@@ -105,7 +108,10 @@ class CLOrient3D:
         n_check = self.n_check
 
         if self.n_theta % 2 == 1:
-            logger.error('n_theta must be even')
+            msg = 'n_theta must be even'
+            logger.error(msg)
+            raise NotImplementedError(msg)
+
         n_theta_half = self.n_theta // 2
 
         # need to do a copy to prevent modifying self.pf for other functions

--- a/src/aspire/utils/misc.py
+++ b/src/aspire/utils/misc.py
@@ -85,7 +85,7 @@ def src_wiener_coords(sim, mean_vol, eig_vols, lambdas=None, noise_var=0, batch_
     """
 
     if not isinstance(mean_vol, Volume):
-        logger.warning('src_wiener_coords mean_vol should be a Volume instance. Attempt correction.')
+        logger.debug('src_wiener_coords mean_vol should be a Volume instance. Attempt correction.')
         if len(mean_vol.shape) == 4 and mean_vol.shape[3] != 1:
             msg = (f'Cannot naively convert {mean_vol.shape} to Volume instance.'
                    'Please change calling code.')
@@ -95,7 +95,7 @@ def src_wiener_coords(sim, mean_vol, eig_vols, lambdas=None, noise_var=0, batch_
         mean_vol = Volume(mean_vol)
 
     if not isinstance(eig_vols, Volume):
-        logger.warning('src_wiener_coords eig_vols should be a Volume instance. Correcting for now.')
+        logger.debug('src_wiener_coords eig_vols should be a Volume instance. Correcting for now.')
         eig_vols = Volume(eig_vols)
 
     k = eig_vols.n_vols

--- a/src/aspire/utils/misc.py
+++ b/src/aspire/utils/misc.py
@@ -26,8 +26,14 @@ def real_type(complextype):
         realtype = np.float32
     elif complextype == np.complex128:
         realtype = np.float64
+    elif complextype in (np.float32, np.float64):
+        logger.debug(f'Corresponding type is already real {complextype}.')
+        realtype = complextype
     else:
-        logger.error('Corresponding real type is not defined.')
+        msg = f'Corresponding real type is not defined for {complextype}.'
+        logger.error(msg)
+        raise TypeError(msg)
+
     return realtype
 
 
@@ -44,8 +50,14 @@ def complex_type(realtype):
         complextype = np.complex64
     elif realtype == np.float64:
         complextype = np.complex128
+    elif realtype in (np.complex64, np.complex128):
+        logger.debug(f'Corresponding type is already complex {realtype}.')
+        complextype = realtype
     else:
-        logger.error('Corresponding complex type is not defined')
+        msg = f'Corresponding complex type is not defined for {realtype}.'
+        logger.error(msg)
+        raise TypeError(msg)
+
     return complextype
 
 

--- a/src/aspire/utils/misc.py
+++ b/src/aspire/utils/misc.py
@@ -85,11 +85,14 @@ def src_wiener_coords(sim, mean_vol, eig_vols, lambdas=None, noise_var=0, batch_
     """
 
     if not isinstance(mean_vol, Volume):
-        logger.warning('src_wiener_coords mean_vol should be a Volume instance. Correcting for now.')
+        logger.warning('src_wiener_coords mean_vol should be a Volume instance. Attempt correction.')
         if len(mean_vol.shape) == 4 and mean_vol.shape[3] != 1:
-            logger.error('Cannot naively convert to Volume instance. Please change calling code.')
-        mean_vol = Volume(mean_vol)
+            msg = (f'Cannot naively convert {mean_vol.shape} to Volume instance.'
+                   'Please change calling code.')
+            logger.error(msg)
+            raise RuntimeError(msg)
 
+        mean_vol = Volume(mean_vol)
 
     if not isinstance(eig_vols, Volume):
         logger.warning('src_wiener_coords eig_vols should be a Volume instance. Correcting for now.')

--- a/tutorials/examples/cov2d_simulation.py
+++ b/tutorials/examples/cov2d_simulation.py
@@ -19,7 +19,7 @@ from aspire.utils.filters import (RadialCTFFilter, ScalarFilter)
 from aspire.utils.matrix import anorm
 from aspire.volume import Volume
 
-logger = logging.getLogger('aspire')
+logger = logging.getLogger(__name__)
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), '../data/')
 

--- a/tutorials/examples/cov3d_simulation.py
+++ b/tutorials/examples/cov3d_simulation.py
@@ -18,7 +18,7 @@ from aspire.utils.matrix import eigs
 from aspire.utils.misc import src_wiener_coords
 from aspire.volume import Volume
 
-logger = logging.getLogger('aspire')
+logger = logging.getLogger(__name__)
 
 # Specify parameters
 num_vols = 2           # number of volumes

--- a/tutorials/examples/image_expansion.py
+++ b/tutorials/examples/image_expansion.py
@@ -16,7 +16,7 @@ from aspire.basis.fpswf_2d import FPSWFBasis2D
 from aspire.basis.pswf_2d import PSWFBasis2D
 from aspire.utils.matrix import anorm
 
-logger = logging.getLogger('aspire')
+logger = logging.getLogger(__name__)
 
 
 logger.info('This script illustrates different image expansion methods in ASPIRE package.')

--- a/tutorials/examples/orient3d_simulation.py
+++ b/tutorials/examples/orient3d_simulation.py
@@ -16,7 +16,7 @@ from aspire.utils.coor_trans import (get_aligned_rotations, get_rots_mse,
 from aspire.utils.filters import RadialCTFFilter
 from aspire.volume import Volume
 
-logger = logging.getLogger('aspire')
+logger = logging.getLogger(__name__)
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), '../data/')
 

--- a/tutorials/examples/preprocess_imgs.py
+++ b/tutorials/examples/preprocess_imgs.py
@@ -14,7 +14,7 @@ from aspire.source.simulation import Simulation
 from aspire.utils.filters import RadialCTFFilter, ScalarFilter
 from aspire.volume import Volume
 
-logger = logging.getLogger('aspire')
+logger = logging.getLogger(__name__)
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), '../data/')
 


### PR DESCRIPTION
Closes #212 .

Most of the competing logging implementation was removed in #283 , so this PR isn't too big, nice.

- Converts logger assignments to `__file__`. We may have one specific place it would be reasonable to deviate from that convention that I am aware of (the tutorials), but it is not necessary the way I have implemented logging here (timestamped logfiles).
- Convert to config file style from a a dictionary style. This moves configuration out of the source code.
- Removes duplicated logging config in `pytest.ini`, also fixes the stdout out duplication under `pytest -s`.
- Adds `fileHandler` with configurable filename.
- Tee stream, >=DEBUG to file and >=INFO to console.
- ISO datetime format in log, and close to it for filename (`:` presents a problem, replaced with `-`)
- add `levelname`

One point of discussion is regarding the default log filename.  This initial PR will drop a timestamped file name for each process where aspire package is imported.  This is pretty common, but can be a little noisy. That is, if you are frantically developing and running tests, you might get many small files in your directory to `rm *.log`, instead of one big one...  

Alternatively it is possible to turn off writing the file by default,  and use a simple bool option like `log_to_file` in `config.ini`.  This would shield users from the python logging configuration, which might seem complicated. (It isn't but certainly has nothing to do with CryoEM). This is easy to implement if desired.

As it stands the log filenames look like `aspire-2020-10-08T14-50-13.456577.log`, with a snippet example attached showing the new format. 
[ex.log](https://github.com/ComputationalCryoEM/ASPIRE-Python/files/5350689/ex.log)
