### PR TITLE
Numpy Updates

### DIFF
--- a/src/aspire/basis/fb_2d.py
+++ b/src/aspire/basis/fb_2d.py
@@ -80,8 +80,8 @@ class FBBasis2D(SteerableBasis2D):
         # We'll also generate a mapping for complex construction
         self.complex_count = sum(self.k_max)
         # These map indices in complex array to pair of indices in real array
-        self._pos = np.zeros(self.complex_count, dtype=np.int)
-        self._neg = np.zeros(self.complex_count, dtype=np.int)
+        self._pos = np.zeros(self.complex_count, dtype=int)
+        self._neg = np.zeros(self.complex_count, dtype=int)
 
         i = 0
         ci = 0
@@ -217,7 +217,7 @@ class FBBasis2D(SteerableBasis2D):
         x = np.zeros(shape=tuple([np.prod(self.sz)] + list(v.shape[1:])), dtype=v.dtype)
         for ell in range(0, self.ell_max + 1):
             k_max = self.k_max[ell]
-            idx_radial = ind_radial + np.arange(0, k_max, dtype=np.int)
+            idx_radial = ind_radial + np.arange(0, k_max, dtype=int)
 
             # include the normalization factor of angular part
             ang_nrms = self.angular_norms[idx_radial]
@@ -228,7 +228,7 @@ class FBBasis2D(SteerableBasis2D):
             for _ in sgns:
                 ang = self._precomp["ang"][:, ind_ang]
                 ang_radial = np.expand_dims(ang[ang_idx], axis=1) * radial[r_idx]
-                idx = ind + np.arange(0, k_max, dtype=np.int)
+                idx = ind + np.arange(0, k_max, dtype=int)
                 x[mask] += ang_radial @ v[idx]
                 ind += len(idx)
                 ind_ang += 1

--- a/src/aspire/basis/fb_3d.py
+++ b/src/aspire/basis/fb_3d.py
@@ -67,9 +67,9 @@ class FBBasis3D(Basis):
         """
         Create the indices for each basis function
         """
-        indices_ells = np.zeros(self.count, dtype=np.int)
-        indices_ms = np.zeros(self.count, dtype=np.int)
-        indices_ks = np.zeros(self.count, dtype=np.int)
+        indices_ells = np.zeros(self.count, dtype=int)
+        indices_ms = np.zeros(self.count, dtype=int)
+        indices_ks = np.zeros(self.count, dtype=int)
 
         ind = 0
         for ell in range(self.ell_max + 1):

--- a/src/aspire/basis/ffb_2d.py
+++ b/src/aspire/basis/ffb_2d.py
@@ -135,7 +135,7 @@ class FFBBasis2D(FBBasis2D):
 
         ind = 0
 
-        idx = ind + np.arange(self.k_max[0], dtype=np.int)
+        idx = ind + np.arange(self.k_max[0], dtype=int)
 
         # include the normalization factor of angular part into radial part
         radial_norm = self._precomp["radial"] / np.expand_dims(self.angular_norms, 1)
@@ -145,8 +145,8 @@ class FFBBasis2D(FBBasis2D):
         ind_pos = ind
 
         for ell in range(1, self.ell_max + 1):
-            idx = ind + np.arange(self.k_max[ell], dtype=np.int)
-            idx_pos = ind_pos + np.arange(self.k_max[ell], dtype=np.int)
+            idx = ind + np.arange(self.k_max[ell], dtype=int)
+            idx_pos = ind_pos + np.arange(self.k_max[ell], dtype=int)
             idx_neg = idx_pos + self.k_max[ell]
 
             v_ell = (v[:, idx_pos] - 1j * v[:, idx_neg]) / 2.0

--- a/src/aspire/classification/legacy_implementations.py
+++ b/src/aspire/classification/legacy_implementations.py
@@ -191,7 +191,7 @@ def bispec_2drot_large(coeff, freqs, eigval, alpha, sample_n):
     freqs_not_zero = freqs != 0
 
     coeff_norm = np.log(np.power(np.absolute(coeff[freqs_not_zero]), alpha))
-    if np.any(coeff_norm == np.float("-inf")):
+    if np.any(coeff_norm == float("-inf")):
         raise ValueError("coeff_norm should not be -inf")
 
     phase = coeff[freqs_not_zero] / np.absolute(coeff[freqs_not_zero])

