### PR TITLE
Add simple alignments and supporting code

### DIFF
--- a/gallery/tutorials/class_averaging.py
+++ b/gallery/tutorials/class_averaging.py
@@ -12,6 +12,7 @@ import numpy as np
 from PIL import Image as PILImage
 
 from aspire.classification import RIRClass2D
+from aspire.image import Image
 from aspire.image.xform import NoiseAdder
 from aspire.operators import ScalarFilter
 from aspire.source import ArrayImageSource  # Helpful hint if you want to BYO array.
@@ -30,6 +31,7 @@ logger = logging.getLogger(__name__)
 L = 100
 round_disc = gaussian_2d(L, sigma_x=L / 4, sigma_y=L / 4)
 plt.imshow(round_disc)
+plt.show()
 
 # %%
 # Oval 2D Gaussian Image
@@ -37,10 +39,36 @@ plt.imshow(round_disc)
 
 oval_disc = gaussian_2d(L, sigma_x=L / 20, sigma_y=L / 5)
 plt.imshow(oval_disc)
+plt.show()
 
 # %%
-# Example Data Set
-# ^^^^^^^^^^^^^^^^
+# Handed Image
+# ^^^^^^^^^^^^
+#
+# Create richer test set by including an asymmetric image.
+
+# Create a second oval.
+oval_disc2 = gaussian_2d(L, L / 5, L / 6, sigma_x=L / 15, sigma_y=L / 20)
+
+# Strategically add it to `oval_disc`.
+yoval_discL = oval_disc.copy()
+yoval_discL += oval_disc2
+plt.imshow(yoval_discL)
+plt.show()
+
+# %%
+# Reflected Image
+# ^^^^^^^^^^^^^^^
+#
+# Also include the reflection of  the asymmetric image.
+
+yoval_discR = np.flipud(yoval_discL)
+plt.imshow(yoval_discR)
+plt.show()
+
+# %%
+# Example Data Set Source
+# ^^^^^^^^^^^^^^^^^^^^^^^
 #
 # We concatenate and shuffle 512 rotations of the Gaussian images above to create our data set.
 
@@ -50,13 +78,18 @@ thetas = np.linspace(start=0, stop=360, num=N, endpoint=False)
 
 classRound = np.zeros((N, L, L))
 classOval = np.zeros((N, L, L))
+classYOvalL = np.zeros((N, L, L))
+classYOvalR = np.zeros((N, L, L))
 
 for i, theta in enumerate(thetas):
     classRound[i] = np.asarray(PILImage.fromarray(round_disc).rotate(theta))
     classOval[i] = np.asarray(PILImage.fromarray(oval_disc).rotate(theta))
+    classYOvalL[i] = np.asarray(PILImage.fromarray(yoval_discL).rotate(theta))
+    classYOvalR[i] = np.asarray(PILImage.fromarray(yoval_discR).rotate(theta))
 
 # We'll make an example data set by concatentating then shuffling these.
-example_array = np.concatenate((classRound, classOval))
+example_array = np.concatenate((classRound, classOval, classYOvalL, classYOvalR))
+np.random.seed(1234567)
 np.random.shuffle(example_array)
 
 # So now that we have cooked up an example dataset, lets create an ASPIRE source
@@ -76,18 +109,18 @@ rir = RIRClass2D(
     src,
     fspca_components=400,
     bispectrum_components=300,  # Compressed Features after last PCA stage.
-    n_nbor=5,
+    n_nbor=10,
     n_classes=10,
     large_pca_implementation="legacy",
-    nn_implementation="sklearn",
+    nn_implementation="legacy",
     bispectrum_implementation="legacy",
 )
 
-classes, reflections, rotations, corr = rir.classify()
+classes, reflections, rotations, shifts, corr = rir.classify()
 
 # %%
 # Display Classes
-# ---------------
+# ^^^^^^^^^^^^^^^
 
 avgs = rir.output(classes, reflections, rotations)
 avgs.images(0, 10).show()
@@ -98,11 +131,12 @@ avgs.images(0, 10).show()
 
 # %%
 # Add Noise to Data Set
-# ---------------------
+# ^^^^^^^^^^^^^^^^^^^^^
 
 # Using the sample variance, we'll compute a target noise variance
+# Noise
 var = np.var(src.images(0, src.n).asnumpy())
-noise_var = 0.5 * var
+noise_var = var * 2 ** 4
 
 # We create a uniform noise to apply to the 2D images
 noise_filter = ScalarFilter(dim=2, value=noise_var)
@@ -121,24 +155,58 @@ noisy_src.images(0, 10).show()
 
 # %%
 # RIR with Noise
-# --------------
+# ^^^^^^^^^^^^^^
 
+# This also demonstrates changing the Nearest Neighbor search to using scikit-learn.
 noisy_rir = RIRClass2D(
     noisy_src,
     fspca_components=400,
     bispectrum_components=300,
-    n_nbor=5,
+    n_nbor=10,
     n_classes=10,
     large_pca_implementation="legacy",
     nn_implementation="sklearn",
     bispectrum_implementation="legacy",
 )
 
-classes, reflections, rotations, corr = noisy_rir.classify()
+classes, reflections, rotations, shifts, corr = noisy_rir.classify()
 
 # %%
 # Display Classes
-# ---------------
+# ^^^^^^^^^^^^^^^
 
 avgs = noisy_rir.output(classes, reflections, rotations)
 avgs.images(0, 10).show()
+
+
+# %%
+# Review a class
+# --------------
+#
+# Select a class to review.
+
+review_class = 5
+
+# Display the original image.
+noisy_src.images(review_class, 1).show()
+
+# Report the identified neighbor indices
+logger.info(f"Class {review_class}'s neighors: {classes[review_class]}")
+
+# Report the identified neighbors
+Image(noisy_src.images(0, np.inf)[classes[review_class]]).show()
+
+# Report their associated rots_refls
+rots_refls = ["index, Rotation, Reflection"]
+for i in range(classes.shape[1]):
+    rots_refls.append(
+        f"{i}, {rotations[review_class, i] * 180 / np.pi}, {reflections[review_class, i]}"
+    )
+rots_refls = "\n".join(rots_refls)
+
+logger.info(
+    f"Class {review_class}'s  estimated Rotations and Reflections:\n{rots_refls}"
+)
+
+# Display the averaged result
+avgs.images(review_class, 1).show()

--- a/src/aspire/basis/fspca.py
+++ b/src/aspire/basis/fspca.py
@@ -559,7 +559,7 @@ class FSPCABasis(SteerableBasis2D):
         Returns coefs shifted by `shifts`.
 
         This will transform to real cartesian space, shift,
-        and transform pack to Polar Fourier-Bessel space.
+        and transform back to Polar Fourier-Bessel space.
 
         :param coef: Basis coefs.
         :param shifts: Shifts in pixels (x,y). Shape (1,2) or (len(coef), 2).

--- a/src/aspire/basis/fspca.py
+++ b/src/aspire/basis/fspca.py
@@ -553,3 +553,29 @@ class FSPCABasis(SteerableBasis2D):
             eigvecs = eigvecs.dense()
 
         return self.basis.evaluate(eigvecs.T)
+
+    def shift(self, coef, shifts):
+        """
+        Returns coefs shifted by `shifts`.
+
+        This will transform to real cartesian space, shift,
+        and transform pack to Polar Fourier-Bessel space.
+
+        :param coef: Basis coefs.
+        :param shifts: Shifts in pixels (x,y). Shape (1,2) or (len(coef), 2).
+        :return: coefs of shifted images.
+        """
+
+        shifts = np.atleast_2d(np.array(shifts))
+        if shifts.ndim != 2:
+            raise ValueError("`shifts` should be a one or two dimensional array.")
+        if shifts.shape[1] != 2 or shifts.shape[0] not in (1, len(coef)):
+            raise ValueError(
+                "`shifts` should be shape (1,2) or (len(coef),2),"
+                f" received {shifts.shape}."
+            )
+
+        # This transforms FSPCA->FB->Image->FB->FSPCA
+        return self.expand_from_image_basis(
+            self.evaluate_to_image_basis(coef).shift(shifts)
+        )

--- a/src/aspire/basis/steerable.py
+++ b/src/aspire/basis/steerable.py
@@ -172,7 +172,7 @@ class SteerableBasis2D(Basis):
         Returns coefs shifted by `shifts`.
 
         This will transform to real cartesian space, shift,
-        and transform pack to Polar Fourier-Bessel space.
+        and transform back to Polar Fourier-Bessel space.
 
         :param coef: Basis coefs.
         :param shifts: Shifts in pixels (x,y). Shape (1,2) or (len(coef), 2).

--- a/src/aspire/basis/steerable.py
+++ b/src/aspire/basis/steerable.py
@@ -166,3 +166,26 @@ class SteerableBasis2D(Basis):
         complex_coef[:] = complex_coef * np.exp(-1j * ks * radians)
 
         return complex_coef
