### PR TITLE
Irregular Block Diagonal Extension

### DIFF
--- a/src/aspire/operators/blk_diag_matrix.py
+++ b/src/aspire/operators/blk_diag_matrix.py
@@ -48,7 +48,6 @@ class BlkDiagMatrix:
         self._cached_blk_sizes = np.array(partition)
         if len(partition):
             assert self._cached_blk_sizes.shape[1] == 2
-            assert all([BlkDiagMatrix.__check_square(s) for s in partition])
 
     def reset_cache(self):
         """
@@ -106,7 +105,6 @@ class BlkDiagMatrix:
         Convenience wrapper, setter on self.data.
         """
 
-        BlkDiagMatrix.__check_square(value.shape)
         self.data[key] = value
         self.reset_cache()
 
@@ -136,9 +134,10 @@ class BlkDiagMatrix:
 
         return np.isscalar(x)
 
-    def __check_size_compatible(self, other):
+    def __check_size_compatible_add(self, other):
         """
-        Sanity check two BlkDiagMatrix instances are compatible in size.
+        Sanity check two BlkDiagMatrix instances are compatible in size
+        for addition operators. (Same size)
 
         :param other: The BlkDiagMatrix to compare with self.
         """
@@ -146,12 +145,28 @@ class BlkDiagMatrix:
         if np.any(self.partition != other.partition):
             # be helpful and find the first one as an example
             for _i, (a, b) in enumerate(zip(self.partition, other.partition)):
-                if a != b:
+                if any(a != b):
                     break
             raise RuntimeError(
                 "Block i={} of BlkDiagMatrix instances are "
                 "not same shape {} {}".format(_i, a, b)
             )
+
+    def __check_size_compatible_mul(self, other):
+        """
+        Sanity check two BlkDiagMatrix instances are compatible in size
+        for multiplication operators. (m n) @ (n k).
+
+        :param other: The BlkDiagMatrix to compare with self.
+        """
+
+        for _i, a in enumerate(self.partition):
+            b = other.partition[_i]
+            if a[1] != b[0]:
+                raise RuntimeError(
+                    "Block i={} of BlkDiagMatrix instances are "
+                    "not compatible. {} {}".format(_i, a, b)
+                )
 
     def __check_dtype_compatible(self, other):
         """
@@ -167,7 +182,7 @@ class BlkDiagMatrix:
                 " as appropriate.".format(self.dtype, other.dtype)
             )
 
-    def __check_compatible(self, other):
+    def __check_compatible(self, other, size_compat="add"):
         """
         Sanity check two BlkDiagMatrix instances are compatible in size.
 
@@ -185,7 +200,13 @@ class BlkDiagMatrix:
                 "Number of blocks {} {} are not equal.".format(len(self), len(other))
             )
 
-        self.__check_size_compatible(other)
+        if size_compat == "add":
+            self.__check_size_compatible_add(other)
+        elif size_compat == "mul":
+            self.__check_size_compatible_mul(other)
+        else:
+            raise RuntimeError("Unknown compatibility type {}".format(size_compat))
+
         self.__check_dtype_compatible(other)
 
     @property
@@ -373,7 +394,7 @@ class BlkDiagMatrix:
                 "(matmul,@) of non BlkDiagMatrix {}, try (*,mul)".format(repr(other))
             )
 
-        self.__check_compatible(other)
+        self.__check_compatible(other, size_compat="mul")
 
         if inplace:
             for i in range(self.nblocks):
@@ -694,22 +715,6 @@ class BlkDiagMatrix:
             C[i] = make_psd(self[i])
 
         return C
-
-    @staticmethod
-    def __check_square(shp):
-        """
-        Check if supplied shape tuple is square.
-
-        :param shp:  Shape to test, expressed as a 2-tuple.
-        """
-
-        if shp[0] != shp[1]:
-            raise NotImplementedError(
-                "Currently BlkDiagMatrix only supports"
-                " square blocks.  Received {}".format(shp)
-            )
-
-        return True
 
     @staticmethod
     def empty(nblocks, dtype=np.float32):

--- a/src/aspire/operators/blk_diag_matrix.py
+++ b/src/aspire/operators/blk_diag_matrix.py
@@ -210,7 +210,7 @@ class BlkDiagMatrix:
         self.__check_dtype_compatible(other)
 
     @property
