### PR TITLE
ship config with nworkers=1 to prevent oversub

### DIFF
--- a/src/aspire/config.ini
+++ b/src/aspire/config.ini
@@ -31,7 +31,7 @@ minimum_overlap_amount = 7
 tau1 = 710
 tau2 = 7100
 container_size = 450
-n_processes = 4
+n_processes = 1
 
 # Margins to discard from any processed .mrc file
 # TODO: Margins are asymmetrical to conform to old behavior - fix going forward


### PR DESCRIPTION
Patches the default setting from #324 .  Can leave the issue open until it merits a deep look or deprecates itself (rumor is there is a newer apple picker version somewhere).  Mainly just don't want to ship a config that would ruin my workstation.