+
+    def shift(self, coef, shifts):
+        """
+        Returns coefs shifted by `shifts`.
+
+        This will transform to real cartesian space, shift,
+        and transform pack to Polar Fourier-Bessel space.
+
+        :param coef: Basis coefs.
+        :param shifts: Shifts in pixels (x,y). Shape (1,2) or (len(coef), 2).
+        :return: coefs of shifted images.
+        """
+
+        shifts = np.atleast_2d(np.array(shifts))
+        if shifts.ndim != 2:
+            raise ValueError("`shifts` should be a one or two dimensional array.")
+        if shifts.shape[1] != 2 or shifts.shape[0] not in (1, len(coef)):
+            raise ValueError(
+                "`shifts` should be shape (1,2) or (len(coef),2),"
+                f" received {shifts.shape}."
+            )
+
+        return self.evaluate_t(self.evaluate(coef).shift(shifts))

--- a/src/aspire/classification/__init__.py
+++ b/src/aspire/classification/__init__.py
@@ -1,2 +1,3 @@
+from .align2d import Align2D, BFRAlign2D, BFSRAlign2D, EMAlign2D, FTKAlign2D
 from .class2d import Class2D
 from .rir_class2d import RIRClass2D

--- a/src/aspire/classification/align2d.py
+++ b/src/aspire/classification/align2d.py
@@ -13,6 +13,11 @@ class Align2D:
     """
 
     def __init__(self, basis, dtype):
+        """
+        :param basis: Basis to be used for any methods during alignment.
+        :param dtype: Numpy dtype to be used during alignment.
+        """
+
         self.basis = basis
         if dtype is None:
             dtype = self.basis.dtype
@@ -20,21 +25,29 @@ class Align2D:
 
     def align(self, classes, reflections, basis_coefficients):
         """
-        Any class averagiing alignment method should take in the following arguments and return the tuple described.
+        Any class averagiing alignment method should take in the following arguments and return the described tuple.
 
-        The returned `classes` and `reflections` should be same as the input.
+        Generally, the returned `classes` and `reflections` should be same as
+        the input.  They are provided for convience, considering they would
+        all be required for image output.
 
-        Returned `rotations` is an (n_classes, n_nbor) array of angles which should represent the rotations needed to align images within that class. `rot` is measure in Radians.
+        Returned `rotations` is an (n_classes, n_nbor) array of angles,
+        which should represent the rotations needed to align images within
+        that class. `rotations` is measured in Radians.
 
-        Returned `correlations` is an (n_classes, n_nbor) array that should represent a correlation like measure between classified images and their base image (image index 0).
+        Returned `correlations` is an (n_classes, n_nbor) array representing
+        a correlation like measure between classified images and their base
+        image (image index 0).
 
-        Returned `shifts` is None or an (n_classes, n_nbor) array of 2D shifts which should represent the translation needed to best align the images within that class.
+        Returned `shifts` is None or an (n_classes, n_nbor) array of 2D shifts
+        which should represent the translation needed to best align the images
+        within that class.
 
-        Subclasses of `align` should extend with arguments as needed.
+        Subclasses of `align` should extend this method with optional arguments.
 
         :param classes: (n_classes, n_nbor) integer array of indices
         :param refl: (n_classes, n_nbor) bool array of reflections
-        :param coef: (n_img, self.pca_basis.count) array of compressed basis coefficients.
+        :param coef: (n_img, self.pca_basis.count) compressed basis coefficients.
 
         :returns: (classes, reflections, rotations, shifts, correlations)
         """
@@ -42,11 +55,18 @@ class Align2D:
 
 
 class BFRAlign2D(Align2D):
+    """
+    This perfoms a Brute Force Rotational alignment.
+
+    For each class,
+        constructs n_angles rotations of all class members,
+        and then identifies angle yielding largest correlation(dot).
+    """
+
     def __init__(self, basis, n_angles=359, dtype=None):
         """
-        Configurable options
-        `n_angles` sets the number of brute force rotations to attempt.
-        Defaults `n_angles=359`.
+        :params basis: Basis providing a `rotate` method.
+        :params n_angles: Number of brute force rotations to attempt, defaults 359.
         """
         super().__init__(basis, dtype)
 
@@ -57,11 +77,7 @@ class BFRAlign2D(Align2D):
 
     def align(self, classes, reflections, basis_coefficients):
         """
-        This perfoms a Brute Force Rotational alignment.
-
-        For each class,
-            constructs n_angles rotations of all class members,
-            and then identifies angle yielding largest correlation(dot).
+        See `Align2D.align`
         """
         n_classes, n_nbor = classes.shape
 
@@ -101,11 +117,29 @@ class BFRAlign2D(Align2D):
 
 
 class BFSRAlign2D(BFRAlign2D):
+    """
+    This perfoms a Brute Force Shift and Rotational alignment.
+    It is potentially expensive to brute force this search space.
+
+    For each pair of x_shifts and y_shifts,
+       Perform BFR
+
+    Return the rotation and shift yielding the best results.
+    """
+
     def __init__(self, basis, n_angles=359, n_x_shifts=1, n_y_shifts=1, dtype=None):
         """
-        Configurable options
-        `n_angles` sets the number of brute force rotations to attempt.
-        Defaults `n_angles=359`.
+        Note that n_x_shifts and n_y_shifts are the number of shifts to perform
+        in each direction.
+
+        Example: n_x_shifts=1, n_y_shifts=0 would test {-1,0,1} X {0}.
+
+        n_x_shifts=n_y_shifts=0 is the same as calling BFRAlign2D.
+
+        :params basis: Basis providing a `shift` and `rotate` method.
+        :params n_angles: Number of brute force rotations to attempt, defaults 359.
+        :params n_x_shifts: +- Number of brute force xshifts to attempt, defaults 1.
+        :params n_y_shifts: +- Number of brute force xshifts to attempt, defaults 1.
         """
         super().__init__(basis, n_angles, dtype)
 
@@ -122,12 +156,7 @@ class BFSRAlign2D(BFRAlign2D):
 
     def align(self, classes, reflections, basis_coefficients):
         """
-        This perfoms a Brute Force Shift and Rotational alignment.
-
-        For each pair of x_shifts and y_shifts,
-           Perform BFR
-
-        Return the rotation and shift yielding the best results.
+        See `Align2D.align`
         """
         n_classes = classes.shape[0]
 
@@ -191,7 +220,7 @@ class BFSRAlign2D(BFRAlign2D):
 
 class EMAlign2D(Align2D):
     """
-    Citation?
+    Citation needed.
     """
 
     def __init__(self, basis, dtype=None):
@@ -206,3 +235,6 @@ class FTKAlign2D(Align2D):
 
     def __init__(self, basis, dtype=None):
         super().__init__(basis, dtype)
+
+    def align(self, classes, reflections, basis_coefficients):
+        raise NotImplementedError

--- a/src/aspire/classification/align2d.py
+++ b/src/aspire/classification/align2d.py
@@ -184,6 +184,8 @@ class BFSRAlign2D(BFRAlign2D):
         y_shifts = np.roll(
             np.arange(-self.n_y_shifts, self.n_y_shifts + 1), -self.n_y_shifts
         )
+        # Above rolls should force initial pair of shifts to (0,0).
+        # This is done primarily in case of a tie later we would take unshifted.
         assert (x_shifts[0], y_shifts[0]) == (0, 0)
 
         # These arrays will incrementally store our best alignment.

--- a/src/aspire/classification/align2d.py
+++ b/src/aspire/classification/align2d.py
@@ -20,8 +20,13 @@ class Align2D:
 
         self.basis = basis
         if dtype is None:
-            dtype = self.basis.dtype
-        self.dtype = np.dtype(dtype)
+            self.dtype = self.basis.dtype
+        else:
+            self.dtype = np.dtype(dtype)
+            if self.dtype != self.basis.dtype:
+                logger.warning(
+                    f"Align2D basis.dtype {self.basis.dtype} does not match self.dtype {self.dtype}."
+                )
 
     def align(self, classes, reflections, basis_coefficients):
         """
@@ -51,7 +56,7 @@ class Align2D:
 
         :returns: (classes, reflections, rotations, shifts, correlations)
         """
-        raise NotImplementedError("Subclasses must implement align")
+        raise NotImplementedError("Subclasses must implement align.")
 
 
 class BFRAlign2D(Align2D):
@@ -73,7 +78,9 @@ class BFRAlign2D(Align2D):
         self.n_angles = n_angles
 
         if not hasattr(self.basis, "rotate"):
-            raise RuntimeError("BFRAlign2D basis must provide a `rotate` method.")
+            raise RuntimeError(
+                f"BFRAlign2D's basis {self.basis} must provide a `rotate` method."
+            )
 
     def align(self, classes, reflections, basis_coefficients):
         """
