### PR TITLE
ArrayImageSource Patches for use in MeanEstimator

### DIFF
--- a/src/aspire/reconstruction/estimator.py
+++ b/src/aspire/reconstruction/estimator.py
@@ -30,6 +30,12 @@ class Estimator:
                 f" basis: {self.basis.dtype}"
             )
 
+        if src.L != basis.nres:
+            raise ValueError(
+                "Currently require 2D source and 3D volume resolution to be the same."
+                f" Given src.L={src.L} != {basis.nres}"
+            )
+
         """
         An object representing a 2*L-by-2*L-by-2*L array containing the non-centered Fourier transform of the mean
         least-squares estimator kernel.

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -121,7 +121,10 @@ class ImageSource:
         self.unique_filters = []
         self.generation_pipeline = Pipeline(xforms=None, memory=memory)
         self._metadata_out = None
-        self._rotations_set = False
+        # _rotations is assigned non None value
+        #  by `rots` or `angles` setters.
+        #  It is potentially used by sublasses to test if we've used setters.
+        self._rotations = None
 
     @property
     def states(self):
@@ -226,7 +229,6 @@ class ImageSource:
         self.set_metadata(
             ["_rlnAngleRot", "_rlnAngleTilt", "_rlnAnglePsi"], np.rad2deg(values)
         )
-        self._rotations_set = True
 
     @rots.setter
     def rots(self, values):
@@ -240,7 +242,6 @@ class ImageSource:
             ["_rlnAngleRot", "_rlnAngleTilt", "_rlnAnglePsi"],
             self._rotations.as_euler("ZYZ", degrees=True),
         )
-        self._rotations_set = True
 
     def set_metadata(self, metadata_fields, values, indices=None):
         """
@@ -788,11 +789,11 @@ class ArrayImageSource(ImageSource):
 
     def _rots(self):
         """
-        Private method, checks if `_rotations_set` is True,
+        Private method, checks if `_rotations` has been set,
         then returns inherited rots, otherwise raise.
         """
 
