### PR TITLE
tweak tox check settings for isort, no verbose

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,7 @@ deps =
 skip_install = true
 commands =
     flake8 .
-    isort --verbose --check-only --diff .
+    isort --check-only --diff .
     black --check --diff .
     check-manifest .
     python setup.py sdist


### PR DESCRIPTION
In our team meeting we decided to turn of verbosity for the isort call in tox.