### PR TITLE
add some more tests for Rotation class

### DIFF
--- a/tests/test_rotation.py
+++ b/tests/test_rotation.py
@@ -22,7 +22,9 @@ class UtilsTestCase(TestCase):
     def testRotMatrices(self):
         rot_ref = sp_rot.from_matrix(self.matrices)
         matrices = rot_ref.as_matrix().astype(self.dtype)
-        self.assertTrue(np.allclose(self.matrices, matrices))
+        self.assertTrue(
+            np.allclose(self.matrices, matrices, atol=utest_tolerance(self.dtype))
+        )
 
     def testRotAngles(self):
         rot_ref = sp_rot.from_euler("ZYZ", self.angles, degrees=False)

--- a/tests/test_rotation.py
+++ b/tests/test_rotation.py
@@ -1,9 +1,12 @@
+import logging
 from unittest import TestCase
 
 import numpy as np
 from scipy.spatial.transform import Rotation as sp_rot
 
 from aspire.utils import Rotation, utest_tolerance
+
+logger = logging.getLogger(__name__)
 
 
 class UtilsTestCase(TestCase):
@@ -60,6 +63,18 @@ class UtilsTestCase(TestCase):
                 and np.allclose(q_mat_est, q_mat, atol=utest_tolerance(self.dtype))
             )
 
+    def testRegister(self):
+        # These will yield two more distinct sets of random rotations wrt self.rot_obj
+        set1 = Rotation.generate_random_rotations(self.num_rots, dtype=self.dtype)
+        set2 = Rotation.generate_random_rotations(
+            self.num_rots, dtype=self.dtype, seed=7
+        )
+        # Align both sets of random rotations to rot_obj
+        aligned_rots1 = self.rot_obj.register(set1)
+        aligned_rots2 = self.rot_obj.register(set2)
+        self.assertTrue(aligned_rots1.mse(aligned_rots2) < utest_tolerance(self.dtype))
+        self.assertTrue(aligned_rots2.mse(aligned_rots1) < utest_tolerance(self.dtype))
+
     def testMSE(self):
         q_ang = [np.random.random(3)]
         q_mat = sp_rot.from_euler("ZYZ", q_ang, degrees=False).as_matrix()[0]
@@ -71,3 +86,22 @@ class UtilsTestCase(TestCase):
     def testCommonLines(self):
         ell_ij, ell_ji = self.rot_obj.common_lines(8, 11, 360)
         self.assertTrue(ell_ij == 235 and ell_ji == 284)
+
+    def testString(self):
+        logger.debug(str(self.rot_obj))
+
+    def testRepr(self):
+        logger.debug(repr(self.rot_obj))
+
+    def testLen(self):
+        self.assertTrue(len(self.rot_obj) == self.num_rots)
+
+    def testSetterGetter(self):
+        # Excute set
+        tmp = np.arange(9).reshape((3, 3))
+        self.rot_obj[13] = tmp
+        # Execute get
+        self.assertTrue(np.all(self.rot_obj[13] == tmp))
+
+    def testDtype(self):
+        self.assertTrue(self.dtype == self.rot_obj.dtype)


### PR DESCRIPTION
This is happening because the Rotation class crashed for me when it tried to print/log itself (fixed elsewhere)... so besides fixing that I want to check all the class's methods are at least invoked by pytest. I think some of the more advanced calls were already covered with some scrutiny. I didn't run into any other crashes yet.

One concern, is whether there is a more robust way to implement `testCommonLines` s.t. we can easily change `num_rots` at will.  Flexing `num_rots` by hand I found one other flaky test (up to `atol`), but I can imagine other reasons that might cause this particular `testCommonLines` result to change over time...