### PR TITLE
cov2d negative sqrt workaround

### DIFF
--- a/src/aspire/covariance/covar2d.py
+++ b/src/aspire/covariance/covar2d.py
@@ -42,8 +42,11 @@ def shrink_covar(covar, noise_var, gamma, shrinker="frobenius_norm"):
                 lambdas
                 - noise_var * (gamma - 1)
                 + np.sqrt(
-                    (lambdas - noise_var * (gamma - 1)) ** 2
-                    - 4 * noise_var ** 2 * lambdas
+                    np.maximum(
+                        0,
+                        (lambdas - noise_var * (gamma - 1)) ** 2
+                        - 4 * noise_var ** 2 * lambdas,
+                    )
                 )
             )
             - noise_var
@@ -59,8 +62,11 @@ def shrink_covar(covar, noise_var, gamma, shrinker="frobenius_norm"):
                 lambdas
                 - noise_var * (gamma - 1)
                 + np.sqrt(
-                    (lambdas - noise_var * (gamma - 1)) ** 2
-                    - 4 * noise_var ** 2 * lambdas
+                    np.maximum(
+                        0,
+                        (lambdas - noise_var * (gamma - 1)) ** 2
+                        - 4 * noise_var ** 2 * lambdas,
+                    )
                 )
             )
             - noise_var


### PR DESCRIPTION
Workaround for sensitive sqrt in cov2d eigen shrinkers.

Seems to occur for very noisy data.  Found in experimental set 10025, but I was able to reproduce with `Simulation` by asking for very high noise variance.