@@ -148,7 +155,7 @@ class BFSRAlign2D(BFRAlign2D):
 
         if not hasattr(self.basis, "shift"):
             raise RuntimeError(
-                f"BFSRAlign2D basis {self.basis} must provide a `shift` method."
+                f"BFSRAlign2D's basis {self.basis} must provide a `shift` method."
             )
 
         # Each shift will require calling the parent BFRAlign2D.align

--- a/src/aspire/classification/align2d.py
+++ b/src/aspire/classification/align2d.py
@@ -1,0 +1,208 @@
+import logging
+from itertools import product
+
+import numpy as np
+from tqdm import trange
+
+logger = logging.getLogger(__name__)
+
+
+class Align2D:
+    """
+    Base class for 2D Image Alignment methods.
+    """
+
+    def __init__(self, basis, dtype):
+        self.basis = basis
+        if dtype is None:
+            dtype = self.basis.dtype
+        self.dtype = np.dtype(dtype)
+
+    def align(self, classes, reflections, basis_coefficients):
+        """
+        Any class averagiing alignment method should take in the following arguments and return the tuple described.
+
+        The returned `classes` and `reflections` should be same as the input.
+
+        Returned `rotations` is an (n_classes, n_nbor) array of angles which should represent the rotations needed to align images within that class. `rot` is measure in Radians.
+
+        Returned `correlations` is an (n_classes, n_nbor) array that should represent a correlation like measure between classified images and their base image (image index 0).
+
+        Returned `shifts` is None or an (n_classes, n_nbor) array of 2D shifts which should represent the translation needed to best align the images within that class.
+
+        Subclasses of `align` should extend with arguments as needed.
+
+        :param classes: (n_classes, n_nbor) integer array of indices
+        :param refl: (n_classes, n_nbor) bool array of reflections
+        :param coef: (n_img, self.pca_basis.count) array of compressed basis coefficients.
+
+        :returns: (classes, reflections, rotations, shifts, correlations)
+        """
+        raise NotImplementedError("Subclasses must implement align")
+
+
+class BFRAlign2D(Align2D):
+    def __init__(self, basis, n_angles=359, dtype=None):
+        """
+        Configurable options
+        `n_angles` sets the number of brute force rotations to attempt.
+        Defaults `n_angles=359`.
+        """
+        super().__init__(basis, dtype)
+
+        self.n_angles = n_angles
+
+        if not hasattr(self.basis, "rotate"):
+            raise RuntimeError("BFRAlign2D basis must provide a `rotate` method.")
+
+    def align(self, classes, reflections, basis_coefficients):
+        """
+        This perfoms a Brute Force Rotational alignment.
+
+        For each class,
+            constructs n_angles rotations of all class members,
+            and then identifies angle yielding largest correlation(dot).
+        """
+        n_classes, n_nbor = classes.shape
+
+        # Construct array of angles to brute force.
+        test_angles = np.linspace(0, 2 * np.pi, self.n_angles, endpoint=False)
+
+        # Instantiate matrices for results
+        rotations = np.empty(classes.shape, dtype=self.dtype)
+        correlations = np.empty(classes.shape, dtype=self.dtype)
+        results = np.empty((n_nbor, self.n_angles))
+
+        for k in trange(n_classes):
+
+            # Get the coefs for these neighbors
+            nbr_coef = basis_coefficients[classes[k]]
+
+            for i, angle in enumerate(test_angles):
+                # Rotate the set of neighbors by angle,
+                rotated_nbrs = self.basis.rotate(nbr_coef, angle, reflections[k])
+
+                # then store dot between class base image (0) and each nbor
+                for j, nbor in enumerate(rotated_nbrs):
+                    results[j, i] = np.dot(nbr_coef[0], nbor)
+
+            # Now along each class, find the index of the angle reporting highest correlation
+            angle_idx = np.argmax(results, axis=1)
+
+            # Store that angle as our rotation for this image
+            rotations[k, :] = test_angles[angle_idx]
+
+            # Also store the correlations for each neighbor
+            for j in range(n_nbor):
+                correlations[k, j] = results[j, angle_idx[j]]
+
+        # None is placeholder for shifts
+        return classes, reflections, rotations, None, correlations
+
+
+class BFSRAlign2D(BFRAlign2D):
+    def __init__(self, basis, n_angles=359, n_x_shifts=1, n_y_shifts=1, dtype=None):
+        """
+        Configurable options
+        `n_angles` sets the number of brute force rotations to attempt.
+        Defaults `n_angles=359`.
+        """
+        super().__init__(basis, n_angles, dtype)
+
+        self.n_x_shifts = n_x_shifts
+        self.n_y_shifts = n_y_shifts
+
+        if not hasattr(self.basis, "shift"):
+            raise RuntimeError(
+                f"BFSRAlign2D basis {self.basis} must provide a `shift` method."
+            )
+
+        # Each shift will require calling the parent BFRAlign2D.align
+        self._bfr_align = super().align
+
+    def align(self, classes, reflections, basis_coefficients):
+        """
+        This perfoms a Brute Force Shift and Rotational alignment.
+
+        For each pair of x_shifts and y_shifts,
+           Perform BFR
+
+        Return the rotation and shift yielding the best results.
+        """
+        n_classes = classes.shape[0]
+
+        # Compute the shifts. Roll array so 0 is first.
+        x_shifts = np.roll(
+            np.arange(-self.n_x_shifts, self.n_x_shifts + 1), -self.n_x_shifts
+        )
+        y_shifts = np.roll(
+            np.arange(-self.n_y_shifts, self.n_y_shifts + 1), -self.n_y_shifts
+        )
+        assert (x_shifts[0], y_shifts[0]) == (0, 0)
+
+        # These arrays will incrementally store our best alignment.
+        rotations = np.empty(classes.shape, dtype=self.dtype)
+        correlations = np.ones(classes.shape, dtype=self.dtype) * -np.inf
+        shifts = np.empty((*classes.shape, 2), dtype=int)
+
+        # We want to maintain the original coefs for the base images,
+        #  because we will mutate them with shifts in the loop.
+        original_coef = basis_coefficients[classes[:, 0], :]
+        assert original_coef.shape == (n_classes, self.basis.count)
+
+        # Loop over shift search space, updating best result
+        for x, y in product(x_shifts, y_shifts):
+            shift = np.array([x, y], dtype=int)
+            logger.info(f"Computing Rotational alignment after shift ({x},{y}).")
+
+            # Shift the coef representing the first (base) entry in each class
+            #   by the negation of the shift
+            # Shifting one image is more efficient than shifting every neighbor
+            basis_coefficients[classes[:, 0], :] = self.basis.shift(
+                original_coef, -shift
+            )
+
+            _, _, _rotations, _, _correlations = self._bfr_align(
+                classes, reflections, basis_coefficients
+            )
+
+            # Each class-neighbor pair may have a best shift-rot from a different shift.
+            # Test and update
+            improved_indices = _correlations > correlations
+            rotations[improved_indices] = _rotations[improved_indices]
+            correlations[improved_indices] = _correlations[improved_indices]
+            shifts[improved_indices] = shift
+
+            # Restore unshifted base coefs
+            basis_coefficients[classes[:, 0], :] = original_coef
+
+            if (x, y) == (0, 0):
+                logger.info("Initial rotational alignment complete (shift (0,0))")
+                assert np.sum(improved_indices) == np.size(
+                    classes
+                ), f"{np.sum(improved_indices)} =?= {np.size(classes)}"
+            else:
+                logger.info(
+                    f"Shift ({x},{y}) complete. Improved {np.sum(improved_indices)} alignments."
+                )
+
+        return classes, reflections, rotations, shifts, correlations
+
+
+class EMAlign2D(Align2D):
+    """
+    Citation?
+    """
+
+    def __init__(self, basis, dtype=None):
+        super().__init__(basis, dtype)
+
+
+class FTKAlign2D(Align2D):
+    """
+    Factorization of the translation kernel for fast rigid image alignment.
+    Rangan, A.V., Spivak, M., Anden, J., & Barnett, A.H. (2019).
+    """
+
+    def __init__(self, basis, dtype=None):
+        super().__init__(basis, dtype)

--- a/src/aspire/classification/align2d.py
+++ b/src/aspire/classification/align2d.py
@@ -30,11 +30,12 @@ class Align2D:
 
     def align(self, classes, reflections, basis_coefficients):
         """
-        Any class averagiing alignment method should take in the following arguments and return the described tuple.
+        Any align2D alignment method should take in the following arguments
+        and return the described tuple.
 
         Generally, the returned `classes` and `reflections` should be same as
-        the input.  They are provided for convience, considering they would
-        all be required for image output.
+        the input.  They are passed through for convience,
+        considering they would all be required for image output.
 
         Returned `rotations` is an (n_classes, n_nbor) array of angles,
         which should represent the rotations needed to align images within
@@ -50,9 +51,9 @@ class Align2D:
 
         Subclasses of `align` should extend this method with optional arguments.
 
-        :param classes: (n_classes, n_nbor) integer array of indices
-        :param refl: (n_classes, n_nbor) bool array of reflections
-        :param coef: (n_img, self.pca_basis.count) compressed basis coefficients.
+        :param classes: (n_classes, n_nbor) integer array of img indices
+        :param refl: (n_classes, n_nbor) bool array of corresponding reflections
+        :param coef: (n_img, self.pca_basis.count) compressed basis coefficients
 
         :returns: (classes, reflections, rotations, shifts, correlations)
         """
