### PR TITLE
Remove BlkDiagMatrix dense expansion in FSPCA compression

### DIFF
--- a/src/aspire/basis/fspca.py
+++ b/src/aspire/basis/fspca.py
@@ -286,8 +286,7 @@ class FSPCABasis(SteerableBasis2D):
         """
 
         # Apply linear combination defined by FSPCA (eigvecs)
-        #  The following is equivalent to `x @ eigvecs`
-        c_fspca = self.eigvecs.T.apply(x.T).T
+        c_fspca = x @ self.eigvecs
 
         assert c_fspca.shape == (x.shape[0], self.count)
 

--- a/src/aspire/basis/fspca.py
+++ b/src/aspire/basis/fspca.py
@@ -284,15 +284,10 @@ class FSPCABasis(SteerableBasis2D):
         Fourier Bessel basis.
         :return: Stack of coefs in the FSPCABasis.
         """
-        # apply linear combination defined by FSPCA (eigvecs)
-        #  can try blk_diag here, but I think needs to be extended to non square...,
-        #  or masked.
-        # c_fspca = (self.eigvecs.apply(c_fb.T)).T
-        eigvecs = self.eigvecs
-        if isinstance(eigvecs, BlkDiagMatrix):
-            eigvecs = eigvecs.dense()
 
-        c_fspca = x @ eigvecs
+        # Apply linear combination defined by FSPCA (eigvecs)
+        #  The following is equivalent to `x @ eigvecs`
+        c_fspca = self.eigvecs.T.apply(x.T).T
 
         assert c_fspca.shape == (x.shape[0], self.count)
 

--- a/tests/test_BlkDiagMatrix.py
+++ b/tests/test_BlkDiagMatrix.py
@@ -145,6 +145,10 @@ class BlkDiagMatrixTestCase(TestCase):
             e[:, i] = self.blk_a.apply(coeffm[:, i])
         self.allallfunc(e, d)
 
+        # We can use syntactic sugar @ for apply as well
+        f = self.blk_a @ coeffm
+        self.allallfunc(f, d)
+
         # Test the rapply is also functional
         coeffm = coeffm.T  # matmul dimensions
         res = coeffm @ self.blk_a.dense()
@@ -154,6 +158,17 @@ class BlkDiagMatrixTestCase(TestCase):
         # And the syntactic sugar @
         d = coeffm @ self.blk_a
         self.allallfunc(res, d)
+
+        # And test some incorrrect invocations:
+        # inplace not supported for matmul of mixed classes.
+        with pytest.raises(RuntimeError, match=r".*method not supported.*"):
+            self.blk_a @= coeffm
+
+        # Test left operand of an __rmatmul__ must be an ndarray
+        with pytest.raises(
+            RuntimeError, match=r".*only defined for np.ndarray @ BlkDiagMatrix.*"
+        ):
+            _ = list(coeffm) @ self.blk_a
 
     def testBlkDiagMatrixMatMult(self):
         result = [np.matmul(*tup) for tup in zip(self.blk_a, self.blk_b)]

--- a/tests/test_BlkDiagMatrix.py
+++ b/tests/test_BlkDiagMatrix.py
@@ -145,6 +145,16 @@ class BlkDiagMatrixTestCase(TestCase):
             e[:, i] = self.blk_a.apply(coeffm[:, i])
         self.allallfunc(e, d)
 
+        # Test the rapply is also functional
+        coeffm = coeffm.T  # matmul dimensions
+        res = coeffm @ self.blk_a.dense()
+        d = self.blk_a.rapply(coeffm)
+        self.allallfunc(res, d)
+
+        # And the syntactic sugar @
+        d = coeffm @ self.blk_a
+        self.allallfunc(res, d)
+
     def testBlkDiagMatrixMatMult(self):
         result = [np.matmul(*tup) for tup in zip(self.blk_a, self.blk_b)]
 


### PR DESCRIPTION
#444 brought in the irregular (non square) block diagonal matrix feature.  This PR uses the new feature in the FSPCA compression area of the class averaging implementation.

Also adds related syntactic sugar and tests used for that invocation.

Closes #442 