### PR TITLE
Coefficient containers

### DIFF
--- a/src/aspire/basis/__init__.py
+++ b/src/aspire/basis/__init__.py
@@ -1,4 +1,5 @@
 from .basis import Basis
+from .container import CoefContainer
 from .dirac import DiracBasis
 from .fb_2d import FBBasis2D
 from .fb_3d import FBBasis3D

--- a/src/aspire/basis/container.py
+++ b/src/aspire/basis/container.py
@@ -98,8 +98,9 @@ class CoefContainer:
                     f"Incorrect mappings shape {mapping.shape[0]} for dimension {d}, expected {self._m}"
                 )
 
-        # # This is potentially used many times, compute it once.
-        # self._rng = [np.arange(d[0], d[1]+1) for d in self.bounds)]
+        # Precompute these attributes
+        self._shape = tuple([len(np.unique(axis)) for axis in self._mappings])
+        self._bounds = [(np.min(axis), np.max(axis)) for axis in self._mappings]
 
     def __repr__(self):
         return f"{type(self)}({self._data}, {self._mappings})"
@@ -206,7 +207,7 @@ class CoefContainer:
 
         :returns: tuple
         """
-        return tuple([len(np.unique(axis)) for axis in self._mappings])
+        return self._shape
 
     @property
     def bounds(self):
@@ -216,5 +217,4 @@ class CoefContainer:
 
         :returns: list of tuples
         """
-
-        return [(np.min(axis), np.max(axis)) for axis in self._mappings]
+        return self._bounds

--- a/src/aspire/basis/container.py
+++ b/src/aspire/basis/container.py
@@ -101,7 +101,10 @@ class CoefContainer:
         self._rng = np.arange(self._m)
 
     def __repr__(self):
-        return f"{tuple(self).__class__.__name__}({self._data}, {self._mappings})"
+        return f"{type(self)}({self._data}, {self._mappings})"
+
+    def __str__(self):
+        return f"{type(self)} {self._n} entries of {self._m} coefficients mapped as {self.dim} dimensions."
 
     def __len__(self):
         return self._n

--- a/src/aspire/basis/container.py
+++ b/src/aspire/basis/container.py
@@ -6,7 +6,72 @@ logger = logging.getLogger(__name__)
 
 
 class CoefContainer:
+    """
+    This class interfaces between mathematical representations of sophisticated
+    basis and the linear memory representations used in lower level code.
+
+    For performance and portability reasons ASPIRE-Python stores alternative
+    basis representations, such as the Fast Fourier Bessel Basis `FFBBasis2D`
+    and `FFBBasis3d`, in stacks of flattened numpy arrays mapped with
+    arrays of indexes described by the basis.
+
+    The coef data indexing is theoretically defined using some number of
+    axes, typically representing frequencies.  In a classic Fourier basis,
+    these frequencies are dense and uniform (stride 1), so easily
+    represented by a multi-dimensional array.  However, for most other basis
+    in ASPIRE the frequency space is not required to be (and generally is not)
+    dense or uniform.  Instead frequencies are defined in dense arrays of
+    `indices`.  The ragged arrays of coefficients are flattened,
+    and the `indices` provide a map to lookup locations of desired frequencies'
+    values.
+
+    While it would be possible to store coef data as high level
+    objects indexed by arbitrary frequencies using dictionaries etc,
+    this would yield poor perfomance over large stacks of images commonly
+    found in Cryo-EM datasets.  Instead we provide an effecient container
+    for naturally accessing the array storage.
+
+    This class is intentionally generic to container mapping dimension
+    and agnostic to data types.
+
+    `data` and `mappings` should both be two dimensional arrays.
+    The stack index is trivial, and  is the first (slow) moving axis of `data`.
+    The container's dimension is taken from the first (slow) axis of `mappings`.
+    The second axis of mappings describes the indice mapping for each basis
+    axis.  For example, consider the following sequence having two basis
+    dimensions `k` and `q`, writing coefs as C_k_q:
+
+    {C_0_0, C_0_1, C_0_2, C_1_0, C_1_1, ...} corresponds to
+
+    `k` indices {0, 0, 0, 1, 1, ...}
+    `q` indices {0, 1, 2, 0, 1, ...}
+
+    So we would provide mapping array:
+    [[0, 0, 0, 1, 1, ...],
+    [0, 1, 2, 0, 1, ...]]
+
+    In practice indices are computed and accessible from Basis classes,
+    and just need to be provided to CoefContainer (or a subclass).
+    """
+
     def __init__(self, data, mappings):
