### PR TITLE
Pin version of FINUFFT for now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     author_email="devs.aspire@gmail.com",
     install_requires=[
         "click",
-        "finufft",
+        "finufft==2.0.0",
         "importlib_resources>=1.0.2",
         "joblib",
         "matplotlib",


### PR DESCRIPTION
I think some upstream changes to FINUFFT (2.0.3) might be breaking Windows at runtime in our CI.

This pins to the last known working version (2.0.0)