### PR TITLE
fix oversight in `circ` and `inverse_r` centering

### DIFF
--- a/src/aspire/utils/misc.py
+++ b/src/aspire/utils/misc.py
@@ -164,7 +164,7 @@ def circ(size, x0=0, y0=0, radius=1, peak=1, dtype=np.float64):
     g = grid_2d(size, shifted=True, normalized=False, dtype=dtype)
 
     circ = ((g["x"] - x0) ** 2 + (g["y"] - y0) ** 2) < radius * radius
-    return circ.astype(dtype)
+    return (peak * circ).astype(dtype)
 
 
 def inverse_r(size, x0=0, y0=0, peak=1, dtype=np.float64):

--- a/src/aspire/utils/misc.py
+++ b/src/aspire/utils/misc.py
@@ -163,8 +163,8 @@ def circ(size, x0=0, y0=0, radius=1, peak=1, dtype=np.float64):
     # Construct centered mesh
     g = grid_2d(size, shifted=True, normalized=False, dtype=dtype)
 
-    circ = ((g["x"] - x0) ** 2 + (g["y"] - y0) ** 2) < radius * radius
-    return (peak * circ).astype(dtype)
+    vals = ((g["x"] - x0) ** 2 + (g["y"] - y0) ** 2) < radius * radius
+    return (peak * vals).astype(dtype)
 
 
 def inverse_r(size, x0=0, y0=0, peak=1, dtype=np.float64):
@@ -187,6 +187,6 @@ def inverse_r(size, x0=0, y0=0, peak=1, dtype=np.float64):
     g = grid_2d(size, shifted=True, normalized=False, dtype=dtype)
 
     # Compute the denominator
-    circ = np.sqrt(1 + (g["x"] - x0) ** 2 + (g["y"] - y0) ** 2)
+    vals = np.sqrt(1 + (g["x"] - x0) ** 2 + (g["y"] - y0) ** 2)
 
-    return (peak / circ).astype(dtype)
+    return (peak / vals).astype(dtype)

--- a/src/aspire/utils/misc.py
+++ b/src/aspire/utils/misc.py
@@ -163,7 +163,7 @@ def circ(size, x0=0, y0=0, radius=1, peak=1, dtype=np.float64):
     # Construct centered mesh
     g = grid_2d(size, shifted=True, normalized=False, dtype=dtype)
 
-    circ = (g["x"] ** 2 + g["y"] ** 2) < radius * radius
+    circ = ((g["x"] - x0) ** 2 + (g["y"] - y0) ** 2) < radius * radius
     return circ.astype(dtype)
 
 
@@ -187,6 +187,6 @@ def inverse_r(size, x0=0, y0=0, peak=1, dtype=np.float64):
     g = grid_2d(size, shifted=True, normalized=False, dtype=dtype)
 
     # Compute the denominator
-    circ = np.sqrt(1 + g["x"] ** 2 + g["y"] ** 2)
+    circ = np.sqrt(1 + (g["x"] - x0) ** 2 + (g["y"] - y0) ** 2)
 
     return (peak / circ).astype(dtype)


### PR DESCRIPTION
Forgot to plumb arguments for `x0` `y0`.  Found when using `circ` for something yesterday.