+        """
+        Instantiate a CoefContainer described by `mappings`
+        and backed by `data`.
+
+        :param data: Numpy array of coef data.
+        :param mappings: Iterable (list,tuple,array) of mappings, see class doc.
+        """
+
+        if not isinstance(data, np.ndarray):
+            logger.warning(
+                f"`data` is type {type(data)} not numpy array, attmepting conversion."
+            )
+            try:
+                data = np.array(data)
+            except Exception as e:
+                logger.error("Conversion of `data` to numpy array failed!")
+                raise e
 
         self._data = data
         if self._data.ndim != 2:
@@ -17,38 +82,62 @@ class CoefContainer:
         self._n = data.shape[0]
         self._m = self._data.shape[1]
 
-        self._mappings = mappings
-        self._dim = len(mappings)
+        try:
+            self._mappings = np.array(mappings)
+        except Exception as e:
+            logger.error(
+                f"Conversion of `mappings` {type(mappings)} to numpy array failed!"
+            )
+            raise e
+
+        self.dim = self._mappings.shape[0]
         for d, mapping in enumerate(mappings):
             if len(mapping) != self._m:
                 raise RuntimeError(
-                    f"Incorrect mappings shape {len(mapping)} for dimension {d}, expected {self._m}"
+                    f"Incorrect mappings shape {mapping.shape[0]} for dimension {d}, expected {self._m}"
                 )
 
+        # This is potentially used many times, compute it once.
+        self._rng = np.arange(self._m)
+
     def __repr__(self):
-        return f"{tuple(self).__name__}({self._data}, {self._mappings})"
+        return f"{tuple(self).__class__.__name__}({self._data}, {self._mappings})"
 
     def __len__(self):
-        return self.n
+        return self._n
 
-    def __getitem__(self, idx):
-        logger.debug(f"idx {type(idx)} {idx}")
+    def _expand_tuple(self, idx):
+        """
+        Expands any missing slice operators in idx.
 
-        if isinstance(idx, tuple):
-            full_idx = [slice(None, None, None)] * (
-                self._dim + 1
-            )  # Mappings + Stack axes
-            for i, _idx in enumerate(idx):
-                full_idx[i] = _idx
-            idx = tuple(full_idx)
-        else:
-            # make it a full tuple
-            return self[
-                idx,
-            ]
+        :param idx: Index operator, typically from `__getitem__` or `__setitem__`.
+        :returns: self.dim dimensional tuple of slices and/or ints.
+        """
 
-        # Now that we have a consistent tuple
-        #  we can use the same logic for all cases.
+        # Convert to tuple so we can always use same logic
+        if not isinstance(idx, tuple):
+            idx = (idx,)
+
+        # Completely describe every slice
+        # When high dims are missing, that implies :, ie, default slice of Nones
+        full_idx = [slice(None, None, None)] * (self.dim + 1)  # Mappings + Stack axes
+
+        for i, _idx in enumerate(idx):
+            full_idx[i] = _idx
+
+        return tuple(full_idx)
+
+    def compute_idx(self, idx):
+        """
+        Given a one to `self.dim`-dimensional index (slices and/or ints),
+        computes the indices into the stack of flattened arrays `data`.
+
+        :param idx: Index operator, typically from `__getitem__` or `__setitem__`.
+        :returns: tuple (stack_idx, data_idx) indexing `data`.
+        """
+
+        # Make a consistent tuple so we can use the same logic for all cases.
+        idx = self._expand_tuple(idx)
 
         # The first axis is always the "stack" axis
         stack_idx = idx[0]
