### PR TITLE
Bump skimage, older version has a packaging bug.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         "pytest-cov",
         "scipy==1.4.0",
         "scikit-learn",
-        "scikit-image==0.14.0",
+        "scikit-image==0.16.2",
         "setuptools>=0.41",
         "sphinxcontrib-bibtex",
         "sphinx-rtd-theme>=0.4.2",


### PR DESCRIPTION
I was able to bump skimage one version to 0.15.0 and then install on a clean Ubuntu 20.04 VM.

@janden , would you mind pulling this branch down and trying `pip3 install -e .` or equivalent? If it also works on your machine and all the CI tests I think we can undraft this to move forward with a minimal patch. (you may want to uninstall scikit-image first since you worked around it earlier)