@@ -86,6 +87,10 @@ class BFRAlign2D(Align2D):
         """
         See `Align2D.align`
         """
+        # Admit simple case of single case alignment
+        classes = np.atleast_2d(classes)
+        reflections = np.atleast_2d(reflections)
+
         n_classes, n_nbor = classes.shape
 
         # Construct array of angles to brute force.
@@ -165,6 +170,11 @@ class BFSRAlign2D(BFRAlign2D):
         """
         See `Align2D.align`
         """
+
+        # Admit simple case of single case alignment
+        classes = np.atleast_2d(classes)
+        reflections = np.atleast_2d(reflections)
+
         n_classes = classes.shape[0]
 
         # Compute the shifts. Roll array so 0 is first.

--- a/src/aspire/classification/class2d.py
+++ b/src/aspire/classification/class2d.py
@@ -21,13 +21,11 @@ class Class2D:
         """
         Base constructor of an object for classifying 2D images.
 
+        :param src: ImageSource or subclass, provides images.
         :param n_nbor: Number of nearest neighbors to compute.
         :param n_classes: Number of class averages to return.
-        :param alignment_implementation: See `alignment`.
-        :param alignment_opts: Optional implementation specific configuration options. See `alignment`.
         :param seed: Optional RNG seed to be passed to random methods, (example Random NN).
-
-
+        :param dtype: Numpy dtype, defaults to `src.dtype`.
         """
         self.src = src
 

--- a/src/aspire/classification/class2d.py
+++ b/src/aspire/classification/class2d.py
@@ -1,8 +1,6 @@
 import logging
-from itertools import product
 
 import numpy as np
-from tqdm import trange
 
 logger = logging.getLogger(__name__)
 
@@ -17,8 +15,6 @@ class Class2D:
         src,
         n_nbor=100,
         n_classes=50,
-        alignment_implementation="bfr",
-        alignment_opts=None,
         seed=None,
         dtype=None,
     ):
@@ -46,163 +42,4 @@ class Class2D:
 
         self.n_nbor = n_nbor
         self.n_classes = n_classes
-        self.alignment_implementation = alignment_implementation
-        self.alignment_opts = alignment_opts
         self.seed = seed
-
-        alignment_implementations = {
-            "bfr": self._bfr_align,
-            "bfsr": self._bfsr_align,
-        }
-
-        if alignment_implementation not in alignment_implementations:
-            raise ValueError(
-                f"Provided alignment_implementation={alignment_implementation}"
-                f" not in {alignment_implementations.keys()}."
-            )
-        self._alignment = alignment_implementations[alignment_implementation]
-
-    def alignment(self, classes, refl, coef, alignment_opts=None):
-        """
-        Any class averagiing alignment method should take in the following arguments and return the tuple described.
-
-        The returned `classes` and `refl` should be same as the input.
-
-        Returned `rot` is an (n_classes, n_nbor) array of angles which should represent the rotations needed to align images within that class. `rot` is measure in Radians.
-
-        Returned `corr` is an (n_classes, n_nbor) array that should represent a correlation like measure between classified images and their base image (image index 0).
-
-        Returned `shifts` is None or an (n_classes, n_nbor) array of 2D shifts which should represent the translation needed to best align the images within that class.
-
-
-        Alignment implementations may admit specific conifguration options using an optional `alignment_opts` dictionary.
-
-        :param classes: (n_classes, n_nbor) integer array of indices
-        :param refl: (n_classes, n_nbor) bool array of reflections
-        :param coef: (n_img, self.pca_basis.count) array of compressed basis coefficients.
-
-        :returns: (classes, refl, rot, corr, shifts)
-        """
-
-        # _alignment is assigned during initialization.
-        return self._alignment(classes, refl, coef, alignment_opts)
-
-    def _bfsr_align(self, classes, refl, coef, alignment_opts=None):
-        """
-        This perfoms a Brute Force Shift and Rotational alignment.
-
-        For each pair of x_shifts and y_shifts,
-           Perform BFR
-
-        Return the rotation and shift yielding the best results.
-        """
-
-        # Unpack any configuration options, or get defaults.
-        if alignment_opts is None:
-            alignment_opts = {}
-        # Default shift search space of +- 1 in X and Y
-        n_x_shifts = alignment_opts.get("n_x_shifts", 1)
-        n_y_shifts = alignment_opts.get("n_y_shifts", 1)
-
-        # Compute the shifts. Roll array so 0 is first.
-        x_shifts = np.roll(np.arange(-n_x_shifts, n_x_shifts + 1), -n_x_shifts)
-        y_shifts = np.roll(np.arange(-n_y_shifts, n_y_shifts + 1), -n_y_shifts)
-        assert (x_shifts[0], y_shifts[0]) == (0, 0)
-
-        # These arrays will incrementally store our best alignment.
-        rots = np.empty(classes.shape, dtype=self.dtype)
-        corr = np.ones(classes.shape, dtype=self.dtype) * -np.inf
-        shifts = np.empty((*classes.shape, 2), dtype=int)
-
-        # We want to maintain the original coefs for the base images,
-        #  because we will mutate them with shifts in the loop.
-        original_coef = coef[classes[:, 0], :]
-        assert original_coef.shape == (self.n_classes, self.pca_basis.count)
-
-        # Loop over shift search space, updating best result
-        for x, y in product(x_shifts, y_shifts):
-            shift = np.array([x, y], dtype=int)
-            logger.info(f"Computing Rotational alignment after shift ({x},{y}).")
-
-            # Shift the coef representing the first (base) entry in each class
-            #   by the negation of the shift
-            # Shifting one image is more efficient than shifting every neighbor
-            coef[classes[:, 0], :] = self.pca_basis.shift(original_coef, -shift)
-
-            _, _, _rots, _, _corr = self._bfr_align(classes, refl, coef, alignment_opts)
-
-            # Each class-neighbor pair may have a best shift-rot from a different shift.
-            # Test and update
-            improved_indices = _corr > corr
-            rots[improved_indices] = _rots[improved_indices]
-            corr[improved_indices] = _corr[improved_indices]
-            shifts[improved_indices] = shift
-
-            # Restore unshifted base coefs
-            coef[classes[:, 0], :] = original_coef
-
-            if (x, y) == (0, 0):
-                logger.info("Initial rotational alignment complete (shift (0,0))")
-                assert np.sum(improved_indices) == np.size(
-                    classes
-                ), f"{np.sum(improved_indices)} =?= {np.size(classes)}"
-            else:
-                logger.info(
-                    f"Shift ({x},{y}) complete. Improved {np.sum(improved_indices)} alignments."
-                )
-
-        return classes, refl, rots, shifts, corr
-
-    def _bfr_align(self, classes, refl, coef, alignment_opts=None):
-        """
-        This perfoms a Brute Force Rotational alignment.
-
-        For each class,
-            constructs n_angles rotations of all class members,
-            and then identifies angle yielding largest correlation(dot).
-
-        For params, see `align`.
-
-        Configurable `alignment_opts`:
-        `n_angles` sets the number of brute force rotations to attempt.
-        Defaults `n_angles=359`.
-        """
-
-        # Configure any alignment options, otherwise use defaults.
-        if alignment_opts is None:
-            alignment_opts = {}
-        n_angles = alignment_opts.get("n_angles", 359)
-
-        # Construct array of angles to brute force.
-        test_angles = np.linspace(0, 2 * np.pi, n_angles, endpoint=False)
-
-        # Instantiate matrices for results
-        rots = np.empty(classes.shape, dtype=self.dtype)
-        corr = np.empty(classes.shape, dtype=self.dtype)
-        results = np.empty((self.n_nbor, n_angles))
-
-        for k in trange(self.n_classes):
-
-            # Get the coefs for these neighbors
-            nbr_coef = coef[classes[k]]
-
-            for i, angle in enumerate(test_angles):
-                # Rotate the set of neighbors by angle,
-                rotated_nbrs = self.pca_basis.rotate(nbr_coef, angle, refl[k])
-
-                # then store dot between class base image (0) and each nbor
-                for j, nbor in enumerate(rotated_nbrs):
-                    results[j, i] = np.dot(nbr_coef[0], nbor)
-
-            # Now along each class, find the index of the angle reporting highest correlation
-            angle_idx = np.argmax(results, axis=1)
-
-            # Store that angle as our rotation for this image
-            rots[k, :] = test_angles[angle_idx]
-
-            # Also store the correlations for each neighbor
-            for j in range(self.n_nbor):
-                corr[k, j] = results[j, angle_idx[j]]
-
-        # None is placeholder for shifts
-        return classes, refl, rots, None, corr