-        if self._rotations_set:
+        if self._rotations is not None:
             return super()._rots()
         else:
             raise RuntimeError(
@@ -803,11 +804,11 @@ class ArrayImageSource(ImageSource):
 
     def _angles(self):
         """
-        Private method, checks if `_rotations_set` is True,
+        Private method, checks if `_rotations` has been set,
         then returns inherited angles, otherwise raise.
         """
 
-        if self._rotations_set:
+        if self._rotations is not None:
             return super()._angles()
         else:
             raise RuntimeError(

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -192,6 +192,14 @@ class ImageSource:
         """
         :return: Rotation matrices as a n x 3 x 3 array
         """
+        # Call a private method. This allows sub classes to effeciently override.
+        return self._rots()
+
+    def _rots(self):
+        """
+        Converts interal `_rotations` representation to expected matrix form.
+        :return: Rotation matrices as a n x 3 x 3 array
+        """
         return self._rotations.as_matrix().astype(self.dtype)
 
     @angles.setter
@@ -742,7 +750,16 @@ class ArrayImageSource(ImageSource):
         :param im: An `Image` object representing image data served up by this `ImageSource`
         :param metadata: A Dataframe of metadata information corresponding to this ImageSource's images
         """
+
         super().__init__(
             L=im.res, n=im.n_images, dtype=im.dtype, metadata=metadata, memory=None
         )
+
         self._cached_im = im
+
+    def _rots(self):
+        """
+        Private method to populate rots attribute if called by consumer of this `source`.
+        Supports mean volume estimating code which expects rotations.
+        """
+        return np.zeros((self.n, 3, 3), dtype=self.dtype)

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -764,7 +764,7 @@ class ArrayImageSource(ImageSource):
         Initialize from an `Image` object
         :param im: An `Image` object representing image data served up by this `ImageSource`
         :param metadata: A Dataframe of metadata information corresponding to this ImageSource's images
-        :param angles:
+        :param angles: Optional n-by-3 array of rotation angles corresponding to `im`.
         """
 
         super().__init__(
@@ -782,29 +782,36 @@ class ArrayImageSource(ImageSource):
         if angles is not None:
             if angles.shape != (self.n, 3):
                 raise ValueError(f"Angles should be shape {(self.n, 3)}")
-            # This will popular ._rotations which is exposed by properties `angles` and `rots`.
+            # This will populate `_rotations`,
+            #   which is exposed by properties `angles` and `rots`.
             self.angles = angles
 
     def _rots(self):
         """
-        Private method, checks if `_rotations_set` is True then returns inherited rots, otherwise raise.
+        Private method, checks if `_rotations_set` is True,
+        then returns inherited rots, otherwise raise.
         """
 
         if self._rotations_set:
             return super()._rots()
         else:
             raise RuntimeError(
-                "Consumer of ArrayImageSource trying to access rots, but rots were not defined for this source.  Try instantiating with angles."
+                "Consumer of ArrayImageSource trying to access rots,"
+                " but rots were not defined for this source."
+                "  Try instantiating with angles."
             )
 
     def _angles(self):
         """
-        Private method, checks if `_rotations_set` is True then returns inherited angles, otherwise raise.
+        Private method, checks if `_rotations_set` is True,
+        then returns inherited angles, otherwise raise.
         """
 
         if self._rotations_set:
             return super()._angles()
         else:
             raise RuntimeError(
-                "Consumer of ArrayImageSource trying to access angles, but angles were not defined for this source.  Try instantiating with angles."
+                "Consumer of ArrayImageSource trying to access angles,"
+                " but angles were not defined for this source."
+                "  Try instantiating with angles."
             )

--- a/src/aspire/source/simulation.py
+++ b/src/aspire/source/simulation.py
@@ -38,7 +38,7 @@ class Simulation(ImageSource):
         Other than the base class attributes, it has:
 
         :param C: The number of distinct volumes
-        :param angles: A 3-by-n array of rotation angles
+        :param angles: A n-by-3 array of rotation angles
         """
         super().__init__(L=L, n=n, dtype=dtype, memory=memory)
 

--- a/tests/test_array_image_source.py
+++ b/tests/test_array_image_source.py
@@ -1,0 +1,56 @@
+import os.path
+from unittest import TestCase
+
+import numpy as np
+
+from aspire.basis import FBBasis3D
+from aspire.image import Image
+from aspire.reconstruction import MeanEstimator
+from aspire.source import ArrayImageSource, Simulation
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), "saved_test_data")
+
+
+class ImageTestCase(TestCase):
+    def setUp(self):
+        self.dtype = np.float32
+
+        # Generate a stack of images
+        sim = Simulation(
+            n=1024,
+            L=64,
+            seed=0,
+            dtype=self.dtype,
+        )
+
+        # Expose images as numpy array.
+        self.ims_np = sim.images(0, sim.n).asnumpy()
+        self.im = Image(self.ims_np)
+
+    def testArrayImageSource(self):
+        """
+        An Image can be wrapped in an ArrayImageSource when we need to deal with ImageSource objects.
+
+        This checks round trip conversion does not crash and returns identity.
+        """
+
+        src = ArrayImageSource(self.im)
+        im = src.images(start=0, num=np.inf)  # returns Image instance
+        self.assertTrue(np.allclose(im.asnumpy(), self.ims_np))
+
+    def testArrayImageSourceMeanVol(self):
+        """
+        Test that ArrayImageSource can be consumed by mean/volume codes.
+        """
+
+        # Construct the source for testing
+        src = ArrayImageSource(self.im)
+
+        # Vol estimation requires a 3D basis
+        basis = FBBasis3D((8, 8, 8), dtype=self.dtype)
+
+        # Instatiate a volume estimator
+        estimator = MeanEstimator(src, basis, preconditioner="none")
+
+        # Test we do not crash.
+        _ = estimator.estimate()

--- a/tests/test_array_image_source.py
+++ b/tests/test_array_image_source.py
@@ -71,9 +71,8 @@ class ImageTestCase(TestCase):
         with raises(RuntimeError, match=r"Consumer of ArrayImageSource.*"):
             _ = src.angles
 
-        # We also test that a source consumer generates same error.
-
-        # Instantiate a volume estimator
+        # We also test that a source consumer generates same error,
+        #   by instantiating a volume estimator.
         estimator = MeanEstimator(src, self.basis, preconditioner="none")
 
         # Test we raise with expected message
@@ -82,7 +81,9 @@ class ImageTestCase(TestCase):
 
     def testArrayImageSourceRotGetterError(self):
         """
-        Test that ArrayImageSource when instantiated without required rotations/angles gives an appropriate error.  Here we specifically test `rots`.
+        Test that ArrayImageSource when instantiated without required
+        rotations/angles gives an appropriate error.
+        Here we specifically test `rots`.
         """
 
         # Construct the source for testing.
@@ -112,10 +113,14 @@ class ImageTestCase(TestCase):
         # Get estimate consuming ArrayImageSource
         est = estimator.estimate()
 
+        # Compute RMS error and log it for debugging.
         delta = np.sqrt(np.mean(np.square(est - sim_est)))
         logger.info(f"Simulation vs ArrayImageSource estimates MRSE: {delta}")
 
+        # Estimate RMSE should be small.
         self.assertTrue(delta <= utest_tolerance(self.dtype))
+        # And the estimate themselves should be close (virtually same inputs).
+        #  We should be within same neighborhood as generating sim_est multiple times...
         self.assertTrue(np.allclose(est, sim_est, atol=utest_tolerance(self.dtype)))
 
     def testArrayImageSourceRotsSetGet(self):

--- a/tests/test_array_image_source.py
+++ b/tests/test_array_image_source.py
@@ -1,31 +1,47 @@
+import logging
 import os.path
 from unittest import TestCase
 
 import numpy as np
+from pytest import raises
 
 from aspire.basis import FBBasis3D
 from aspire.image import Image
+from aspire.operators import IdentityFilter
 from aspire.reconstruction import MeanEstimator
 from aspire.source import ArrayImageSource, Simulation
+from aspire.utils import utest_tolerance
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "saved_test_data")
+
+logger = logging.getLogger(__name__)
 
 
 class ImageTestCase(TestCase):
     def setUp(self):
         self.dtype = np.float32
+        self.resolution = 8
+
+        n = 1024
 
         # Generate a stack of images
-        sim = Simulation(
-            n=1024,
-            L=64,
+        self.sim = sim = Simulation(
+            n=n,
+            L=self.resolution,
+            unique_filters=[IdentityFilter()],
             seed=0,
             dtype=self.dtype,
+            # We'll use random angles
+            offsets=np.zeros((n, 2)),  # No offsets
+            amplitudes=np.ones((n)),  # Constant amplitudes
         )
 
         # Expose images as numpy array.
         self.ims_np = sim.images(0, sim.n).asnumpy()
         self.im = Image(self.ims_np)
+
+        # Vol estimation requires a 3D basis
+        self.basis = FBBasis3D((self.resolution,) * 3, dtype=self.dtype)
 
     def testArrayImageSource(self):
         """
@@ -38,19 +54,44 @@ class ImageTestCase(TestCase):
         im = src.images(start=0, num=np.inf)  # returns Image instance
         self.assertTrue(np.allclose(im.asnumpy(), self.ims_np))
 
-    def testArrayImageSourceMeanVol(self):
+    def testArrayImageSourceMeanVolError1(self):
         """
-        Test that ArrayImageSource can be consumed by mean/volume codes.
+        Test that ArrayImageSource when instantiated without required rotations/angles gives an appropriate error.
         """
 
         # Construct the source for testing
+        # Rotations(angles) are required, but we intentionally do not pass to instantiater here.
         src = ArrayImageSource(self.im)
 
-        # Vol estimation requires a 3D basis
-        basis = FBBasis3D((8, 8, 8), dtype=self.dtype)
-
         # Instatiate a volume estimator
-        estimator = MeanEstimator(src, basis, preconditioner="none")
+        estimator = MeanEstimator(src, self.basis, preconditioner="none")
 
-        # Test we do not crash.
-        _ = estimator.estimate()
+        # Test we raise with expected message
+        with raises(RuntimeError, match=r"Consumer of ArrayImageSource.*"):
+            _ = estimator.estimate()
+
+    def testArrayImageSourceMeanVol(self):
+        """
+        Test that ArrayImageSource can be consumed by mean/volume codes.
+        Checks that the estimate is consistent with Simulation source.
+        """
+
+        # Run estimator with a Simulation source as a reference.
+        sim_estimator = MeanEstimator(self.sim, self.basis, preconditioner="none")
+        sim_est = sim_estimator.estimate()
+        logger.info("Simulation source checkpoint")
+
+        # Construct the source for testing
+        src = ArrayImageSource(self.im, angles=self.sim.angles)
+
+        # Instatiate a volume estimator using ArrayImageSource
+        estimator = MeanEstimator(src, self.basis, preconditioner="none")
+
+        # Get estimate consuming ArrayImageSource
+        est = estimator.estimate()
+
+        delta = np.sqrt(np.mean(np.square(est - sim_est)))
+        logger.info(f"Simulation vs ArrayImageSource estimates MRSE: {delta}")
+
+        self.assertTrue(delta <= utest_tolerance(self.dtype))
+        self.assertTrue(np.allclose(est, sim_est, atol=utest_tolerance(self.dtype)))

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -4,10 +4,7 @@ from unittest import TestCase
 import numpy as np
 from scipy import misc
 
-from aspire.basis import FBBasis3D
 from aspire.image import Image, _im_translate2
-from aspire.reconstruction import MeanEstimator
-from aspire.source import ArrayImageSource
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "saved_test_data")
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -4,7 +4,9 @@ from unittest import TestCase
 import numpy as np
 from scipy import misc
 
+from aspire.basis import FBBasis3D
 from aspire.image import Image, _im_translate2
+from aspire.reconstruction import MeanEstimator
 from aspire.source import ArrayImageSource
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "saved_test_data")
@@ -12,13 +14,14 @@ DATA_DIR = os.path.join(os.path.dirname(__file__), "saved_test_data")
 
 class ImageTestCase(TestCase):
     def setUp(self):
+        self.dtype = np.float64
         # numpy array for top-level functions that directly expect it
-        self.im_np = misc.face(gray=True).astype(np.float64)[np.newaxis, :768, :768]
+        self.im_np = misc.face(gray=True).astype(self.dtype)[np.newaxis, :768, :768]
         # Independent Image object for testing Image methods
-        self.im = Image(misc.face(gray=True).astype(np.float64)[:768, :768])
+        self.im = Image(misc.face(gray=True).astype(self.dtype)[:768, :768])
         # Construct a simple stack of Images
         self.n = 3
-        self.ims_np = np.empty((3, *self.im_np.shape[1:]), dtype=self.im_np.dtype)
+        self.ims_np = np.empty((3, *self.im_np.shape[1:]), dtype=self.dtype)
         for i in range(self.n):
             self.ims_np[i] = self.im_np * (i + 1) / float(self.n)
         # Independent Image stack object for testing Image methods
@@ -46,12 +49,6 @@ class ImageTestCase(TestCase):
         self.assertTrue(np.allclose(im.asnumpy(), im1.asnumpy()))
         self.assertTrue(np.allclose(im1.asnumpy(), im2.asnumpy()))
         self.assertTrue(np.allclose(im1.asnumpy()[0, :, :], im3))
-
-    def testArrayImageSource(self):
-        # An Image can be wrapped in an ArrayImageSource when we need to deal with ImageSource objects.
-        src = ArrayImageSource(self.im)
-        im = src.images(start=0, num=np.inf)
-        self.assertTrue(np.allclose(im.asnumpy(), self.im_np))
 
     def testImageSqrt(self):
         self.assertTrue(np.allclose(self.im.sqrt().asnumpy(), np.sqrt(self.im_np)))


### PR DESCRIPTION
Working through some issues actually trying to use `ArrayImageSource`. 

Adds optional `angles` arg to `ArrayImageSource`.
Breaks `ArrayImageSource` test into own file away from `ImageSource` (different size inputs).
Adds supporting tests covering the parameter and some misc things found in process of debugging.
Some light cleanup in areas I was poking around.