-    def _issquare(self):
+    def is_square(self):
         """
         Check if all blocks are square.
 
@@ -645,7 +645,7 @@ class BlkDiagMatrix:
         # Use `np.linalg.solve` for square matrices/blocks.
         #   If user requires solving non square, we'll need to extend for
         #   lstsq or qr,triangle solvers.
-        if not self._issquare:
+        if not self.is_square:
             raise NotImplementedError(
                 "BlkDiagMatrix.solve is only defined for square arrays. "
                 "If you require solving non square BlkDiagMatrix please "

--- a/src/aspire/operators/blk_diag_matrix.py
+++ b/src/aspire/operators/blk_diag_matrix.py
@@ -210,7 +210,7 @@ class BlkDiagMatrix:
         self.__check_dtype_compatible(other)
 
     @property
-    def isregular(self):
+    def _issquare(self):
         """
         Check if all blocks are square.
 
@@ -644,7 +644,7 @@ class BlkDiagMatrix:
 
         # Default using `np.linalg.solve` for square matrices/blocks.
         _solve = solve
-        if not self.isregular:
+        if not self._issquare:
             # For non-square use `lstsq`.  Wrap for slightly different syntax.
             def _solve(a, b):
                 return lstsq(a, b, rcond=None)[0]

--- a/tests/test_BlkDiagMatrix.py
+++ b/tests/test_BlkDiagMatrix.py
@@ -429,32 +429,18 @@ class IrrBlkDiagMatrixTestCase(TestCase):
         self.allallfunc(d, self.blk_x.dense() @ coeffm)
 
     def testSolve(self):
-        from numpy.linalg import lstsq
+        """
+        Test attempts to solve non square BlkDiagMatrix raise error.
+        """
 
-        # Construct a matrix for solving.
-        B = self.blk_x + BlkDiagMatrix.eye_like(self.blk_x)
-
+        # Setup a dummy coeff matrix
         n = np.sum(self.blk_x.partition[:, 0])
-        m = np.sum(self.blk_x.partition[:, 1])
         k = 3
         coeffm = np.arange(n * k).reshape(n, k).astype(self.blk_x.dtype)
 
-        # Manually compute
-        indra = 0
-        indrb = 0
-        res = np.empty(shape=(m, k), dtype=coeffm.dtype)
-        for b, blk in enumerate(B):
-            rb, ra = B.partition[b]
-            res[indra : indra + ra, :] = lstsq(
-                blk, coeffm[indrb : indrb + rb, :], rcond=None
-            )[0]
-            indra += ra
-            indrb += rb
-
-        # Solve using the Block Diagonal implementation and compare
-        coeff_est = B.solve(coeffm)
-        self.allallfunc(res, coeff_est)
-
-        # Convert to dense then solve using Numpy and compare
-        coeff_est = lstsq(B.dense(), coeffm, rcond=None)[0]
-        self.allallfunc(res, coeff_est)
+        with pytest.raises(
+            NotImplementedError,
+            match=r"BlkDiagMatrix.solve is only defined for square arrays.*",
+        ):
+            # Attemplt solve using the Block Diagonal implementation
+            _ = self.blk_x.solve(coeffm)

--- a/tests/test_BlkDiagMatrix.py
+++ b/tests/test_BlkDiagMatrix.py
@@ -368,6 +368,24 @@ class IrrBlkDiagMatrixTestCase(TestCase):
         ):
             _ = self.blk_x + self.blk_xt
 
+    def testSub(self):
+        Y = BlkDiagMatrix.zeros_like(self.blk_x)
+        BlkY = self.blk_x - self.blk_x
+
+        self.allallfunc(Y, BlkY)
+
+    def testSubIncompat(self):
+        with pytest.raises(
+            RuntimeError, match=r".*BlkDiagMatrix instances are not same shape.*"
+        ):
+            _ = self.blk_x - self.blk_xt
+
+    def testScalars(self):
+        self.allallfunc((42 - self.blk_x) * 13, [13 * (42 - x) for x in self.X])
+
+    def testTranspose(self):
+        self.allallfunc(self.blk_x.T, self.blk_xt)
+
     def testMatMul(self):
         result = [np.matmul(*tup) for tup in zip(self.X, self.XT)]
 
@@ -414,9 +432,7 @@ class IrrBlkDiagMatrixTestCase(TestCase):
         from numpy.linalg import lstsq
 
         # Construct a matrix for solving.
-        B = self.blk_x
-        for _i, blk in enumerate(B):
-            B[_i] = blk + np.eye(*blk.shape)
+        B = self.blk_x + BlkDiagMatrix.eye_like(self.blk_x)
 
         n = np.sum(self.blk_x.partition[:, 0])
         m = np.sum(self.blk_x.partition[:, 1])


### PR DESCRIPTION
Relating to #442 .

This extends the block diagonal code to operate with non square matrices.  The main reason to do this is to support truncation of eigenvectors stored in a block diagonal matrix, which will yield an irregular block diagonal structure.

The draft PR makes some minor bookkeeping code updates and provides a second unit test class focused on irregular block diagonal test cases.

~Todo: Will work on the `solve` method.~