--- a/src/aspire/classification/class2d.py
+++ b/src/aspire/classification/class2d.py
@@ -1,6 +1,8 @@
 import logging
+from itertools import product
 
 import numpy as np
+from tqdm import trange
 
 logger = logging.getLogger(__name__)
 
@@ -10,7 +12,27 @@ class Class2D:
     Base class for 2D Image Classification methods.
     """
 
-    def __init__(self, src, dtype=None):
+    def __init__(
+        self,
+        src,
+        n_nbor=100,
+        n_classes=50,
+        alignment_implementation="bfr",
+        alignment_opts=None,
+        seed=None,
+        dtype=None,
+    ):
+        """
+        Base constructor of an object for classifying 2D images.
+
+        :param n_nbor: Number of nearest neighbors to compute.
+        :param n_classes: Number of class averages to return.
+        :param alignment_implementation: See `alignment`.
+        :param alignment_opts: Optional implementation specific configuration options. See `alignment`.
+        :param seed: Optional RNG seed to be passed to random methods, (example Random NN).
+
+
+        """
         self.src = src
 
         if dtype is not None:
@@ -21,3 +43,166 @@ class Class2D:
                 )
         else:
             self.dtype = self.src.dtype
+
+        self.n_nbor = n_nbor
+        self.n_classes = n_classes
+        self.alignment_implementation = alignment_implementation
+        self.alignment_opts = alignment_opts
+        self.seed = seed
+
+        alignment_implementations = {
+            "bfr": self._bfr_align,
+            "bfsr": self._bfsr_align,
+        }
+
+        if alignment_implementation not in alignment_implementations:
+            raise ValueError(
+                f"Provided alignment_implementation={alignment_implementation}"
+                f" not in {alignment_implementations.keys()}."
+            )
+        self._alignment = alignment_implementations[alignment_implementation]
+
+    def alignment(self, classes, refl, coef, alignment_opts=None):
+        """
+        Any class averagiing alignment method should take in the following arguments and return the tuple described.
+
+        The returned `classes` and `refl` should be same as the input.
+
+        Returned `rot` is an (n_classes, n_nbor) array of angles which should represent the rotations needed to align images within that class. `rot` is measure in Radians.
+
+        Returned `corr` is an (n_classes, n_nbor) array that should represent a correlation like measure between classified images and their base image (image index 0).
+
+        Returned `shifts` is None or an (n_classes, n_nbor) array of 2D shifts which should represent the translation needed to best align the images within that class.
+
+
+        Alignment implementations may admit specific conifguration options using an optional `alignment_opts` dictionary.
+
+        :param classes: (n_classes, n_nbor) integer array of indices
+        :param refl: (n_classes, n_nbor) bool array of reflections
+        :param coef: (n_img, self.pca_basis.count) array of compressed basis coefficients.
+
+        :returns: (classes, refl, rot, corr, shifts)
+        """
+
+        # _alignment is assigned during initialization.
+        return self._alignment(classes, refl, coef, alignment_opts)
+
+    def _bfsr_align(self, classes, refl, coef, alignment_opts=None):
+        """
+        This perfoms a Brute Force Shift and Rotational alignment.
+
+        For each pair of x_shifts and y_shifts,
+           Perform BFR
+
+        Return the rotation and shift yielding the best results.
+        """
+
+        # Unpack any configuration options, or get defaults.
+        if alignment_opts is None:
+            alignment_opts = {}
+        # Default shift search space of +- 1 in X and Y
+        n_x_shifts = alignment_opts.get("n_x_shifts", 1)
+        n_y_shifts = alignment_opts.get("n_y_shifts", 1)
+
+        # Compute the shifts. Roll array so 0 is first.
+        x_shifts = np.roll(np.arange(-n_x_shifts, n_x_shifts + 1), -n_x_shifts)
+        y_shifts = np.roll(np.arange(-n_y_shifts, n_y_shifts + 1), -n_y_shifts)
+        assert (x_shifts[0], y_shifts[0]) == (0, 0)
+
+        # These arrays will incrementally store our best alignment.
+        rots = np.empty(classes.shape, dtype=self.dtype)
+        corr = np.ones(classes.shape, dtype=self.dtype) * -np.inf
+        shifts = np.empty((*classes.shape, 2), dtype=int)
+
+        # We want to maintain the original coefs for the base images,
+        #  because we will mutate them with shifts in the loop.
+        original_coef = coef[classes[:, 0], :]
+        assert original_coef.shape == (self.n_classes, self.pca_basis.count)
+
+        # Loop over shift search space, updating best result
+        for x, y in product(x_shifts, y_shifts):
+            shift = np.array([x, y], dtype=int)
+            logger.info(f"Computing Rotational alignment after shift ({x},{y}).")
+
+            # Shift the coef representing the first (base) entry in each class
+            #   by the negation of the shift
+            # Shifting one image is more efficient than shifting every neighbor
+            coef[classes[:, 0], :] = self.pca_basis.shift(original_coef, -shift)
+
+            _, _, _rots, _, _corr = self._bfr_align(classes, refl, coef, alignment_opts)
+
+            # Each class-neighbor pair may have a best shift-rot from a different shift.
+            # Test and update
+            improved_indices = _corr > corr
+            rots[improved_indices] = _rots[improved_indices]
+            corr[improved_indices] = _corr[improved_indices]
+            shifts[improved_indices] = shift
+
+            # Restore unshifted base coefs
+            coef[classes[:, 0], :] = original_coef
+
+            if (x, y) == (0, 0):
+                logger.info("Initial rotational alignment complete (shift (0,0))")
+                assert np.sum(improved_indices) == np.size(
+                    classes
+                ), f"{np.sum(improved_indices)} =?= {np.size(classes)}"
+            else:
+                logger.info(
+                    f"Shift ({x},{y}) complete. Improved {np.sum(improved_indices)} alignments."
+                )
+
+        return classes, refl, rots, shifts, corr
+
+    def _bfr_align(self, classes, refl, coef, alignment_opts=None):
+        """
+        This perfoms a Brute Force Rotational alignment.
+
+        For each class,
+            constructs n_angles rotations of all class members,
+            and then identifies angle yielding largest correlation(dot).
+
+        For params, see `align`.
+
+        Configurable `alignment_opts`:
+        `n_angles` sets the number of brute force rotations to attempt.
+        Defaults `n_angles=359`.
+        """
+
+        # Configure any alignment options, otherwise use defaults.
+        if alignment_opts is None:
+            alignment_opts = {}
+        n_angles = alignment_opts.get("n_angles", 359)
+
+        # Construct array of angles to brute force.
+        test_angles = np.linspace(0, 2 * np.pi, n_angles, endpoint=False)
+
+        # Instantiate matrices for results
+        rots = np.empty(classes.shape, dtype=self.dtype)
+        corr = np.empty(classes.shape, dtype=self.dtype)
+        results = np.empty((self.n_nbor, n_angles))
+
+        for k in trange(self.n_classes):
+
+            # Get the coefs for these neighbors
+            nbr_coef = coef[classes[k]]
+
+            for i, angle in enumerate(test_angles):
+                # Rotate the set of neighbors by angle,
+                rotated_nbrs = self.pca_basis.rotate(nbr_coef, angle, refl[k])
+
+                # then store dot between class base image (0) and each nbor
+                for j, nbor in enumerate(rotated_nbrs):
+                    results[j, i] = np.dot(nbr_coef[0], nbor)
+
+            # Now along each class, find the index of the angle reporting highest correlation
+            angle_idx = np.argmax(results, axis=1)
+
+            # Store that angle as our rotation for this image
+            rots[k, :] = test_angles[angle_idx]
+
+            # Also store the correlations for each neighbor
+            for j in range(self.n_nbor):
+                corr[k, j] = results[j, angle_idx[j]]
+
+        # None is placeholder for shifts
+        return classes, refl, rots, None, corr

--- a/src/aspire/classification/rir_class2d.py
+++ b/src/aspire/classification/rir_class2d.py
@@ -1,10 +1,9 @@
 import logging
-from itertools import product
 
 import matplotlib.pyplot as plt
 import numpy as np
 from sklearn.neighbors import NearestNeighbors
-from tqdm import tqdm, trange
+from tqdm import tqdm
 
 from aspire.basis import FSPCABasis
 from aspire.classification import Class2D
@@ -69,7 +68,15 @@ class RIRClass2D(Class2D):
         :return: RIRClass2D instance to be used to compute bispectrum-like rotationally invariant 2D classification.
         """
 