@@ -57,11 +146,11 @@ class CoefContainer:
         # Remaining axes are container dimensions
         #   described by `mappings`
         # Find the data array indices represented by the container's slices.
-        masks = np.zeros((self._dim, self._m), dtype=bool)
-        rng = np.arange(self._m)
+        masks = np.zeros((self.dim, self._m), dtype=bool)
+
         for dim, _idx in enumerate(idx[1:]):
             # Evaluate the slice
-            indices = rng[_idx]
+            indices = self._rng[_idx]
             logger.debug(f"dim {dim} indices {indices}")
 
             # Union all locations we find indices
@@ -76,10 +165,29 @@ class CoefContainer:
         data_idx = masks.all(axis=0)
         logger.debug(f"data_idx {data_idx}")
 
-        return self._data[stack_idx, data_idx]
+        return stack_idx, data_idx
 
-    def __setitem__(self):
-        pass
+    def __getitem__(self, idx):
+        logger.debug(f"get idx {type(idx)} {idx}")
+        return self._data[self.compute_idx(idx)]
+
+    def __setitem__(self, idx, values):
+        logger.debug(f"set idx {type(idx)} {idx}")
+        self._data[self.compute_idx(idx)] = values
 
     def asnumpy(self):
         return self._data
+
+    def copy(self):
+        """
+        Copy, copies `data` and `mappings` arrays backing instance.
+
+        :return: new container instance.
+        """
+        return type(self)(self._data.copy(), self._mappings.copy())
+
+    def shape(self):
+        pass
+
+    def bounds(self):
+        pass

--- a/src/aspire/basis/container.py
+++ b/src/aspire/basis/container.py
@@ -1,0 +1,85 @@
+import logging
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+class CoefContainer:
+    def __init__(self, data, mappings):
+
+        self._data = data
+        if self._data.ndim != 2:
+            raise RuntimeError(
+                f"Incorrect data array dimension {self._data.ndim}, expected 2"
+            )
+
+        self._n = data.shape[0]
+        self._m = self._data.shape[1]
+
+        self._mappings = mappings
+        self._dim = len(mappings)
+        for d, mapping in enumerate(mappings):
+            if len(mapping) != self._m:
+                raise RuntimeError(
+                    f"Incorrect mappings shape {len(mapping)} for dimension {d}, expected {self._m}"
+                )
+
+    def __repr__(self):
+        return f"{tuple(self).__name__}({self._data}, {self._mappings})"
+
+    def __len__(self):
+        return self.n
+
+    def __getitem__(self, idx):
+        logger.debug(f"idx {type(idx)} {idx}")
+
+        if isinstance(idx, tuple):
+            full_idx = [slice(None, None, None)] * (
+                self._dim + 1
+            )  # Mappings + Stack axes
+            for i, _idx in enumerate(idx):
+                full_idx[i] = _idx
+            idx = tuple(full_idx)
+        else:
+            # make it a full tuple
+            return self[
+                idx,
+            ]
+
+        # Now that we have a consistent tuple
+        #  we can use the same logic for all cases.
+
+        # The first axis is always the "stack" axis
+        stack_idx = idx[0]
+        logger.debug(f"stack_idx {stack_idx}")
+
+        # Remaining axes are container dimensions
+        #   described by `mappings`
+        # Find the data array indices represented by the container's slices.
+        masks = np.zeros((self._dim, self._m), dtype=bool)
+        rng = np.arange(self._m)
+        for dim, _idx in enumerate(idx[1:]):
+            # Evaluate the slice
+            indices = rng[_idx]
+            logger.debug(f"dim {dim} indices {indices}")
+
+            # Union all locations we find indices
+            logger.debug(f"_idx {_idx}  self._mappings[dim]{self._mappings[dim]}")
+            masks[dim] = np.atleast_2d(np.isin(self._mappings[dim], indices)).any(
+                axis=0
+            )
+            logger.debug(f"masks[dim] {masks[dim]}")
+
+        # Now find the intersection of the masks for each container axis.
+        #  This represents the indices into each entry of the stack.
+        data_idx = masks.all(axis=0)
+        logger.debug(f"data_idx {data_idx}")
+
+        return self._data[stack_idx, data_idx]
+
+    def __setitem__(self):
+        pass
+
+    def asnumpy(self):
+        return self._data

