### PR TITLE
Loading a `RelionSource` fails when a `.mrcs` stack contains only one image

### DIFF
--- a/src/aspire/source/relion.py
+++ b/src/aspire/source/relion.py
@@ -97,6 +97,12 @@ class RelionSource(ImageSource):
         dtype = dtypes[mode]
 
         shape = mrc.data.shape
+        # the code below  accounts for the case where the first MRCS image in the STAR file has one image
+        # in that case, the shape will be (resolution, resolution), whereas this code expects
+        # (1, resolution, resolution). below, the shape is expanded to accomodate this expectation
+        if len(shape) == 2:
+            shape = (1,) + shape
+
         ensure(shape[1] == shape[2], "Only square images are supported")
         L = shape[1]
         logger.debug(f"Image size = {L}x{L}")
@@ -152,6 +158,10 @@ class RelionSource(ImageSource):
 
         def load_single_mrcs(filepath, df):
             arr = mrcfile.open(filepath).data
+            # if the stack only contains one image, arr will have shape (resolution, resolution)
+            # the code below reshapes it to (1, resolution, resolution)
+            if len(arr.shape) == 2:
+                arr = arr.reshape((1,) + arr.shape)
             data = arr[df["__mrc_index"] - 1, :, :]
 
             return df.index, data


### PR DESCRIPTION
Corrects an issue (see #475) where if an `.mrcs` file only contains one particle in the stack, it will be loaded as a 2D numpy array, rather than 3D, which the code in `relion._images` expects. 