-        super().__init__(src=src, dtype=dtype)
+        super().__init__(
+            src=src,
+            n_nbor=n_nbor,
+            n_classes=n_classes,
+            alignment_implementation=alignment_implementation,
+            alignment_opts=alignment_opts,
+            seed=seed,
+            dtype=dtype,
+        )
 
         # For now, only run with FSPCA basis
         if pca_basis and not isinstance(pca_basis, FSPCABasis):
@@ -82,11 +89,7 @@ class RIRClass2D(Class2D):
         self.sample_n = sample_n
         self.alpha = alpha
         self.bispectrum_components = bispectrum_components
-        self.n_nbor = n_nbor
-        self.n_classes = n_classes
         self.bispectrum_freq_cutoff = bispectrum_freq_cutoff
-        self.seed = seed
-        self.alignment_opts = alignment_opts
 
         if self.src.n < self.bispectrum_components:
             raise RuntimeError(
@@ -133,17 +136,6 @@ class RIRClass2D(Class2D):
                 " Check class configuration and retry."
             )
         self._bispectrum = bispectrum_implementations[bispectrum_implementation]
-
-        alignment_implementations = {
-            "bfr": self._bfr_align,
-            "bfsr": self._bfsr_align,
-        }
-        if alignment_implementation not in alignment_implementations:
-            raise ValueError(
-                f"Provided alignment_implementation={alignment_implementation}"
-                f" not in {alignment_implementations.keys()}."
-            )
-        self._alignment = alignment_implementations[alignment_implementation]
 
     def classify(self, diagnostics=False):
         """
@@ -338,151 +330,6 @@ class RIRClass2D(Class2D):
 
         # Now we convert the averaged images from FB to Cartesian.
         return ArrayImageSource(self.fb_basis.evaluate(fb_avgs))
-
-    def alignment(self, classes, refl, coef, alignment_opts=None):
-        """
-        Any class averagiing alignment method should take in the following arguments and return the tuple described.
-
-        The returned `classes` and `refl` should be same as the input.
-
-        Returned `rot` is an (n_classes, n_nbor) array of angles which should represent the rotations needed to align images within that class. `rot` is measure in Radians.
-
-        Returned `corr` is an (n_classes, n_nbor) array that should represent a correlation like measure between classified images and their base image (image index 0).
-
-        Returned `shifts` is None or an (n_classes, n_nbor) array of 2D shifts which should represent the translation needed to best align the images within that class.
-
-
-        Alignment implementations may admit specific conifguration options using an optional `alignment_opts` dictionary.
-
-        :param classes: (n_classes, n_nbor) integer array of indices
-        :param refl: (n_classes, n_nbor) bool array of reflections
-        :param coef: (n_img, self.pca_basis.count) array of compressed basis coefficients.
-
-        :returns: (classes, refl, rot, corr, shifts)
-        """
-
-        # _alignment is assigned during initialization.
-        return self._alignment(classes, refl, coef, alignment_opts)
-
-    def _bfsr_align(self, classes, refl, coef, alignment_opts=None):
-        """
-        This perfoms a Brute Force Shift and Rotational alignment.
-
-        For each pair of x_shifts and y_shifts,
-           Perform BFR
-
-        Return the rotation and shift yielding the best results.
-        """
-
-        # Unpack any configuration options, or get defaults.
-        if alignment_opts is None:
-            alignment_opts = {}
-        # Default shift search space of +- 1 in X and Y
-        n_x_shifts = alignment_opts.get("n_x_shifts", 1)
-        n_y_shifts = alignment_opts.get("n_y_shifts", 1)
-
-        # Compute the shifts. Roll array so 0 is first.
-        x_shifts = np.roll(np.arange(-n_x_shifts, n_x_shifts + 1), -n_x_shifts)
-        y_shifts = np.roll(np.arange(-n_y_shifts, n_y_shifts + 1), -n_y_shifts)
-        assert (x_shifts[0], y_shifts[0]) == (0, 0)
-
-        # These arrays will incrementally store our best alignment.
-        rots = np.empty(classes.shape, dtype=self.dtype)
-        corr = np.ones(classes.shape, dtype=self.dtype) * -np.inf
-        shifts = np.empty((*classes.shape, 2), dtype=int)
-
-        # We want to maintain the original coefs for the base images,
-        #  because we will mutate them with shifts in the loop.
-        original_coef = coef[classes[:, 0], :]
-        assert original_coef.shape == (self.n_classes, self.pca_basis.count)
-
-        # Loop over shift search space, updating best result
-        for x, y in product(x_shifts, y_shifts):
-            shift = np.array([x, y], dtype=int)
-            logger.info(f"Computing Rotational alignment after shift ({x},{y}).")
-
-            # Shift the coef representing the first (base) entry in each class
-            #   by the negation of the shift
-            # Shifting one image is more efficient than shifting every neighbor
-            coef[classes[:, 0], :] = self.pca_basis.shift(original_coef, -shift)
-
-            _, _, _rots, _, _corr = self._bfr_align(classes, refl, coef, alignment_opts)
-
-            # Each class-neighbor pair may have a best shift-rot from a different shift.
-            # Test and update
-            improved_indices = _corr > corr
-            rots[improved_indices] = _rots[improved_indices]
-            corr[improved_indices] = _corr[improved_indices]
-            shifts[improved_indices] = shift
-
-            # Restore unshifted base coefs
-            coef[classes[:, 0], :] = original_coef
-
-            if (x, y) == (0, 0):
-                logger.info("Initial rotational alignment complete (shift (0,0))")
-                assert np.sum(improved_indices) == np.size(
-                    classes
-                ), f"{np.sum(improved_indices)} =?= {np.size(classes)}"
-            else:
-                logger.info(
-                    f"Shift ({x},{y}) complete. Improved {np.sum(improved_indices)} alignments."
-                )
-
-        return classes, refl, rots, shifts, corr
-
-    def _bfr_align(self, classes, refl, coef, alignment_opts=None):
-        """
-        This perfoms a Brute Force Rotational alignment.
-
-        For each class,
-            constructs n_angles rotations of all class members,
-            and then identifies angle yielding largest correlation(dot).
-
-        For params, see `align`.
-
-        Configurable `alignment_opts`:
-        `n_angles` sets the number of brute force rotations to attempt.
-        Defaults `n_angles=359`.
-        """
-
-        # Configure any alignment options, otherwise use defaults.
-        if alignment_opts is None:
-            alignment_opts = {}
-        n_angles = alignment_opts.get("n_angles", 359)
-
-        # Construct array of angles to brute force.
-        test_angles = np.linspace(0, 2 * np.pi, n_angles, endpoint=False)
-
-        # Instantiate matrices for results
-        rots = np.empty(classes.shape, dtype=self.dtype)
-        corr = np.empty(classes.shape, dtype=self.dtype)
-        results = np.empty((self.n_nbor, n_angles))
-
-        for k in trange(self.n_classes):
-
-            # Get the coefs for these neighbors
-            nbr_coef = coef[classes[k]]
-
-            for i, angle in enumerate(test_angles):
-                # Rotate the set of neighbors by angle,
-                rotated_nbrs = self.pca_basis.rotate(nbr_coef, angle, refl[k])
-
-                # then store dot between class base image (0) and each nbor
-                for j, nbor in enumerate(rotated_nbrs):
-                    results[j, i] = np.dot(nbr_coef[0], nbor)
-
-            # Now along each class, find the index of the angle reporting highest correlation
-            angle_idx = np.argmax(results, axis=1)
-
-            # Store that angle as our rotation for this image
-            rots[k, :] = test_angles[angle_idx]
-
-            # Also store the correlations for each neighbor
-            for j in range(self.n_nbor):
-                corr[k, j] = results[j, angle_idx[j]]
-
-        # None is placeholder for shifts
-        return classes, refl, rots, None, corr
 
     def _legacy_nn_classification(self, coeff_b, coeff_b_r, batch_size=2000):
         """

--- a/src/aspire/classification/rir_class2d.py
+++ b/src/aspire/classification/rir_class2d.py
@@ -3,7 +3,7 @@ import logging
 import matplotlib.pyplot as plt
 import numpy as np
 from sklearn.neighbors import NearestNeighbors
-from tqdm import tqdm
+from tqdm import tqdm, trange
 
 from aspire.basis import FSPCABasis
 from aspire.classification import Class2D
@@ -369,7 +369,7 @@ class RIRClass2D(Class2D):
 
         results = np.empty((self.n_nbor, n_angles))
         
-        for k in range(self.n_classes):
+        for k in trange(self.n_classes):
 
             # get the coefs for these neighbors
             nbr_coef = coef[classes[k]]

--- a/src/aspire/classification/rir_class2d.py
+++ b/src/aspire/classification/rir_class2d.py
@@ -367,9 +367,9 @@ class RIRClass2D(Class2D):
         rots = np.empty(classes.shape, dtype=self.dtype)
         corr = np.empty(classes.shape, dtype=self.dtype)
 
+        results = np.empty((self.n_nbor, n_angles))
+        
         for k in range(self.n_classes):
