### PR TITLE
Add a starfile IO unit test

### DIFF
--- a/src/aspire/io/micrograph.py
+++ b/src/aspire/io/micrograph.py
@@ -10,12 +10,16 @@ from aspire.utils.numeric import xp
 
 
 class Micrograph:
-    def __init__(self, filepath, margin=None, shrink_factor=None, square=False, gauss_filter_size=None, gauss_filter_sigma=None):
+    def __init__(self, filepath, margin=None, shrink_factor=None,
+                 square=False, gauss_filter_size=None, gauss_filter_sigma=None,
+                 permissive=False, dtype=np.float32):
         self.filepath = filepath
         self.shrink_factor = shrink_factor
         self.square = square
         self.gauss_filter_size = gauss_filter_size
         self.gauss_filter_sigma = gauss_filter_sigma
+        self.permissive = permissive
+        self.dtype = np.dtype(dtype)
 
         # Attributes populated by the time this constructor returns
         # A 2-D ndarray if loading a MRC file, a 3-D ndarray if loading a MRCS file,
@@ -35,12 +39,16 @@ class Micrograph:
         self.margin_top, self.margin_right, self.margin_bottom, self.margin_left = t, r, b, l
 
     def _read(self):
-        with mrcfile.open(self.filepath) as mrc:
-            im = mrc.data.astype('double')
+        with mrcfile.open(self.filepath, permissive=self.permissive) as mrc:
+            im = mrc.data
+            if im.dtype != self.dtype:
+                logger.info(
+                    f'Micrograph read casting {self.filepath}'
+                    f' data to {self.dtype} from {im.dtype}.')
+                im = im.astype(self.dtype)
 
         # NOTE: For multiple mrc files, mrcfile returns an ndarray with
         # (shape n_images, height, width)