--- a/tests/test_basis_container.py
+++ b/tests/test_basis_container.py
@@ -1,0 +1,57 @@
+from unittest import TestCase
+
+import numpy as np
+
+from aspire.basis import CoefContainer
+
+
+class CoefContainerTestCase(TestCase):
+    def setUp(self):
+
+        # Construct an index mapping
+        self.maps = np.array(
+            [
+                [0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1],
+                [0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 1, 1],
+                [0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3],
+            ]
+        )
+
+        # Make a stack of data
+        self.data = np.arange(1, 43).reshape(-1, 1) @ np.arange(
+            self.maps.shape[-1]
+        ).reshape(1, -1)
+
+        # Setup a stack+2D container
+        self.C2 = CoefContainer(self.data, self.maps[1:])
+
+        # Setup a stack+3D container
+        self.C3 = CoefContainer(self.data, self.maps)
+
+    def assertAll(self, a, b):
+        return self.assertTrue(np.all(a == b))
+
+    def testContainerZero(self):
+
+        # 3D
+        self.assertAll(self.data[0, 0], self.C3[:, 0:1, 0:1, 0:1])
+        self.assertAll(self.data[0, 0], self.C3[:, 0, 0, 0])
+
+        # 2D
+        c = self.C2[:, 0, 0]
+        self.assertAll(c[:, 0], np.zeros(c.shape[0]))
+        # Should be multiples of 8
+        self.assertAll(c[:, 1] // 8, np.arange(1, c.shape[0] + 1))
+        # Int index should be consistent with slicing syntax
+        self.assertAll(c, self.C2[:, 0:1, 0:1])
+
+    def testContainerStackAxis(self):
+
+        for i in range(self.data.shape[0]):
+            self.assertAll(self.C3[i], self.data[i])
+
+    def testBounds(self):
+        pass
+
+    def testDims(self):
+        pass

--- a/tests/test_basis_container.py
+++ b/tests/test_basis_container.py
@@ -29,9 +29,15 @@ class CoefContainerTestCase(TestCase):
         self.C3 = CoefContainer(self.data, self.maps)
 
     def assertAll(self, a, b):
+        """
+        Helper function, checks np compares all elements is True.
+        """
         return self.assertTrue(np.all(a == b))
 
-    def testContainerZero(self):
+    def testContainerGetter(self):
+        """
+        Sanity test basic gets (accesses).
+        """
 
         # 3D
         self.assertAll(self.data[0, 0], self.C3[:, 0:1, 0:1, 0:1])
@@ -49,6 +55,32 @@ class CoefContainerTestCase(TestCase):
 
         for i in range(self.data.shape[0]):
             self.assertAll(self.C3[i], self.data[i])
+
+    def testContainerSetter(self):
+        """
+        Sanity check basic sets (assignments).
+        """
+
+        # Copy C3 so we can use as a reference later.
+        C = self.C3.copy()
+
+        # We'll excercise setting each axis in a different way.
+        C[:, 1] = 0
+        self.assertTrue(np.sum(C[:, 1]) == 0)
+
+        C[:, :, 1:] = 1
+        self.assertTrue(np.sum(C[:, :, 1:]) == 6 * 42)
+
+        C[:, :, :, 0:2] = np.arange(6)
+        self.assertTrue(np.sum(C[:, :, :, 0:2]) == 15 * 42)
+
+        # Other entries should not have changed.
+        self.assertAll(C[:, 0, 0, 2:], self.C3[:, 0, 0, 2:])
+
+        # Sanity check stack axis assignment.
+        x = np.arange(self.maps.shape[-1])
+        C[13] = x
+        self.assertAll(C[13], x)
 
     def testBounds(self):
         pass

--- a/tests/test_basis_container.py
+++ b/tests/test_basis_container.py
@@ -1,8 +1,11 @@
+import logging
 from unittest import TestCase
 
 import numpy as np
 
 from aspire.basis import CoefContainer
+
+logger = logging.getLogger(__name__)
 
 
 class CoefContainerTestCase(TestCase):
@@ -81,6 +84,15 @@ class CoefContainerTestCase(TestCase):
         x = np.arange(self.maps.shape[-1])
         C[13] = x
         self.assertAll(C[13], x)
+
+    def testStringRepr(self):
+        """
+        String representations should not crash.
+        """
+        logger.info(repr(self.C2))
+        logger.info(str(self.C2))
+        logger.info(repr(self.C3))
+        logger.info(str(self.C3))
 
     def testBounds(self):
         pass

--- a/tests/test_basis_container.py
+++ b/tests/test_basis_container.py
@@ -94,8 +94,49 @@ class CoefContainerTestCase(TestCase):
         logger.info(repr(self.C3))
         logger.info(str(self.C3))
 
-    def testBounds(self):
-        pass
-
     def testDims(self):
-        pass
+        self.assertTrue(self.C2.dim == 2)
+        self.assertTrue(self.C3.dim == 3)
+
+    def testShape(self):
+        self.assertTrue(self.C2.shape == (2, 4))
+        self.assertTrue(self.C3.shape == (2, 2, 4))
+
+    def testBounds(self):
+        self.assertTrue(self.C2.bounds == [(0, 1), (0, 3)])
+        self.assertTrue(self.C3.bounds == [(0, 1), (0, 1), (0, 3)])
+
+    def testNegative(self):
+        """
+        Container should handle negative indices.
+        """
+
+        # Setup dummy data imagining axes as:
+        # ax1 [-1,0,1] ax2 [0,1,2,3,4]]
+        nmap = [
+            [-1, -1, -1, -1, -1, 0, 1, 1, 1, 1, 1],
+            [0, 1, 2, 3, 4, 0, 0, 1, 2, 3, 4],
+        ]
+        ndata = np.empty((123, 11))
+
+        # Instantiate the container accessor
+        C = CoefContainer(ndata, nmap)
+
+        # Check shape and bounds
+        self.assertTrue(C.shape == (3, 5))
+        self.assertTrue(C.bounds == [(-1, 1), (0, 4)])
+
+    def testIter(self):
+        """
+        Test we able to iterate over the container.
+
+        Realistically only iterating the stack will be common.
+        """
+
+        # Iterate over stack
+        for i, v in enumerate(self.C3):
+            self.assertAll(v, (i + 1) * np.arange(self.maps.shape[-1]))
+
+        # Iterate over first data axis of an element
+        for i, ax1 in enumerate(self.C3[1]):
+            self.assertTrue(2 * i == ax1)


### PR DESCRIPTION
Stashing some WIP on a class for accessing coefficients.

Essentially this intends to make common basis usage patterns more natural in code by using indices closer to literature, and making the raw flattened array indexing opaque.  Currently we sprinkle a lot of raw array indexing arithmetic all around the code and it makes the actual algorithms hard to grok.

For example, with a two dimensional Fast Fourier Bessel Basis, it would be nice to just say something like:

```
coefficients[0:stack_chunksize, my_ks, my_qs]
```
or
```
coefficients[:, 0, :]
```

and have it just return the coefficients we want from the raw (n, count) array.  Similar idea for a setter. I'm thinking for each basis we simply need to pass along the indices maps and coef array to this container like thing.