-
-            results = np.empty((self.n_nbor, n_angles))
 
             # get the coefs for these neighbors
             nbr_coef = coef[classes[k]]

--- a/src/aspire/utils/rotation.py
+++ b/src/aspire/utils/rotation.py
@@ -57,7 +57,7 @@ class Rotation:
     @property
     def angles(self):
         """
-        :return: Rotation matrices as a n x 3 x 3 array
+        :return: Rotation matrices as a n x 3 array
         """
         rotations = sp_rot.from_matrix(self._matrices.astype(self.dtype))
         return rotations.as_euler(self._seq_order, degrees=False).astype(self.dtype)

--- a/tests/test_FFBbasis2D.py
+++ b/tests/test_FFBbasis2D.py
@@ -1,3 +1,4 @@
+import logging
 import os.path
 from unittest import TestCase
 
@@ -7,15 +8,18 @@ from aspire.basis import FFBBasis2D
 from aspire.image import Image
 from aspire.source import Simulation
 from aspire.utils import utest_tolerance
+from aspire.utils.misc import grid_2d
 from aspire.volume import Volume
 
+logger = logging.getLogger(__name__)
 DATA_DIR = os.path.join(os.path.dirname(__file__), "saved_test_data")
 
 
 class FFBBasis2DTestCase(TestCase):
     def setUp(self):
         self.dtype = np.float32  # Required for convergence of this test
-        self.basis = FFBBasis2D((8, 8), dtype=self.dtype)
+        self.L = 8
+        self.basis = FFBBasis2D((self.L, self.L), dtype=self.dtype)
 
     def tearDown(self):
         pass
@@ -302,3 +306,46 @@ class FFBBasis2DTestCase(TestCase):
 
         # Refl (flipped using flipud)
         self.assertTrue(np.allclose(np.flipud(x1[0]), y4[0], atol=1e-4))
+
+    def testShift(self):
+        """
+        Compare shifting using Image with shifting provided by the Basis.
+
+        Note the Basis shift method converts from FB to Image space and back.
+        """
+
+        n_img = 3
+        test_shift = np.array([10, 2])
+
+        # Construct some synthetic data
+        v = Volume(
+            np.load(os.path.join(DATA_DIR, "clean70SRibosome_vol.npy")).astype(
+                np.float64
+            )
+        ).downsample(self.L)
+
+        src = Simulation(L=self.L, n=n_img, vols=v, dtype=np.float64)
+
+        # Shift images using the Image method directly
+        shifted_imgs = src.images(0, n_img).shift(test_shift)
+
+        # Convert original images to basis coefficients
+        basis = FFBBasis2D((self.L,) * 2, dtype=np.float64)
+        f_imgs = basis.evaluate_t(src.images(0, n_img))
+
+        # Use the basis shift method
+        f_shifted_imgs = basis.shift(f_imgs, test_shift)
+
+        # Compute diff between the shifted image sets
+        diff = shifted_imgs.asnumpy() - basis.evaluate(f_shifted_imgs).asnumpy()
+
+        # Compute mask to compare only the core of the shifted images
+        g = grid_2d(self.L, normalized=False)
+        mask = g["r"] > self.L / 2
+        # Masking values outside radius to 0
+        diff = np.where(mask, 0, diff)
+
+        # Compute and check error
+        rmse = np.sqrt(np.mean(np.square(diff), axis=(1, 2)))
+        logger.info(f"RMSE shifted image diffs {rmse}")
+        self.assertTrue(np.allclose(rmse, 0, atol=1e-5))

--- a/tests/test_FFBbasis2D.py
+++ b/tests/test_FFBbasis2D.py
@@ -330,14 +330,13 @@ class FFBBasis2DTestCase(TestCase):
         shifted_imgs = src.images(0, n_img).shift(test_shift)
 
         # Convert original images to basis coefficients
-        basis = FFBBasis2D((self.L,) * 2, dtype=np.float64)
-        f_imgs = basis.evaluate_t(src.images(0, n_img))
+        f_imgs = self.basis.evaluate_t(src.images(0, n_img))
 
         # Use the basis shift method
-        f_shifted_imgs = basis.shift(f_imgs, test_shift)
+        f_shifted_imgs = self.basis.shift(f_imgs, test_shift)
 
         # Compute diff between the shifted image sets
-        diff = shifted_imgs.asnumpy() - basis.evaluate(f_shifted_imgs).asnumpy()
+        diff = shifted_imgs.asnumpy() - self.basis.evaluate(f_shifted_imgs).asnumpy()
 
         # Compute mask to compare only the core of the shifted images
         g = grid_2d(self.L, normalized=False)

--- a/tests/test_align2d.py
+++ b/tests/test_align2d.py
@@ -1,0 +1,221 @@
+import logging
+import os
+from unittest import TestCase
+
+import numpy as np
+import pytest
+
+from aspire.basis import DiracBasis, FFBBasis2D
+from aspire.classification import Align2D, BFRAlign2D, BFSRAlign2D
+from aspire.source import Simulation
+from aspire.utils import Rotation
+from aspire.volume import Volume
+
+logger = logging.getLogger(__name__)
+
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), "saved_test_data")
+
+
+class Align2DTestCase(TestCase):
+    # Subclasses should override `aligner` with a different class.
+    aligner = Align2D
+
+    def setUp(self):
+
+        self.vols = Volume(
+            np.load(os.path.join(DATA_DIR, "clean70SRibosome_vol.npy"))
+        ).downsample(17)
+
+        self.resolution = self.vols.resolution
+        self.n_img = 3
+        self.dtype = np.float64
+
+        # Create a Basis to use in alignment.
+        self.basis = FFBBasis2D((self.resolution, self.resolution), dtype=self.dtype)
+
+        # This sets up a trivial class, where there is one group having all images.
+        self.classes = np.arange(self.n_img, dtype=int).reshape(1, self.n_img)
+        self.reflections = np.zeros(self.classes.shape, dtype=bool)
+
+    # This is a workaround to use a `pytest` fixture with `unittest` style cases.
+    @pytest.fixture(autouse=True)
+    def inject_fixtures(self, caplog):
+        self._caplog = caplog
+
+    def tearDown(self):
+        pass
+
+    def testTypeMismatch(self):
+
+        # Intentionally mismatch Basis and Aligner dtypes
+        if self.dtype == np.float32:
+            test_dtype = np.float64
+        else:
+            test_dtype = np.float32
+
+        with self._caplog.at_level(logging.WARN):
+            self.aligner(self.basis, dtype=test_dtype)
+            assert " does not match self.dtype" in self._caplog.text
+
+    def _construct_rotations(self):
+        """
+        Constructs a `Rotation` object which can yield `angles` as used by `Source`s.
+        """
+
+        # Get a list of angles to test
+        self.thetas, self.step = np.linspace(
+            0, 2 * np.pi, num=self.n_img, endpoint=False, retstep=True, dtype=self.dtype
+        )
+
+        # Common 3D rotation matrix, about z.
+        def r(theta):
+            return np.array(
+                [
+                    [np.cos(theta), -np.sin(theta), 0],
+                    [np.sin(theta), np.cos(theta), 0],
+                    [0, 0, 1],
+                ],
+                dtype=self.dtype,
+            )
+
+        # Construct a sequence of rotation matrices using thetas
+        _rots = np.empty((self.n_img, 3, 3), dtype=self.dtype)
+        for n, theta in enumerate(self.thetas):
+            # Note we negate theta to match Rotation convention.
+            _rots[n] = r(-theta)
+
+        # Use our Rotation class (maybe it should be able to do this one day?)
+        self.rots = Rotation.from_matrix(_rots)
+
+
+class BFRAlign2DTestCase(Align2DTestCase):
+
+    aligner = BFRAlign2D
+
+    def setUp(self):
+
+        self.n_search_angles = 360
+
+        super().setUp()
+
+        # We'll construct our Rotations now
+        self._construct_rotations()
+
+        # Create a `src` to feed our tests
+        self.src = self._getSrc()
+
+        # Get the image coef
+        self.coefs = self.basis.evaluate_t(self.src.images(0, self.n_img))
+
+    def _getSrc(self):
+        if not hasattr(self, "shifts"):
+            self.shifts = np.zeros((self.n_img, 2))
+
+        return Simulation(
+            vols=self.vols,
+            L=self.resolution,
+            n=self.n_img,
+            C=1,
+            angles=self.rots.angles,
+            offsets=self.shifts,
+            amplitudes=np.ones(self.n_img),
+            seed=12345,
+            dtype=self.dtype,
+        )
+
+    def testNoRot(self):
+        """
+        Test we raise an error when our basis does not provide `rotate` method.
+        """
+        # DiracBasis does not provide `rotate`,
+        basis = DiracBasis((self.resolution, self.resolution), dtype=self.dtype)
+
+        # and that should raise an error during instantiation.
+        with pytest.raises(RuntimeError, match=r".* must provide a `rotate` method."):
+            _ = self.aligner(basis)
+
+    def testAlign(self):
+        """
+        Construct a stack of images with known rotations.
+
+        Rotationally align the stack and compare output with known rotations.
+        """
+
+        # Construction the Aligner and then call the main `align` method
+        _classes, _reflections, _rotations, _shifts, _ = self.aligner(
+            self.basis, n_angles=self.n_search_angles
+        ).align(self.classes, self.reflections, self.coefs)
+
+        self.assertTrue(np.all(_classes == self.classes))
+        self.assertTrue(np.all(_reflections == self.reflections))
+        self.assertIsNone(_shifts)
+
+        # Crude check that we are closer to known angle than the next rotation
+        self.assertTrue(np.all((_rotations - self.thetas) <= (self.step / 2)))
+
+        # Fine check that we are within n_angles.
+        self.assertTrue(
+            np.all((_rotations - self.thetas) <= (2 * np.pi / self.n_search_angles))
+        )
+
+
+class BFSRAlign2DTestCase(BFRAlign2DTestCase):
+
+    aligner = BFSRAlign2D
+
+    def setUp(self):
+        # Inherit basic params from the base class
+        super(BFRAlign2DTestCase, self).setUp()
+
+        # Setup shifts, don't shift the base image
+        self.shifts = np.zeros((self.n_img, 2))
+        self.shifts[1:, 0] = 2
+        self.shifts[1:, 1] = 4
+
+        # Execute the remaining setup from BFRAlign2DTestCase
+        super().setUp()
+
+    def testNoShift(self):
+        """
+        Test we raise an error when our basis does not provide `shift` method.
+        """
+
+        # DiracBasis does not provide `rotate` or `shift`.
+        basis = DiracBasis((self.resolution, self.resolution), dtype=self.dtype)
+
+        # The missing `rotate` case was already covered by (inherited) NoRot.
+        # Add a dummy rotate method; we will still be missing `shift`,
+        basis.rotate = lambda x: x
+
+        # and that should raise an error during instantiation.
+        with pytest.raises(RuntimeError, match=r".* must provide a `shift` method."):
+            _ = self.aligner(basis)
+
+    def testAlign(self):
+        """
+        Construct a stack of images with known rotations.
+
+        Rotationally align the stack and compare output with known rotations.
+        """
+
+        # Construction the Aligner and then call the main `align` method
+        _classes, _reflections, _rotations, _shifts, _ = self.aligner(
+            self.basis, n_angles=self.n_search_angles, n_x_shifts=1, n_y_shifts=1
+        ).align(self.classes, self.reflections, self.coefs)
+
+        self.assertTrue(np.all(_classes == self.classes))
+        self.assertTrue(np.all(_reflections == self.reflections))
+
+        # Crude check that we are closer to known angle than the next rotation
+        self.assertTrue(np.all((_rotations - self.thetas) <= (self.step / 2)))
+
+        # Fine check that we are within n_angles.
+        self.assertTrue(
+            np.all((_rotations - self.thetas) <= (2 * np.pi / self.n_search_angles))
+        )
+
+        # Check that we are _not_ shifting the base image
+        self.assertTrue(np.all(_shifts[0][0] == 0))
+        # Check that we produced  estimated shifts away from origin
+        self.assertTrue(np.all(np.hypot(*_shifts[0][1:].T) >= 1))