-        # TODO: check all of these handle C ordered im data (currently unused).
 
         # Discard outer pixels
         im = im[...,
@@ -50,7 +58,7 @@ class Micrograph:
 
         if self.square:
             side_length = min(im.shape[-2], im.shape[-1])
-            im = im[:side_length, :side_length]
+            im = im[..., :side_length, :side_length]
 
         if self.shrink_factor is not None:
             size = tuple((np.array(im.shape) / config.apple.mrc_shrink_factor).astype(int))

--- a/src/aspire/io/mrc.py
+++ b/src/aspire/io/mrc.py
@@ -1,0 +1,54 @@
+import numpy as np
+
+
+class MrcStats:
+    def __init__(self):
+        """
+        Instantiate an empty instance ready to receive slices of arrays.
+        """
+
+        self.amin = np.inf
+        self.amax = -np.inf
+        self.asum = 0.
+        self.asize = 0
+        self.asum2 = 0.
+
+    def push(self, array_slice):
+        """
+        Incrementally add contribution of array_slice to stats.
+        """
+
+        self.amin = min(self.amin, np.min(array_slice))
+        self.amax = max(self.amax, np.max(array_slice))
+        # For mean we'll do div when called.
+        self.asum += np.sum(array_slice)
+        self.asum2 += np.sum(np.square(array_slice))
+        self.asize += np.size(array_slice)
+
+    @property
+    def amean(self):
+        """
+        Compute the curren mean.
+        """
+
+        return self.asum / self.asize
+
+    @property
+    def arms(self):
+        """
+        Compute the current standard deviation.
+
+        We use the simplest method.
+        """
+        var = self.asum2 / self.asize - (self.asum / self.asize) ** 2
+        return np.sqrt(var)
+
+    def update_header(self, mrcobj):
+        """
+        Assign the statistics to `mrcobj` header.
+        """
+
+        mrcobj.header.dmin = self.amin.astype(np.float32)
+        mrcobj.header.dmax = self.amax.astype(np.float32)
+        mrcobj.header.dmean = self.amean.astype(np.float32)
+        mrcobj.header.rms = self.arms.astype(np.float32)

--- a/src/aspire/io/mrc.py
+++ b/src/aspire/io/mrc.py
@@ -5,6 +5,8 @@ class MrcStats:
     def __init__(self):
         """
         Instantiate an empty instance ready to receive slices of arrays.
+
+        :return: MrcStats instance
         """
 
         self.amin = np.inf
@@ -16,6 +18,8 @@ class MrcStats:
     def push(self, array_slice):
         """
         Incrementally add contribution of array_slice to stats.
+
+        :param array_slice: An ndarray to contribute to stats.
         """
 
         self.amin = min(self.amin, np.min(array_slice))
@@ -40,12 +44,15 @@ class MrcStats:
 
         We use the simplest method.
         """
+
         var = self.asum2 / self.asize - (self.asum / self.asize) ** 2
         return np.sqrt(var)
 
     def update_header(self, mrcobj):
         """
         Assign the statistics to `mrcobj` header.
+
+        :param mrcobj: The `mrcfile` instance we want stats written to.
         """
 
         mrcobj.header.dmin = self.amin.astype(np.float32)

--- a/src/aspire/io/starfile.py
+++ b/src/aspire/io/starfile.py
@@ -187,24 +187,37 @@ def save_star(image_source, starfile_filepath, batch_size=1024, save_mode=None, 
 
     with open(starfile_filepath, 'w') as f:
         if save_mode == 'single':
-            # save all images into one single mrc file
-            mrcs_filename = os.path.splitext(os.path.basename(starfile_filepath)
-                                            )[0] + f'_{0}_{image_source.n-1}.mrcs'
-            mrcs_filepath = os.path.join(
-                os.path.dirname(starfile_filepath),
-                mrcs_filename
-            )
-            df['_rlnImageName'][0: image_source.n] = pd.Series(['{0:06}@{1}'.format(j + 1, mrcs_filepath)
-                                                                for j in range(image_source.n)])
-            with mrcfile.new_mmap(mrcs_filepath, shape=(image_source.n, image_source.L,
-                                                        image_source.L), mrc_mode=2, overwrite=overwrite) as mrc:
+            # Save all images into one single mrc file
+
+            # First, construct name for mrc file
+            fdir = os.path.dirname(starfile_filepath)
+            fname = os.path.basename(starfile_filepath)
+            fstem = os.path.splitext(fname)[0]
+            mrcs_filename = f'{fstem}_{0}_{image_source.n-1}.mrcs'
+            mrcs_filepath = os.path.join(fdir, mrcs_filename)
+
+            # Then set name in dataframe for the StarFile
+            df['_rlnImageName'][0: image_source.n] = pd.Series(
+                [f'{j + 1:06}@{mrcs_filename}' for j in range(image_source.n)])
+
+            # Open new MRC file
+            with mrcfile.new_mmap(
+                    mrcs_filepath,
+                    shape=(image_source.n, image_source.L, image_source.L),
+                    mrc_mode=2,
+                    overwrite=overwrite) as mrc:
+
+                # Loop over source setting data into mrc file
                 for i_start in np.arange(0, image_source.n, batch_size):
                     i_end = min(image_source.n, i_start + batch_size)
                     num = i_end - i_start
                     logger.info(f'Saving ImageSource[{i_start}-{i_end-1}] to {mrcs_filepath}')
-                    mrc.data[i_start:i_end, :, :] = image_source.images(
+                    mrc.data[i_start:i_end] = image_source.images(
                         start=i_start, num=num).data.astype('float32')
-            mrc.close()
+
+                # To be safe, explicitly set the header
+                #   before the mrc file context closes.
+                mrc.update_header_from_data()
 
         else:
             # save all images into multiple mrc files in batch size

--- a/src/aspire/io/starfile.py
+++ b/src/aspire/io/starfile.py
@@ -187,24 +187,37 @@ def save_star(image_source, starfile_filepath, batch_size=1024, save_mode=None, 
 
     with open(starfile_filepath, 'w') as f:
         if save_mode == 'single':
-            # save all images into one single mrc file
-            mrcs_filename = os.path.splitext(os.path.basename(starfile_filepath)
-                                            )[0] + f'_{0}_{image_source.n-1}.mrcs'
-            mrcs_filepath = os.path.join(
-                os.path.dirname(starfile_filepath),
-                mrcs_filename
-            )
-            df['_rlnImageName'][0: image_source.n] = pd.Series(['{0:06}@{1}'.format(j + 1, mrcs_filepath)
-                                                                for j in range(image_source.n)])
-            with mrcfile.new_mmap(mrcs_filepath, shape=(image_source.n, image_source.L,
-                                                        image_source.L), mrc_mode=2, overwrite=overwrite) as mrc:
+            # Save all images into one single mrc file
+
+            # First, construct name for mrc file
+            fdir = os.path.dirname(starfile_filepath)
+            fname = os.path.basename(starfile_filepath)
+            fstem = os.path.splitext(fname)[0]
+            mrcs_filename = f'{fstem}_{0}_{image_source.n-1}.mrcs'
+            mrcs_filepath = os.path.join(fdir, mrcs_filename)
+
+            # Then set name in dataframe for the StarFile
+            df['_rlnImageName'][0: image_source.n] = pd.Series(
+                [f'{j + 1:06}@{mrcs_filename}' for j in range(image_source.n)])
+
+            # Open new MRC file
+            with mrcfile.new_mmap(
+                    mrcs_filepath,
+                    shape=(image_source.n, image_source.L, image_source.L),
+                    mrc_mode=2,
+                    overwrite=overwrite) as mrc:
+
+                # Loop over source setting data into mrc file
                 for i_start in np.arange(0, image_source.n, batch_size):
                     i_end = min(image_source.n, i_start + batch_size)
                     num = i_end - i_start
                     logger.info(f'Saving ImageSource[{i_start}-{i_end-1}] to {mrcs_filepath}')
-                    mrc.data[i_start:i_end, :, :] = np.swapaxes(image_source.images(
-                        start=i_start, num=num).data.astype('float32'), 0, 2)
-            mrc.close()
+                    mrc.data[i_start:i_end] = image_source.images(
+                        start=i_start, num=num).data.astype('float32')
+
+                # To be safe, explicitly set the header
+                #   before the mrc file context closes.
+                mrc.update_header_from_data()
 
         else:
             # save all images into multiple mrc files in batch size

--- a/tests/test_mrc.py
+++ b/tests/test_mrc.py
@@ -1,5 +1,6 @@
 import filecmp
 import os
+import tempfile
 from datetime import datetime
 from unittest import TestCase
 
@@ -70,14 +71,16 @@ class MrcStatsTestCase(TestCase):
             self.stats.arms))
 
     def testUpdate(self):
-        mrcs_filepath = 'test.mrc'
-        files = (f'{mrcs_filepath}.1',
-                 f'{mrcs_filepath}.2')
+        # Create a tmpdir in a context. Cleans up on exit.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create two filenames in our tmpdir
+            mrcs_filepath = os.path.join(tmpdir, 'test.mrc')
+            files = (f'{mrcs_filepath}.1',
+                     f'{mrcs_filepath}.2')
 
-        # Note below we will fix the time to avoid racy unit tests.
-        epoch = datetime(1970, 1, 1).strftime('%Y-%m-%d %H:%M:%S')
+            # Note below we will fix the time to avoid racy unit tests.
+            epoch = datetime(1970, 1, 1).strftime('%Y-%m-%d %H:%M:%S')
 
-        try:
             with mrcfile.new_mmap(
                     files[0],
                     shape=(self.n, self.n),
@@ -102,9 +105,3 @@ class MrcStatsTestCase(TestCase):
             filecmp.clear_cache()  # clear any previous attempts
             # Shallow=False is important to ensure we check file contents.
             self.assertTrue(filecmp.cmp(files[0], files[1], shallow=False))
-
-        finally:
-            # Cleanup
-            for fn in files:
-                if os.path.exists(fn):
-                    os.remove(fn)

--- a/tests/test_mrc.py
+++ b/tests/test_mrc.py
@@ -13,7 +13,8 @@ class MrcStatsTestCase(TestCase):
     def setUp(self):
         # Create dummy data
         self.n = n = 100
-        self.a = a = np.arange(n*n).reshape((n, n))
+        # Note, integers will overflow on windows, use floats.
+        self.a = a = np.arange(n * n).reshape((n, n)).astype(np.float32)
 
         # Create stats instance
         self.stats = MrcStats()
@@ -98,7 +99,9 @@ class MrcStatsTestCase(TestCase):
                 mrc.header.time = epoch
 
             # Our homebrew and mrcfile files should now match to the bit.
-            self.assertTrue(filecmp.cmp(files[0], files[1]))
+            filecmp.clear_cache()  # clear any previous attempts
+            # Shallow=False is important to ensure we check file contents.
+            self.assertTrue(filecmp.cmp(files[0], files[1], shallow=False))
 
         finally:
             # Cleanup

--- a/tests/test_mrc.py
+++ b/tests/test_mrc.py
@@ -1,0 +1,107 @@
+import filecmp
+import os
+from datetime import datetime
+from unittest import TestCase
+
+import mrcfile
+import numpy as np
+
+from aspire.io.mrc import MrcStats
+
+
+class MrcStatsTestCase(TestCase):
+    def setUp(self):
+        # Create dummy data
+        self.n = n = 100
+        self.a = a = np.arange(n*n).reshape((n, n))
+
+        # Create stats instance
+        self.stats = MrcStats()
+
+        # Push chunks of data to it.
+        for i in range(n):
+            self.stats.push(a[i])
+
+    def testMin(self):
+        self.assertTrue(np.allclose(
+            np.min(self.a),
+            self.stats.amin))
+
+        self.stats.push(-10. * abs(self.stats.amin))
+        self.assertTrue(np.allclose(
+            -10. * abs(np.min(self.a)),
+            self.stats.amin))
+
+    def testMax(self):
+        self.assertTrue(np.allclose(
+            np.max(self.a),
+            self.stats.amax))
+
+        self.stats.push(10. * self.stats.amax)
+
+        self.assertTrue(np.allclose(
+            10. * np.max(self.a),
+            self.stats.amax))
+
+    def testMean(self):
+        self.assertTrue(np.allclose(
+            np.mean(self.a),
+            self.stats.amean))
+
+        orig = self.stats.amean
+
+        # Push some enough zeros to halve our original mean
+        self.stats.push(np.zeros(self.n * self.n))
+
+        self.assertTrue(np.allclose(
+            self.stats.amean,
+            orig/2.))
+
+        # Push enough mean data in to restore it
+        self.stats.push(np.ones(self.n * self.n) * orig * 2.)
+        self.assertTrue(np.allclose(
+            self.stats.amean,
+            orig))
+
+    def testRms(self):
+        self.assertTrue(np.allclose(
+            np.std(self.a),
+            self.stats.arms))
+
+    def testUpdate(self):
+        mrcs_filepath = 'test.mrc'
+        files = (f'{mrcs_filepath}.1',
+                 f'{mrcs_filepath}.2')
+
+        # Note below we will fix the time to avoid racy unit tests.
+        epoch = datetime(1970, 1, 1).strftime('%Y-%m-%d %H:%M:%S')
+
+        try:
+            with mrcfile.new_mmap(
+                    files[0],
+                    shape=(self.n, self.n),
+                    mrc_mode=2,
+                    overwrite=True) as mrc:
+
+                mrc.data[:, :] = self.a
+                mrc.update_header_from_data()
+                self.stats.update_header(mrc)
+                mrc.header.time = epoch
+
+            with mrcfile.new_mmap(
+                    files[1],
+                    shape=(self.n, self.n),
+                    mrc_mode=2,
+                    overwrite=True) as mrc:
+
+                mrc.set_data(self.a.astype(np.float32))
+                mrc.header.time = epoch
+
+            # Our homebrew and mrcfile files should now match to the bit.
+            self.assertTrue(filecmp.cmp(files[0], files[1]))
+
+        finally:
+            # Cleanup
+            for fn in files:
+                if os.path.exists(fn):
+                    os.remove(fn)

--- a/tests/test_starfileio.py
+++ b/tests/test_starfileio.py
@@ -1,18 +1,18 @@
-import importlib_resources
-import numpy as np
 import os.path
-
 from itertools import zip_longest
 from os.path import splitext
+from unittest import TestCase
+
+import importlib_resources
+import numpy as np
 from pandas import DataFrame
 from scipy import misc
-from unittest import TestCase
 
 import tests.saved_test_data
 from aspire.image import Image
+from aspire.io.starfile import StarFile, StarFileBlock, save_star
 from aspire.source import ArrayImageSource
 from aspire.source.mrcstack import MrcStack
-from aspire.io.starfile import StarFile, StarFileBlock, save_star
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'saved_test_data')
 

--- a/tests/test_starfileio.py
+++ b/tests/test_starfileio.py
@@ -22,6 +22,17 @@ DATA_DIR = os.path.join(os.path.dirname(__file__), 'saved_test_data')
 
 # From itertools standard recipes
 def grouper(iterable, n, fillvalue=None):
+    """
+    Collect data into fixed-length chunks or blocks.
+
+    # grouper('ABCDEFG', 3, 'x') --> ABC DEF Gxx
+
+    :param iterable: Iterable object to split into chunks
+    :param n: Size of each chunk
+    :param fillvalue: Value to tail fill if iterable not exact multiple of n
+    :return: iterator over chunks of length n
+    """
+
     args = [iter(iterable)] * n
     return zip_longest(*args, fillvalue=fillvalue)
 

--- a/tests/test_starfileio.py
+++ b/tests/test_starfileio.py
@@ -2,6 +2,7 @@ import importlib_resources
 import numpy as np
 import os.path
 
+from itertools import zip_longest
 from os.path import splitext
 from pandas import DataFrame
 from scipy import misc
@@ -16,20 +17,37 @@ from aspire.io.starfile import StarFile, StarFileBlock, save_star
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'saved_test_data')
 
 
+# From itertools standard recipes
+def grouper(iterable, n, fillvalue=None):
+    args = [iter(iterable)] * n
+    return zip_longest(*args, fillvalue=fillvalue)
+
+
 class StarFileTestCase(TestCase):
     def setUp(self):
-        with importlib_resources.path(tests.saved_test_data, 'sample.star') as path:
+        with importlib_resources.path(tests.saved_test_data,
+                                      'sample.star') as path:
             self.starfile = StarFile(path)
 
         # Independent Image object for testing Image source methods
-        self.im = Image(misc.face(gray=True).astype('float64')[:768, :768])
+        L = 768
+        self.im = Image(misc.face(gray=True).astype('float64')[:L, :L])
         self.img_src = ArrayImageSource(self.im)
+
+        # We also want to flex the stack logic.
+        self.n = 21
+        im_stack = np.broadcast_to(self.im.data, (self.n, L, L))
+        # make each image methodically different
+        im_stack = np.multiply(im_stack, np.arange(self.n)[:, None, None])
+        self.im_stack = Image(im_stack)
+        self.img_src_stack = ArrayImageSource(self.im_stack)
 
     def tearDown(self):
         pass
 
     def testLength(self):
-        # StarFile is an iterable that gives us blocks. We have 2 blocks in our sample starfile.
+        # StarFile is an iterable that gives us blocks.
+        #   We have 2 blocks in our sample starfile.
         self.assertEqual(2, len(self.starfile))
 
     def testIteration(self):
@@ -45,14 +63,16 @@ class StarFileTestCase(TestCase):
         self.assertEqual(0, len(block0))
 
     def testBlockByName(self):
-        # Indexing a StarFile with a string gives us a block with that name ("data_<name>" in starfile).
+        # Indexing a StarFile with a string gives us a block with that name
+        #   ("data_<name>" in starfile).
         # In our case the block at index 1 has name 'planetary'
         block1 = self.starfile['planetary']
         # This block has a two 'loops'.
         self.assertEqual(2, len(block1))
 
     def testBlockProperties(self):
-        # A StarFileBlock may have attributes that were read from the starfile key=>value pairs
+        # A StarFileBlock may have attributes that were read from the
+        #   starfile key=>value pairs.
         block0 = self.starfile['general']
         # Note that no typecasting is performed
         self.assertEqual(block0._three, '3')
@@ -65,7 +85,7 @@ class StarFileTestCase(TestCase):
         df = self.starfile['planetary'][0]
         self.assertEqual(8, len(df))
         self.assertEqual(4, len(df.columns))
-        # Note that no typecasting of values is performed at the io.StarFile level
+        # Note that no typecasting of values is performed at io.StarFile level
         self.assertEqual('1', df[df['_name'] == 'Earth'].iloc[0]['_gravity'])
 
     def testData2(self):
@@ -73,10 +93,13 @@ class StarFileTestCase(TestCase):
         self.assertEqual(3, len(df))
         self.assertEqual(2, len(df.columns))
         # Missing values in a loop default to ''
-        self.assertEqual('', df[df['_name'] == 'Earth'].iloc[0]['_discovered_year'])
+        self.assertEqual(
+            '',
+            df[df['_name'] == 'Earth'].iloc[0]['_discovered_year'])
 
     def testSave(self):
-        # Save the StarFile object to disk, re-read it back, and check for equality
+        # Save the StarFile object to disk,
+        #   read it back, and check for equality.
         # Note that __eq__ is supported for StarFile/StarFileBlock classes
 
         with open('sample_saved.star', 'w') as f:
@@ -92,18 +115,111 @@ class StarFileTestCase(TestCase):
 
         try:
             # Save some data using the wrapper.
-            #save_star(self.img_src, test_path, save_mode='single')
             save_star(self.img_src, test_path)
 
-            # Read it back using the class.
-            starfile2 = StarFile(test_path)
-            # Check we get expected filename?or?
+            # Can we read it back using the class?
+            _ = StarFile(test_path)
 
-            # Use something else to read the data file then...
+            # Read the data file
             saved_data = MrcStack(mrc_path).im.data
 
             # Compare
-            self.assertTrue(np.allclose(self.im.data, saved_data))
+            self.assertTrue(np.allclose(
+                self.im.data,
+                saved_data))
+
+        finally:
+            # Cleanup
+            if os.path.exists(test_path):
+                os.remove(test_path)
+
+            if os.path.exists(mrc_path):
+                os.remove(mrc_path)
+
+    def testSaveStarSingle(self):
+        test_path = 'sample_save_single.star'
+        mrc_path = splitext(test_path)[0] + '_0_0.mrcs'
+
+        try:
+            # Save some data using the wrapper.
+            save_star(self.img_src, test_path, save_mode='single')
+
+            # Can we read it back using the class?
+            _ = StarFile(test_path)
+
+            # Read the data file.
+            saved_data = MrcStack(mrc_path).im.data
+
+            # Compare
+            self.assertTrue(np.allclose(
+                self.im.data,
+                saved_data))
+
+        finally:
+            # Cleanup
+            if os.path.exists(test_path):
+                os.remove(test_path)
+
+            if os.path.exists(mrc_path):
+                os.remove(mrc_path)
+
+    def testSaveStarStack(self):
+        test_path = 'sample_save_stack.star'
+        cleanup_files = [test_path]
+        batch_size = 2
+
+        try:
+            # Save some data using the wrapper.
+            save_star(self.img_src_stack, test_path, batch_size=batch_size)
+
+            # Can we read it back using the class?
+            _ = StarFile(test_path)
+
+            # Loop over the stack of files
+            for itr in grouper(range(self.n), batch_size):
+                grp = list(filter(None.__ne__, itr))
+
+                # Parse fname
+                mrc_path = (splitext(test_path)[0] +
+                            f'_{min(grp)}_{max(grp)}.mrcs')
+                cleanup_files.append(mrc_path)
+
+                # Read the data file.
+                saved_data = MrcStack(mrc_path).im.data
+
+                # Compare
+                self.assertTrue(np.allclose(
+                    self.im_stack[min(grp):max(grp)+1],
+                    saved_data))
+
+        finally:
+            # Cleanup
+            for fn in cleanup_files:
+                if os.path.exists(fn):
+                    os.remove(fn)
+
+    def testSaveStarSingleStack(self):
+        test_path = 'sample_save_single_stack.star'
+        mrc_path = (splitext(test_path)[0] +
+                    f'_0_{self.im_stack.n_images-1}.mrcs')
+
+        try:
+            # Save some data using the wrapper.
+            save_star(self.img_src_stack,
+                      test_path,
+                      batch_size=2,
+                      save_mode='single')
+
+            # Can we read it back using the class?
+            _ = StarFile(test_path)
+
+            # Read the data file.
+            saved_data = MrcStack(mrc_path).im.data
+
+            # Compare
+            self.assertTrue(np.allclose(
+                self.im_stack.data,
+                saved_data))
 
         finally:
             # Cleanup


### PR DESCRIPTION
Closes #292

Use `save_star` to write out star file with corresponding `mrcs`.  Read back the `mrcs` and compare image data.  Also some light cleanup to help with readability.

This is still a draft, there are many cases that I think should be covered based on what I saw/read today.