### PR TITLE
Fix distribution of noise_var in shrinker formulas

### DIFF
--- a/src/aspire/covariance/covar2d.py
+++ b/src/aspire/covariance/covar2d.py
@@ -42,8 +42,7 @@ def shrink_covar(covar, noise_var, gamma, shrinker="frobenius_norm"):
                 lambdas
                 - noise_var * (gamma - 1)
                 + np.sqrt(
-                    (lambdas - noise_var * (gamma - 1)) ** 2
-                    - 4 * noise_var ** 2 * lambdas
+                    (lambdas - noise_var * (gamma - 1)) ** 2 - 4 * noise_var * lambdas
                 )
             )
             - noise_var
@@ -59,8 +58,7 @@ def shrink_covar(covar, noise_var, gamma, shrinker="frobenius_norm"):
                 lambdas
                 - noise_var * (gamma - 1)
                 + np.sqrt(
-                    (lambdas - noise_var * (gamma - 1)) ** 2
-                    - 4 * noise_var ** 2 * lambdas
+                    (lambdas - noise_var * (gamma - 1)) ** 2 - 4 * noise_var * lambdas
                 )
             )
             - noise_var


### PR DESCRIPTION
I wrote down why I think the `  - 4 * noise_var ** 2 * lambdas` should be `-4 * noise_var * lambdas`.

![shrinkage_formula](https://user-images.githubusercontent.com/47759732/137369866-71625f44-a67e-49fe-a656-abf02c8c0046.jpeg)

I would appreciate if someone can double check it independently.  @janden or @yunpeng-shi ?

I tested locally for a small (class averaging, which uses covar2d's cov ests) on clean and very noisy images.