### PR TITLE
Fix ctf cli arg bug

### DIFF
--- a/src/aspire/commands/estimate_ctf.py
+++ b/src/aspire/commands/estimate_ctf.py
@@ -50,13 +50,11 @@ logger = logging.getLogger("aspire")
     default="float32",
     help="NumPy dtype to use in computation.  Example: 'float32' or 'float64'.",
 )
-
 @click.option(
     "--output_dir",
     default="results",
     help="Path to output files, defaults to './results'",
 )
-
 def estimate_ctf(
     data_folder,
     pixel_size,

--- a/src/aspire/commands/estimate_ctf.py
+++ b/src/aspire/commands/estimate_ctf.py
@@ -50,6 +50,13 @@ logger = logging.getLogger("aspire")
     default="float32",
     help="NumPy dtype to use in computation.  Example: 'float32' or 'float64'.",
 )
+
+@click.option(
+    "--output_dir",
+    default="results",
+    help="Path to output files, defaults to './results'",
+)
+
 def estimate_ctf(
     data_folder,
     pixel_size,

--- a/src/aspire/ctf/ctf_estimator.py
+++ b/src/aspire/ctf/ctf_estimator.py
@@ -672,15 +672,15 @@ class CtfEstimator:
     # Note, This doesn't actually use anything from the class.
     # It is used in a solver loop of some sort, so it may not be correct
     # to just use what is avail in the obj.
-    def write_star(self, df1, df2, ang, cs, voltage, pixel_size, amp, name):
+    def write_star(self, df1, df2, ang, cs, voltage, pixel_size, amp, name, output_dir):
         """
         Writes starfile.
         """
 
-        if os.path.isdir("results") is False:
-            os.mkdir("results")
+        if not os.path.isdir(output_dir):
+            os.mkdir(output_dir)
 
-        f = open("results/" + os.path.splitext(name)[0] + ".log", "w")
+        f = open(os.path.join(output_dir, os.path.splitext(name)[0] + ".log"), "w")
         f.write(
             "data_root\n\nloop_\n_rlnMicrographName #1\n_rlnDefocusU #2\n_rlnDefocusV #3\n_rlnDefocusAngle #4\n"
         )
@@ -839,7 +839,7 @@ def estimate_ctf(
             name,
         )
 
-        ctf_object.write_star(*result)
+        ctf_object.write_star(*result, output_dir)
         results.append(result)
 
         ctf_object.set_df1(cc_array[ml, 0])


### PR DESCRIPTION
Closes #470 .

Here is how I tested this patch:

```
(aspire_ctf_est) ➜  CTF_email_ChunLu ls
ASPIRE-Python
(aspire_ctf_est) ➜  CTF_email_ChunLu mkdir my_input_data        
(aspire_ctf_est) ➜  CTF_email_ChunLu cp ASPIRE-Python/tutorials/data/falcon_2012_06_12-14_33_35_0.mrc my_input_data 
(aspire_ctf_est) ➜  CTF_email_ChunLu ls my_input_data 
falcon_2012_06_12-14_33_35_0.mrc
(aspire_ctf_est) ➜  CTF_email_ChunLu ls              
ASPIRE-Python my_input_data
(aspire_ctf_est) ➜  CTF_email_ChunLu aspire estimate-ctf --data_folder my_input_data --output_dir my_output_data
2021-10-05 10:58:08,973 INFO Expanding 2D image in a frequency-domain Fourier–Bessel basis using the fast method.
2021-10-05 10:58:12,359 INFO Trying NFFT backend finufft
2021-10-05 10:58:12,365 INFO NFFT backend finufft usable.
2021-10-05 10:58:12,365 INFO Trying NFFT backend cufinufft
2021-10-05 10:58:12,366 INFO NFFT backend cufinufft not usable:
	No module named 'pycuda'
2021-10-05 10:58:12,366 INFO Trying NFFT backend pynfft
2021-10-05 10:58:12,366 INFO NFFT backend pynfft not usable:
	No module named 'pynfft'
2021-10-05 10:58:12,366 INFO Selected NFFT backend = finufft.
(aspire_ctf_est) ➜  CTF_email_ChunLu ls
ASPIRE-Python  logs           my_input_data  my_output_data
(aspire_ctf_est) ➜  CTF_email_ChunLu ls my_output_data 
falcon_2012_06_12-14_33_35_0.ctf       falcon_2012_06_12-14_33_35_0_noise.mrc
falcon_2012_06_12-14_33_35_0.log
```

similary, for default (not providing output_dir):

```
(aspire_ctf_est) ➜  CTF_email_ChunLu aspire estimate-ctf --data_folder my_input_data                            
2021-10-05 10:59:19,945 INFO Expanding 2D image in a frequency-domain Fourier–Bessel basis using the fast method.
2021-10-05 10:59:23,784 INFO Trying NFFT backend finufft
2021-10-05 10:59:23,790 INFO NFFT backend finufft usable.
2021-10-05 10:59:23,790 INFO Trying NFFT backend cufinufft
2021-10-05 10:59:23,790 INFO NFFT backend cufinufft not usable:
	No module named 'pycuda'
2021-10-05 10:59:23,790 INFO Trying NFFT backend pynfft
2021-10-05 10:59:23,791 INFO NFFT backend pynfft not usable:
	No module named 'pynfft'
2021-10-05 10:59:23,791 INFO Selected NFFT backend = finufft.
(aspire_ctf_est) ➜  CTF_email_ChunLu ls results 
falcon_2012_06_12-14_33_35_0.ctf       falcon_2012_06_12-14_33_35_0_noise.mrc
falcon_2012_06_12-14_33_35_0.log
```