--- a/src/aspire/ctf/ctf_estimator.py
+++ b/src/aspire/ctf/ctf_estimator.py
@@ -581,8 +581,8 @@ class CtfEstimator:
         rad_sq_min = N * pixel_size / g_min
         rad_sq_max = N * pixel_size / g_max
 
-        max_val = r[center, np.int(center - 1 + np.floor(rad_sq_max))]
-        min_val = r[center, np.int(center - 1 + np.ceil(rad_sq_min))]
+        max_val = r[center, int(center - 1 + np.floor(rad_sq_max))]
+        min_val = r[center, int(center - 1 + np.ceil(rad_sq_min))]
 
         mask = (r <= max_val) & (r > min_val)
         a = a[mask]

--- a/src/aspire/operators/blk_diag_matrix.py
+++ b/src/aspire/operators/blk_diag_matrix.py
@@ -621,7 +621,7 @@ class BlkDiagMatrix:
         """
 
         if self._cached_blk_sizes is None:
-            blk_sizes = np.empty((self.nblocks, 2), dtype=np.int)
+            blk_sizes = np.empty((self.nblocks, 2), dtype=int)
             for i, blk in enumerate(self.data):
                 blk_sizes[i] = np.shape(blk)
             self._cached_blk_sizes = blk_sizes

--- a/src/aspire/reconstruction/mean.py
+++ b/src/aspire/reconstruction/mean.py
@@ -19,7 +19,7 @@ class MeanEstimator(Estimator):
         sq_filters_f = self.src.eval_filter_grid(self.L, power=2)
 
         for i in range(0, self.n, self.batch_size):
-            _range = np.arange(i, min(self.n, i + self.batch_size), dtype=np.int)
+            _range = np.arange(i, min(self.n, i + self.batch_size), dtype=int)
             pts_rot = rotated_grids(self.L, self.src.rots[_range, :, :])
             weights = sq_filters_f[:, :, _range]
             weights *= self.src.amplitudes[_range] ** 2

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -387,7 +387,7 @@ class ImageSource:
         :param kwargs: Any additional keyword arguments to pass on to the `ImageSource`'s underlying `_images` method.
         :return: an `Image` object.
         """
-        indices = np.arange(start, min(start + num, self.n), dtype=np.int)
+        indices = np.arange(start, min(start + num, self.n), dtype=int)
 
         if self._cached_im is not None:
             logger.info("Loading images from cache")

--- a/src/aspire/source/simulation.py
+++ b/src/aspire/source/simulation.py
@@ -179,7 +179,7 @@ class Simulation(ImageSource):
 
     def _images(self, start=0, num=np.inf, indices=None, enable_noise=True):
         if indices is None:
-            indices = np.arange(start, min(start + num, self.n), dtype=np.int)
+            indices = np.arange(start, min(start + num, self.n), dtype=int)
 
         im = self.projections(start=start, num=num, indices=indices)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -47,4 +47,4 @@ class UtilsTestCase(TestCase):
         self.assertEqual(1e-8, utest_tolerance(np.float64))
         self.assertEqual(1e-5, utest_tolerance(np.float32))
         with raises(TypeError):
-            utest_tolerance(np.int)
+            utest_tolerance(int)

--- a/tutorials/examples/basic_image_array.py
+++ b/tutorials/examples/basic_image_array.py
@@ -143,7 +143,7 @@ plt.show()
 def radial_profile(data):
     y, x = np.indices((data.shape))
     # Distance from origin to lower left corner
-    r = np.sqrt(x ** 2 + y ** 2).astype(np.int)
+    r = np.sqrt(x ** 2 + y ** 2).astype(int)
     binsum = np.bincount(r.ravel(), np.log(1 + data.ravel()))
     bincount = np.bincount(r.ravel())
     # Return the mean per bin


### PR DESCRIPTION
Later versions of Numpy, such as those used commonly upstream in Python 3.9, have made some changes to `dtypes`.  The main ways this effects us are that `np.int` is deprecated in favor of `int`, and also `np.float` is deprecated in favor of `float` or a specific numpy type (like `np.float64`).

Those cases have been replaced in this PR.

Related to #387 and #320 .