### PR TITLE
unpin finufft: mistake from merging PR 459

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     author_email="devs.aspire@gmail.com",
     install_requires=[
         "click",
-        "finufft==2.0.0",
+        "finufft",
         "gemmi>=0.4.8",
         "importlib_resources>=1.0.2",
         "joblib",


### PR DESCRIPTION
I resolved the merge conflict in the wrong direction when merging PR #459 into develop. This fixes the mistake and unpins `finufft`