### PR TITLE
Require matplotlib >= 3.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         "gemmi>=0.4.8",
         "importlib_resources>=1.0.2",
         "joblib",
-        "matplotlib",
+        "matplotlib>=3.2.0",
         "mrcfile",
         "numpy==1.16",
         "pandas==0.25.3",


### PR DESCRIPTION
 fixes some 3D plotting import bugs... specifically when a user has an older matplotlib and tries to create a 3d scatterplot.