### PR TITLE
Fixup covar2d shrinker and get_cwf_coeffs for  noise_var=0 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
             "jupyter",
             "pyflakes",
             "pydocstyle",
+            "parameterized",
             "pytest",
             "pytest-cov",
             "pytest-random-order",

--- a/src/aspire/covariance/covar2d.py
+++ b/src/aspire/covariance/covar2d.py
@@ -401,6 +401,11 @@ class RotCov2D:
             These are obtained using a Wiener filter with the specified covariance for the clean images
             and white noise of variance `noise_var` for the noise.
         """
+
+        if noise_var == 0:
+            logger.info("get_cwf_coeffs skipping coefficient estimation (noise_var=0).")
+            return coeffs
+
         if mean_coeff is None:
             mean_coeff = self.get_mean(coeffs, ctf_fb, ctf_idx)
 
@@ -768,6 +773,11 @@ class BatchedRotCov2D(RotCov2D):
             These are obtained using a Wiener filter with the specified covariance for the clean images
             and white noise of variance `noise_var` for the noise.
         """
+
+        if noise_var == 0:
+            logger.info("get_cwf_coeffs skipping coefficient estimation (noise_var=0).")
+            return coeffs
+
         if mean_coeff is None:
             mean_coeff = self.get_mean()
 

--- a/src/aspire/covariance/covar2d.py
+++ b/src/aspire/covariance/covar2d.py
@@ -12,7 +12,7 @@ from aspire.utils.matlab_compat import m_reshape
 logger = logging.getLogger(__name__)
 
 
-def shrink_covar(covar_in, noise_var, gamma, shrinker=None):
+def shrink_covar(covar, noise_var, gamma, shrinker="frobenius_norm"):
     """
     Shrink the covariance matrix
     :param covar_in: An input covariance matrix
@@ -22,14 +22,13 @@ def shrink_covar(covar_in, noise_var, gamma, shrinker=None):
     :return: The shrinked covariance matrix
     """
 
-    if shrinker is None:
-        shrinker = "frobenius_norm"
     ensure(
         shrinker in ("frobenius_norm", "operator_norm", "soft_threshold"),
         "Unsupported shrink method",
     )
 
-    covar = covar_in / noise_var
+    if noise_var > 0:
+        covar /= noise_var
 
     lambs, eig_vec = eig(make_symmat(covar))
 
@@ -68,7 +67,8 @@ def shrink_covar(covar_in, noise_var, gamma, shrinker=None):
     np.fill_diagonal(diag_lambs, lambs)
 
     shrinked_covar = eig_vec @ diag_lambs @ eig_vec.conj().T
-    shrinked_covar *= noise_var
+    if noise_var > 0:
+        shrinked_covar *= noise_var
 
     return shrinked_covar
 
@@ -206,7 +206,7 @@ class RotCov2D:
         ctf_idx=None,
         mean_coeff=None,
         do_refl=True,
-        noise_var=1,
+        noise_var=0,
         covar_est_opt=None,
         make_psd=True,
     ):
