### PR TITLE
Batching causing Numpy error in `DenoisedImageSource`

### DIFF
--- a/src/aspire/denoising/denoised_src.py
+++ b/src/aspire/denoising/denoised_src.py
@@ -25,7 +25,7 @@ class DenoisedImageSource(ImageSource):
         self._im = None
         self.denoiser = denoiser
 
-    def _images(self, start=0, num=np.inf, indices=None):
+    def _images(self, start=0, num=np.inf, indices=None, batch_size=512):
         """
         Internal function to return a set of images after denoising
 
@@ -41,5 +41,12 @@ class DenoisedImageSource(ImageSource):
         end = indices.max()
 
         nimgs = len(indices)
-        imgs_denoised = self.denoiser.images(start, nimgs)
-        return Image(imgs_denoised.data)
+        im = np.empty((nimgs, self.L, self.L))
+
+        logger.info(f"Loading {nimgs} images complete")
+        for istart in range(start, end + 1, batch_size):
+            imgs_denoised = self.denoiser.images(istart, batch_size)
+            iend = min(istart + batch_size, end + 1)
+            im[istart:iend] = imgs_denoised.data
+
+        return Image(im)

--- a/src/aspire/denoising/denoised_src.py
+++ b/src/aspire/denoising/denoised_src.py
@@ -36,10 +36,7 @@ class DenoisedImageSource(ImageSource):
         """
         if indices is None:
             indices = np.arange(start, min(start + num, self.n))
-        else:
-            start = indices.min()
-        end = indices.max()
-
+        start = indices.min()
         nimgs = len(indices)
         imgs_denoised = self.denoiser.images(start, nimgs)
         return Image(imgs_denoised.data)

--- a/src/aspire/denoising/denoised_src.py
+++ b/src/aspire/denoising/denoised_src.py
@@ -47,6 +47,6 @@ class DenoisedImageSource(ImageSource):
         for istart in range(start, end + 1, batch_size):
             imgs_denoised = self.denoiser.images(istart, batch_size)
             iend = min(istart + batch_size, end + 1)
-            im[istart:iend] = imgs_denoised.data
+            im[istart-start:iend-start] = imgs_denoised.data
 
         return Image(im)

--- a/src/aspire/denoising/denoised_src.py
+++ b/src/aspire/denoising/denoised_src.py
@@ -50,6 +50,6 @@ class DenoisedImageSource(ImageSource):
             imgs_denoised = self.denoiser.images(batch_start, batch_size)
             batch_end = min(batch_start + batch_size, end + 1)
             # we subtract start here to correct for any offset in the indices
-            im[batch_start - start : batch_end - start] = imgs_denoised.data
+            im[batch_start - start : batch_end - start] = imgs_denoised.asnumpy()
 
         return Image(im)

--- a/src/aspire/denoising/denoised_src.py
+++ b/src/aspire/denoising/denoised_src.py
@@ -31,7 +31,7 @@ class DenoisedImageSource(ImageSource):
 
         :param start: The inclusive start index from which to return images.
         :param num: The exclusive end index up to which to return images.
-        :param num: The indices of images to return.
+        :param indices: The indices of images to return.
         :return: an `Image` object after denoisng.
         """
         if indices is None:

--- a/src/aspire/denoising/denoised_src.py
+++ b/src/aspire/denoising/denoised_src.py
@@ -47,6 +47,6 @@ class DenoisedImageSource(ImageSource):
         for istart in range(start, end + 1, batch_size):
             imgs_denoised = self.denoiser.images(istart, batch_size)
             iend = min(istart + batch_size, end + 1)
-            im[istart-start:iend-start] = imgs_denoised.data
+            im[istart - start : iend - start] = imgs_denoised.data
 
         return Image(im)

--- a/src/aspire/denoising/denoised_src.py
+++ b/src/aspire/denoising/denoised_src.py
@@ -35,7 +35,7 @@ class DenoisedImageSource(ImageSource):
         :return: an `Image` object after denoisng.
         """
         # start and end (and indices) refer to the indices in the DenoisedImageSource
-        # that are being denoised and returned in batches 
+        # that are being denoised and returned in batches
         if indices is None:
             indices = np.arange(start, min(start + num, self.n))
         else:

--- a/src/aspire/denoising/denoised_src.py
+++ b/src/aspire/denoising/denoised_src.py
@@ -34,6 +34,8 @@ class DenoisedImageSource(ImageSource):
         :param indices: The indices of images to return.
         :return: an `Image` object after denoisng.
         """
+        # start and end (and indices) refer to the indices in the DenoisedImageSource
+        # that are being denoised and returned in batches 
         if indices is None:
             indices = np.arange(start, min(start + num, self.n))
         else:
@@ -44,9 +46,10 @@ class DenoisedImageSource(ImageSource):
         im = np.empty((nimgs, self.L, self.L))
 
         logger.info(f"Loading {nimgs} images complete")
-        for istart in range(start, end + 1, batch_size):
-            imgs_denoised = self.denoiser.images(istart, batch_size)
-            iend = min(istart + batch_size, end + 1)
-            im[istart - start : iend - start] = imgs_denoised.data
+        for batch_start in range(start, end + 1, batch_size):
+            imgs_denoised = self.denoiser.images(batch_start, batch_size)
+            batch_end = min(batch_start + batch_size, end + 1)
+            # we subtract start here to correct for any offset in the indices
+            im[batch_start - start : batch_end - start] = imgs_denoised.data
 
         return Image(im)

--- a/src/aspire/denoising/denoised_src.py
+++ b/src/aspire/denoising/denoised_src.py
@@ -25,7 +25,7 @@ class DenoisedImageSource(ImageSource):
         self._im = None
         self.denoiser = denoiser
 
-    def _images(self, start=0, num=np.inf, indices=None, batch_size=512):
+    def _images(self, start=0, num=np.inf, indices=None):
         """
         Internal function to return a set of images after denoising
 
@@ -41,12 +41,5 @@ class DenoisedImageSource(ImageSource):
         end = indices.max()
 
         nimgs = len(indices)
-        im = np.empty((nimgs, self.L, self.L))
-
-        logger.info(f"Loading {nimgs} images complete")
-        for istart in range(start, end + 1, batch_size):
-            imgs_denoised = self.denoiser.images(istart, batch_size)
-            iend = min(istart + batch_size, end + 1)
-            im[istart:iend] = imgs_denoised.data
-
-        return Image(im)
+        imgs_denoised = self.denoiser.images(start, nimgs)
+        return Image(imgs_denoised.data)

--- a/src/aspire/denoising/denoised_src.py
+++ b/src/aspire/denoising/denoised_src.py
@@ -36,7 +36,10 @@ class DenoisedImageSource(ImageSource):
         """
         if indices is None:
             indices = np.arange(start, min(start + num, self.n))
-        start = indices.min()
+        else:
+            start = indices.min()
+        end = indices.max()
+
         nimgs = len(indices)
         imgs_denoised = self.denoiser.images(start, nimgs)
         return Image(imgs_denoised.data)


### PR DESCRIPTION
This PR fixes #466 by fixing the indexing of the `Image` returned by `DenoisedImageSource._images()`. Previously, if the `indices` passed to the method did not begin at zero, the code would attempt to assign out-of-range indices. 