### PR TITLE
Add diagnostic lines to tox environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,8 @@ deps =
     Cython>=0.23
 commands =
     python -V
+    pip freeze
+    python -c "import numpy; numpy.show_config()"
     pytest --cov=aspire {posargs}
 
 [testenv:py{36,37,38,39}-dev]
@@ -30,6 +32,8 @@ deps =
 commands =
     sh -c "pip freeze | cut -d@ -f1 | cut -d= -f1 | xargs -n1 pip install -U"
     python -V
+    pip freeze
+    python -c "import numpy; numpy.show_config()"
     pytest --cov=aspire {posargs}
 
 [testenv:docs]


### PR DESCRIPTION
This adds the changes I used to diagnose #289 . They are pretty straightforward.  

`pip freeze` prints out the python package versions.  

`... numpy.show_config()` prints out some details about how numpy is implemented in that environment. Notably, it will print out the BLAS/LAPACK backend.

I think having them in the CI logs is worth the extra verbosity when run locally.