--- a/tests/test_align2d.py
+++ b/tests/test_align2d.py
@@ -17,6 +17,8 @@ logger = logging.getLogger(__name__)
 DATA_DIR = os.path.join(os.path.dirname(__file__), "saved_test_data")
 
 
+# Ignore Gimbal lock warning for our in plane rotations.
+@pytest.mark.filterwarnings("ignore:Gimbal lock detected")
 class Align2DTestCase(TestCase):
     # Subclasses should override `aligner` with a different class.
     aligner = Align2D

--- a/tests/test_align2d.py
+++ b/tests/test_align2d.py
@@ -219,5 +219,9 @@ class BFSRAlign2DTestCase(BFRAlign2DTestCase):
 
         # Check that we are _not_ shifting the base image
         self.assertTrue(np.all(_shifts[0][0] == 0))
-        # Check that we produced  estimated shifts away from origin
+        # Check that we produced estimated shifts away from origin
+        #  Note that Simulation's rot+shift is generally not equal to shift+rot.
+        #  Instead we check that some combination of
+        #  non zero shift+rot improved corr.
+        #  Perhaps in the future should check more details.
         self.assertTrue(np.all(np.hypot(*_shifts[0][1:].T) >= 1))

--- a/tests/test_class2D.py
+++ b/tests/test_class2D.py
@@ -191,13 +191,16 @@ class RIRClass2DTestCase(TestCase):
             self.noisy_fspca_basis,
             bispectrum_components=100,
             sample_n=42,
+            n_classes=5,
             large_pca_implementation="sklearn",
             nn_implementation="sklearn",
             bispectrum_implementation="devel",
+            alignment_implementation="bfsr",
+            alignment_opts={"n_angles": 100, "n_x_shifts": 0},
         )
 
         result = rir.classify()
-        _ = rir.output(*result[:3])
+        _ = rir.output(*result[:4])
 
     def testEigenImages(self):
         """

--- a/tests/test_class2D.py
+++ b/tests/test_class2D.py
@@ -7,7 +7,7 @@ import pytest
 from sklearn import datasets
 
 from aspire.basis import FFBBasis2D, FSPCABasis
-from aspire.classification import Class2D, RIRClass2D
+from aspire.classification import BFSRAlign2D, Class2D, RIRClass2D
 from aspire.classification.legacy_implementations import bispec_2drot_large, pca_y
 from aspire.operators import ScalarFilter
 from aspire.source import Simulation
@@ -147,14 +147,45 @@ class RIRClass2DTestCase(TestCase):
         _ = Class2D(self.clean_src, dtype=self.dtype)  # Consistent dtype
         _ = Class2D(self.clean_src, dtype=np.float16)  # Different dtype
 
+    def testIncorrectComponents(self):
+        """
+        Check we raise with inconsistent configuration of FSPCA components.
+        """
+
+        with pytest.raises(
+            RuntimeError, match=r"`pca_basis` components.*provided by user."
+        ):
+            _ = RIRClass2D(
+                self.clean_src,
+                self.clean_fspca_basis,  # 400 components
+                fspca_components=100,
+                large_pca_implementation="legacy",
+                nn_implementation="legacy",
+                bispectrum_implementation="legacy",
+            )
+
+        # Explicitly providing the same number should be okay.
+        _ = RIRClass2D(
+            self.clean_src,
+            self.clean_fspca_basis,  # 400 components
+            fspca_components=self.clean_fspca_basis.components,
+            large_pca_implementation="legacy",
+            nn_implementation="legacy",
+            bispectrum_implementation="legacy",
+        )
+
     def testRIRLegacy(self):
         """
         Currently just tests for runtime errors.
         """
+
+        clean_fspca_basis = FSPCABasis(
+            self.clean_src, self.basis, noise_var=0, components=100
+        )  # Note noise_var assigned zero, skips eigval filtering.
+
         rir = RIRClass2D(
             self.clean_src,
-            self.clean_fspca_basis,
-            fspca_components=100,
+            clean_fspca_basis,
             large_pca_implementation="legacy",
             nn_implementation="legacy",
             bispectrum_implementation="legacy",
@@ -195,8 +226,7 @@ class RIRClass2DTestCase(TestCase):
             large_pca_implementation="sklearn",
             nn_implementation="sklearn",
             bispectrum_implementation="devel",
-            alignment_implementation="bfsr",
-            alignment_opts={"n_angles": 100, "n_x_shifts": 0},
+            aligner=BFSRAlign2D(self.noisy_fspca_basis, n_angles=100, n_x_shifts=0),
         )
 
         result = rir.classify()


### PR DESCRIPTION
A simple brute force implementation of rotational alignment is added to `RIRClass2D`.  Similar to NN, this implements `aligner` as a configurable class for future extension/experimentation.

Results of this crude approach appear to improve the poor alignment results from the simple class averaging tutorial data set both clean and noisy.  It does not consider shifts.  (Attached)
[Small_Class_Average_Example_Aligners.pdf](https://github.com/ComputationalCryoEM/ASPIRE-Python/files/7324068/Small_Class_Average_Example_Aligners.pdf)

I will be repeating with some simulated molecular data...

Currently it is not clear to me whether the poor alignment via legacy code is a bug or an issue with the method.  It really struggles with any axis-symmetry.  I see similar problems in the MATLAB code.  Would like to find a reference to the algorithm used by author(s) of the legacy alignment code.  If we can't I might suggest we remove it, since I would then consider the provenance and performance expectations unknown.

There is an alternative method here https://arxiv.org/abs/1905.12317 which could be added. among others.

