### PR TITLE
Make Codecov Informational

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,2 +1,13 @@
+# We take the defaults except for treating as informational only.
+# This provides feedback without erroring the entire CI pipeline.
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
 ignore:
-  - "*/tests/*”
+  - "*/tests/*"


### PR DESCRIPTION
Turns off the status checks for code cov.

This will still generate the report, deltas, and annotations which can be used to identify important coverage gaps.  It should no longer fail a PR because the coverage was not improved etc.

This was broken out of `cls_avg` since it's independent.