@@ -242,7 +242,7 @@ class RotCov2D:
             return x
 
         default_est_opt = {
-            "shrinker": "None",
+            "shrinker": None,
             "verbose": 0,
             "max_iter": 250,
             "iter_callback": [],
@@ -286,7 +286,7 @@ class RotCov2D:
         if not b_coeff.check_psd():
             logger.warning("Left side b in Cov2D is not positive semidefinite.")
 
-        if covar_est_opt["shrinker"] == "None":
+        if covar_est_opt["shrinker"] is None:
             b = b_coeff - noise_var * b_noise
         else:
             b = self.shrink_covar_backward(
@@ -373,7 +373,7 @@ class RotCov2D:
         ctf_idx=None,
         mean_coeff=None,
         covar_coeff=None,
-        noise_var=1,
+        noise_var=0,
     ):
         """
         Estimate the expansion coefficients using the Covariance Wiener Filtering (CWF) method.
@@ -586,7 +586,7 @@ class BatchedRotCov2D(RotCov2D):
         return b_covar
 
     def _noise_correct_covar_rhs(self, b_covar, b_noise, noise_var, shrinker):
-        if shrinker == "None":
+        if shrinker is None:
             b_noise = -noise_var * b_noise
             b_covar += b_noise
         else:
@@ -652,7 +652,7 @@ class BatchedRotCov2D(RotCov2D):
         return mean_coeff
 
     def get_covar(
-        self, noise_var=1, mean_coeff=None, covar_est_opt=None, make_psd=True
+        self, noise_var=0, mean_coeff=None, covar_est_opt=None, make_psd=True
     ):
         """
         Calculate the block diagonal covariance matrix in the basis
@@ -690,7 +690,7 @@ class BatchedRotCov2D(RotCov2D):
             return x
 
         default_est_opt = {
-            "shrinker": "None",
+            "shrinker": None,
             "verbose": 0,
             "max_iter": 250,
             "iter_callback": [],
@@ -740,7 +740,7 @@ class BatchedRotCov2D(RotCov2D):
         return covar_coeff
 
     def get_cwf_coeffs(
-        self, coeffs, ctf_fb, ctf_idx, mean_coeff, covar_coeff, noise_var=1
+        self, coeffs, ctf_fb, ctf_idx, mean_coeff, covar_coeff, noise_var=0
     ):
         """
         Estimate the expansion coefficients using the Covariance Wiener Filtering (CWF) method.

--- a/tests/test_batched_covar2d.py
+++ b/tests/test_batched_covar2d.py
@@ -184,3 +184,53 @@ class BatchedRotCov2DTestCase(TestCase):
                 atol=utest_tolerance(self.dtype),
             )
         )
+
+    def testCWFCoeffCleanCTF(self):
+        """
+        Test case of clean images (coeff_clean and noise_var=0)
+        while using a non Identity CTF.
+
+        This case may come up when a developer switches between
+        clean and dirty images.
+        """
+
+        # Calculate CWF coefficients using Cov2D base class
+        mean_cov2d = self.cov2d.get_mean(
+            self.coeff, ctf_fb=self.ctf_fb, ctf_idx=self.ctf_idx
+        )
+        covar_cov2d = self.cov2d.get_covar(
+            self.coeff,
+            ctf_fb=self.ctf_fb,
+            ctf_idx=self.ctf_idx,
+            noise_var=self.noise_var,
+            make_psd=True,
+        )
+
+        coeff_cov2d = self.cov2d.get_cwf_coeffs(
+            self.coeff,
+            self.ctf_fb,
+            self.ctf_idx,
+            mean_coeff=mean_cov2d,
+            covar_coeff=covar_cov2d,
+            noise_var=0,
+        )
+
+        # Calculate CWF coefficients using Batched Cov2D class
+        mean_bcov2d = self.bcov2d.get_mean()
+        covar_bcov2d = self.bcov2d.get_covar(noise_var=self.noise_var, make_psd=True)
+
+        coeff_bcov2d = self.bcov2d.get_cwf_coeffs(
+            self.coeff,
+            self.ctf_fb,
+            self.ctf_idx,
+            mean_bcov2d,
+            covar_bcov2d,
+            noise_var=0,
+        )
+        self.assertTrue(
+            self.blk_diag_allclose(
+                coeff_cov2d,
+                coeff_bcov2d,
+                atol=utest_tolerance(self.dtype),
+            )
+        )

--- a/tests/test_batched_covar2d.py
+++ b/tests/test_batched_covar2d.py
@@ -41,7 +41,10 @@ class BatchedRotCov2DTestCase(TestCase):
     def tearDown(self):
         pass
 
-    def blk_diag_allclose(self, blk_diag_a, blk_diag_b, atol=1e-8):
+    def blk_diag_allclose(self, blk_diag_a, blk_diag_b, atol=None):
+        if atol is None:
+            atol = utest_tolerance(self.dtype)
+
         close = True
         for blk_a, blk_b in zip(blk_diag_a, blk_diag_b):
             close = close and np.allclose(blk_a, blk_b, atol=atol)

--- a/tests/test_covar2d.py
+++ b/tests/test_covar2d.py
@@ -154,3 +154,25 @@ class Cov2DTestCase(TestCase):
         self.assertTrue(
             np.allclose(results, self.coeff_cwf_clean, atol=utest_tolerance(self.dtype))
         )
+
+    def testGetCWFCoeffsCleanCTF(self):
+        """
+        Test case of clean images (coeff_clean and noise_var=0)
+        while using a non Identity CTF.
+
+        This case may come up when a developer switches between
+        clean and dirty images.
+        """
+
+        results = np.load(
+            os.path.join(DATA_DIR, "clean70SRibosome_cov2d_cwf_coeff.npy")
+        )
+        coeff_cwf = self.cov2d.get_cwf_coeffs(
+            self.coeff_clean, self.h_ctf_fb, self.h_idx, noise_var=0
+        )
+
+        # Reconstruct images from output of get_cwf_coeffs
+        img_est = self.basis.evaluate(coeff_cwf)
+        # Compare with clean images
+        delta = np.mean(np.square((self.imgs_clean - img_est).asnumpy()))
+        self.assertTrue(delta < 0.02)

--- a/tests/test_covar2d.py
+++ b/tests/test_covar2d.py
@@ -178,10 +178,11 @@ class Cov2DTestCase(TestCase):
 
     def testGetCWFCoeffsCTFargs(self):
         """
-        Test we raise when user supplies incorrect CTF arguments
+        Test we raise when user supplies incorrect CTF arguments,
+        and that the error message matches.
         """
 
-        with raises(RuntimeError):
+        with raises(RuntimeError, match=r".*Given ctf_fb.*"):
             _ = self.cov2d.get_cwf_coeffs(
                 self.coeff, self.h_ctf_fb, None, noise_var=self.noise_var
             )

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ minversion = 3.8.0
 [testenv]
 changedir = tests
 deps =
+    parameterized
     pytest
     pytest-cov
     Cython>=0.23
@@ -27,6 +28,7 @@ whitelist_externals=
     xargs
 changedir = tests
 deps =
+    parameterized
     pytest
     pytest-cov
     Cython>=0.23


### PR DESCRIPTION
Cleaned up a little so we no longer crash with div0 or singular matrices.  However, estimated result for clean case `get_cwf_coeffs` doesn't seem right (to me).

Maybe its too degenerate a case and my expectations are wrong?  If that is the case we can document, log, then no-op or something.. Essentially I'm hoping to be able to setup some code and turn noise on/off without effectively writing a totally new experiment...  We might need that for say integrating with class averaging or other developmental codes using clean images to start with...

Closes #420 