### PR TITLE
Fixup the tox env pattern matching

### DIFF
--- a/src/aspire/covariance/covar2d.py
+++ b/src/aspire/covariance/covar2d.py
@@ -377,7 +377,9 @@ class RotCov2D:
         for ell in range(0, len(b)):
             b_ell = b[ell]
             p = np.size(b_ell, 1)
-            S = sqrtm(b_noise[ell])
+            # scipy >= 1.6.0 will upcast the sqrtm result to doubles
+            #  https://github.com/scipy/scipy/issues/14853
+            S = sqrtm(b_noise[ell]).astype(self.dtype)
             # from Matlab b_ell = S \ b_ell /S
             b_ell = solve(S, b_ell) @ inv(S)
             b_ell = shrink_covar(b_ell, noise_var, p / n, shrinker)

--- a/tox.ini
+++ b/tox.ini
@@ -16,25 +16,7 @@ deps =
     Cython>=0.23
 commands =
     python -V
-    pip freeze
-    python -c "import numpy; numpy.show_config()"
-    # --cov should generate `Coverage` data
-    pytest --cov=aspire --cov-report=xml {posargs}
-
-[testenv:py{3.6,3.7,3.8,3.9}-dev]
-whitelist_externals=
-    sh
-    cut
-    xargs
-changedir = tests
-deps =
-    parameterized
-    pytest
-    pytest-cov
-    Cython>=0.23
-commands =
-    sh -c "pip freeze | cut -d@ -f1 | cut -d= -f1 | xargs -n1 pip install -U"
-    python -V
+    py{3.6,3.7,3.8,3.9}-dev: sh -c "pip freeze | cut -d@ -f1 | cut -d= -f1 | xargs -n1 pip install -U"
     pip freeze
     python -c "import numpy; numpy.show_config()"
     # --cov should generate `Coverage` data


### PR DESCRIPTION
Looks like the tox env pattern matching changed since it was deployed.

Updated to a cleaner pattern. Now we just overload one line instead of the entire `testenv`.

Working locally. Draft until I can inspect the logs on GH.