### PR TITLE
Improve corrupt mrc file handling in APPLE.picking

### DIFF
--- a/src/aspire/apple/picking.py
+++ b/src/aspire/apple/picking.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import warnings
 from concurrent import futures
 
 import mrcfile
@@ -104,8 +105,34 @@ class Picker:
             Micrograph image.
         """
 
-        with mrcfile.open(self.filename, mode="r+", permissive=True) as mrc:
-            im = mrc.data.astype("float")
+        # mrcfile tends to yield many warnings about EMPIAR datasets being corrupt
+        # These warnings generally seem benign, and the message could be clearer
+        # The following code handles the warnings via ASPIRE's logger
+        with warnings.catch_warnings(record=True) as ws:
+            # Cause all warnings to always be triggered in this context
+            warnings.simplefilter("always")
+
+            # Try to open the mrcfile
+            with mrcfile.open(self.filename, mode="r+", permissive=True) as mrc:
+                im = mrc.data.astype("float")
+
+            # Log each mrcfile warning to debug log, noting the associated file
+            for w in ws:
+                logger.debug(
+                    "In APPLE.picking mrcfile.open reports corruption for"
+                    f" {self.filename} warning: {w.message}"
+                )
+
+            # Log a single warning to user
+            # Give context and note assocated filename
+            if len(ws) > 0:
+                logger.warning(
+                    f"APPLE.picking mrcfile reporting {len(ws)} corruptions."
+                    " Most likely this is a problem with the header contents."
+                    " Details written to debug log."
+                    f" APPLE will attempt to continue processing {self.filename}"
+                )
+
         self.original_im = im
 
         # Discard outer pixels

--- a/src/aspire/apple/picking.py
+++ b/src/aspire/apple/picking.py
@@ -113,7 +113,7 @@ class Picker:
             warnings.simplefilter("always")
 
             # Try to open the mrcfile
-            with mrcfile.open(self.filename, mode="r+", permissive=True) as mrc:
+            with mrcfile.open(self.filename, mode="r", permissive=True) as mrc:
                 im = mrc.data.astype("float")
 
             # Log each mrcfile warning to debug log, noting the associated file


### PR DESCRIPTION
Closes #428 

This small patch improves the user experience of APPLE picking a real dataset (10025 20S).

The original warning was not clear and didn't include the problem filepath, or a suggestion about where in ASPIRE the warning was being generated.

We capture the warnings generated by `mrcfile`.  Each warning's specific complaint is logged along with the associated filename to the debug log (by ASPIRE defaults this is logged to disk).

Given any number of corruptions a single message is logged to the console for the user.

Example:
```
aspire apple --mrc_file=/mnt/raid0/CRYO_REFERENCE_DATA/empiar/10025/data/14sep05c_averaged_196/14sep05c_00024sq_00003hl_00002es_c.mrc --output_dir=/scratch/work_files/patch_output
```

Console logs:
```
...
2021-06-14 08:18:30,834 WARNING APPLE.picking mrcfile reporting 2 corruptions. Most likely this is a problem with the header contents. Details written to debug log. APPLE will attempt to continue processing /mnt/raid0/CRYO_REFERENCE_DATA/empiar/10025/data/14sep05c_averaged_196/14sep05c_00024sq_00003hl_00002es_c.mrc
...
```

Debug logs
```
2021-06-14 08:18:30,834 DEBUG In APPLE.picking mrcfile.open reports corruption for /mnt/raid0/CRYO_REFERENCE_DATA/empiar/10025/data/14sep05c_averaged_196/14sep05c_00024sq_00003hl_00002es_c.mrc warning: Map ID string not found - not an MRC file, or file is corrupt
2021-06-14 08:18:30,834 DEBUG In APPLE.picking mrcfile.open reports corruption for /mnt/raid0/CRYO_REFERENCE_DATA/empiar/10025/data/14sep05c_averaged_196/14sep05c_00024sq_00003hl_00002es_c.mrc warning: Unrecognised machine stamp: 0x00 0x00 0x00 0x00
2021-06-14 08:18:30,834 WARNING APPLE.picking mrcfile reporting 2 corruptions. Most likely this is a problem with the header contents. Details written to debug log. APPLE will attempt to continue processing /mnt/raid0/CRYO_REFERENCE_DATA/empiar/10025/data/14sep05c_averaged_196/14sep05c_00024sq_00003hl_00002es_c.mrc
```