### PR TITLE
Fixes corner case where filter eval points outside interp grid.

### DIFF
--- a/src/aspire/operators/filters.py
+++ b/src/aspire/operators/filters.py
@@ -251,7 +251,8 @@ class ArrayFilter(Filter):
             logger.debug(
                 "Size of transfer function matches grid size exactly, skipping interpolation."
             )
-            result = self.xfer_fn_array
+            # Same effect as squeeze below, creating 1-d vector output.
+            result = self.xfer_fn_array.flatten()
 
         else:
             # TODO: This part could do with some documentation - not intuitive!


### PR DESCRIPTION
Odd resolution images could generate omegas outside grid (0.9999999 to 89.0000001 vs 1 to 89).  Allow extrapolation in this case instead of zero fill which will crash in later (PowerFilter) computations.  The exact case to produce this situation was a user supplied stack of 89x89 images, directly or under various odd downsample resolutions.

Also implements short circuit optimization for case where transfer function grid is expected to be identical to interpolation grid.  No need to interpolate there. The reported case is one of these situations where no interpolation was even necessary.

Resolves #401 nans.