### PR TITLE
Github Pages Documentation Using actions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -67,7 +67,7 @@ jobs:
       env:
         GITHUB_ACTOR: ${{ github.actor }}
         GITHUB_REPOSITORY: ${{ github.repository }}
-        GITHUB_TOKEN: ${{ secrets.token }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: "docs/buildsite.sh"
       shell: bash
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -49,3 +49,25 @@ jobs:
         pip install tox tox-gh-actions
     - name: Test with tox
       run: tox --skip-missing-interpreters false -e py${{ matrix.python-version }}-${{ matrix.pyenv }}
+
+  docs:
+    if: github.ref == 'refs/heads/gh_docs'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.6
+    - name: Install Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e ".[dev]"
+    - name: Run Sphinx doc build script
+      env:
+        GITHUB_ACTOR: ${{ github.actor }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        GITHUB_TOKEN: ${{ secrets.token }}
+      run: "docs/buildsite.sh"
+      shell: bash
+

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -51,7 +51,7 @@ jobs:
       run: tox --skip-missing-interpreters false -e py${{ matrix.python-version }}-${{ matrix.pyenv }}
 
   docs:
-    if: github.ref == 'refs/heads/gh_docs'
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -16,6 +16,7 @@ recursive-include docs *.bib
 recursive-include docs *.py
 recursive-include docs *.rst
 recursive-include docs Makefile
+recursive-include docs *.sh
 prune docs/source
 prune tests
 prune tutorials

--- a/docs/buildsite.sh
+++ b/docs/buildsite.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -x
 
+# Change from wherever you are to the directory containing this script.
+pushd "$(dirname "$0")"
+
 pwd ls -lah
 export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
  
@@ -11,6 +14,7 @@ export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
 # Python Sphinx, configured with source/conf.py
 # See https://www.sphinx-doc.org/
 make clean
+sphinx-apidoc -f -o ./source ../src -H Modules
 make html
 
 #######################
@@ -42,7 +46,8 @@ git commit -am "${msg}"
  
 # overwrite the contents of the gh-pages branch on our github.com repo
 git push deploy gh-pages --force
- 
+
+popd
 popd # return to main repo sandbox root
  
 # exit cleanly

--- a/docs/buildsite.sh
+++ b/docs/buildsite.sh
@@ -6,11 +6,11 @@ pushd "$(dirname "$0")"
 
 pwd ls -lah
 export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
- 
+
 ##############
 # BUILD DOCS #
 ##############
- 
+
 # Python Sphinx, configured with source/conf.py
 # See https://www.sphinx-doc.org/
 make clean
@@ -23,32 +23,32 @@ make html
 
 git config --global user.name "${GITHUB_ACTOR}"
 git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
- 
+
 docroot=`mktemp -d`
 rsync -av "build/html/" "${docroot}/"
- 
+
 pushd "${docroot}"
 
 git init
 git remote add deploy "https://token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 git checkout -b gh-pages
- 
-# Adds .nojekyll file to the root to signal to GitHub that  
+
+# Adds .nojekyll file to the root to signal to GitHub that
 # directories that start with an underscore (_) can remain
 touch .nojekyll
- 
-# Copy the resulting html pages built from Sphinx to the gh-pages branch 
+
+# Copy the resulting html pages built from Sphinx to the gh-pages branch
 git add .
- 
+
 # Make a commit with changes and any new files
 msg="Updating Docs for commit ${GITHUB_SHA} made on `date -d"@${SOURCE_DATE_EPOCH}" --iso-8601=seconds` from ${GITHUB_REF} by ${GITHUB_ACTOR}"
 git commit -am "${msg}"
- 
+
 # overwrite the contents of the gh-pages branch on our github.com repo
 git push deploy gh-pages --force
 
 popd
 popd # return to main repo sandbox root
- 
+
 # exit cleanly
 exit 0

--- a/docs/buildsite.sh
+++ b/docs/buildsite.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -x
+
+pwd ls -lah
+export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
+ 
+##############
+# BUILD DOCS #
+##############
+ 
+# Python Sphinx, configured with source/conf.py
+# See https://www.sphinx-doc.org/
+make clean
+make html
+
+#######################
+# Update GitHub Pages #
+#######################
+
+git config --global user.name "${GITHUB_ACTOR}"
+git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+ 
+docroot=`mktemp -d`
+rsync -av "build/html/" "${docroot}/"
+ 
+pushd "${docroot}"
+
+git init
+git remote add deploy "https://token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+git checkout -b gh-pages
+ 
+# Adds .nojekyll file to the root to signal to GitHub that  
+# directories that start with an underscore (_) can remain
+touch .nojekyll
+ 
+# Copy the resulting html pages built from Sphinx to the gh-pages branch 
+git add .
+ 
+# Make a commit with changes and any new files
+msg="Updating Docs for commit ${GITHUB_SHA} made on `date -d"@${SOURCE_DATE_EPOCH}" --iso-8601=seconds` from ${GITHUB_REF} by ${GITHUB_ACTOR}"
+git commit -am "${msg}"
+ 
+# overwrite the contents of the gh-pages branch on our github.com repo
+git push deploy gh-pages --force
+ 
+popd # return to main repo sandbox root
+ 
+# exit cleanly
+exit 0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,7 +37,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.mathjax",
     "sphinxcontrib.bibtex",
-    "numpydoc",
+    "sphinx.ext.napoleon",
 ]
 bibtex_bibfiles = ["references.bib"]
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
         "matplotlib",
         "mrcfile",
         "numpy==1.16",
-        "numpydoc==0.7.0",
         "pandas==0.25.3",
         "pyfftw",
         "pillow",


### PR DESCRIPTION
Closes #365 .This updates our prior doc deployment to function in our GitHub Actions workflow. It is set to update on a push to `master`.

The doc site building logic is contained in a script so that is can potentially be migrated if we have to move away from GHA. The actual GHA workflow is minimal, consisting of four steps:

1. checkout
2. setup python
3. install ASPIRE-Python with developer dependencies
4. Pass credentials and tokens into the `buildsite.sh` script.

The `buildsite.sh` script does the following:

1. Changes working dir
2. Generates the Sphinx module docs
3. Generates the html documentation including 2
4. Configures git based on credentials passed through environment
5. Copies html build product into an empty repo
6. Commits then pushes to `gh-pages`.

From there, Github repo settings are configured to monitor the root of `gh-pages` branch and deploy the page. This is the same as before and should require no action.

This also removes `numpydoc` which appears to no longer be required (most of numpy and google style doc strings are a built in extension now).

I have tested in my fork, but we won't see this in action for the upstream repo until our next merge to master. I am updated the developer google doc now.