### PR TITLE
Redundant method `eval_filter_grid` in `ImageSource`

### DIFF
--- a/src/aspire/covariance/covar.py
+++ b/src/aspire/covariance/covar.py
@@ -11,7 +11,7 @@ from tqdm import tqdm
 from aspire import config
 from aspire.image import Image
 from aspire.nufft import anufft
-from aspire.operators import evaluate_grid_src
+from aspire.operators import evaluate_src_filters_on_grid
 from aspire.reconstruction import Estimator, FourierKernel, MeanEstimator
 from aspire.utils import (
     ensure,
@@ -48,7 +48,7 @@ class CovarianceEstimator(Estimator):
         _2L = 2 * self.L
 
         kernel = np.zeros((_2L, _2L, _2L, _2L, _2L, _2L), dtype=self.dtype)
-        sq_filters_f = evaluate_grid_src(self.src, self.L, power=2)
+        sq_filters_f = np.square(evaluate_src_filters_on_grid(self.src, self.L))
 
         for i in tqdm(range(0, n, self.batch_size)):
             _range = np.arange(i, min(n, i + self.batch_size))

--- a/src/aspire/covariance/covar.py
+++ b/src/aspire/covariance/covar.py
@@ -11,6 +11,7 @@ from tqdm import tqdm
 from aspire import config
 from aspire.image import Image
 from aspire.nufft import anufft
+from aspire.operators import evaluate_grid_src
 from aspire.reconstruction import Estimator, FourierKernel, MeanEstimator
 from aspire.utils import (
     ensure,
@@ -47,7 +48,7 @@ class CovarianceEstimator(Estimator):
         _2L = 2 * self.L
 
         kernel = np.zeros((_2L, _2L, _2L, _2L, _2L, _2L), dtype=self.dtype)
-        sq_filters_f = self.src.eval_filter_grid(self.L, power=2)
+        sq_filters_f = evaluate_grid_src(self.src, self.L, power=2)
 
         for i in tqdm(range(0, n, self.batch_size)):
             _range = np.arange(i, min(n, i + self.batch_size))

--- a/src/aspire/covariance/covar.py
+++ b/src/aspire/covariance/covar.py
@@ -48,7 +48,7 @@ class CovarianceEstimator(Estimator):
         _2L = 2 * self.L
 
         kernel = np.zeros((_2L, _2L, _2L, _2L, _2L, _2L), dtype=self.dtype)
-        sq_filters_f = np.square(evaluate_src_filters_on_grid(self.src, self.L))
+        sq_filters_f = np.square(evaluate_src_filters_on_grid(self.src))
 
         for i in tqdm(range(0, n, self.batch_size)):
             _range = np.arange(i, min(n, i + self.batch_size))

--- a/src/aspire/operators/__init__.py
+++ b/src/aspire/operators/__init__.py
@@ -13,6 +13,7 @@ from .filters import (
     ScalarFilter,
     ScaledFilter,
     ZeroFilter,
+    evaluate_grid_src,
     voltage_to_wavelength,
 )
 from .wemd import wemd_embed, wemd_norm

--- a/src/aspire/operators/__init__.py
+++ b/src/aspire/operators/__init__.py
@@ -13,7 +13,7 @@ from .filters import (
     ScalarFilter,
     ScaledFilter,
     ZeroFilter,
-    evaluate_grid_src,
+    evaluate_src_filters_on_grid,
     voltage_to_wavelength,
 )
 from .wemd import wemd_embed, wemd_norm

--- a/src/aspire/operators/filters.py
+++ b/src/aspire/operators/filters.py
@@ -116,6 +116,20 @@ class Filter:
 
         return h
 
+    def evaluate_grid_src(self, src, L, power=1):
+        grid2d = grid_2d(L, dtype=src.dtype)
+        omega = np.pi * np.vstack((grid2d["x"].flatten(), grid2d["y"].flatten()))
+        h = np.empty((omega.shape[-1], len(src.filter_indices)), dtype=src.dtype)
+        for i, filt, in enumerate(src.unique_filters):
+            idx_k = np.where(src.filter_indices == i)[0]
+            if len(idx_k) > 0:
+                filter_values = filt.evaluate(omega)
+                if power != 1:
+                    filter_values **= power
+                h[:, idx_k] = np.column_stack((filter_values,)*len(idx_k))
+        h = np.reshape(h, grid2d["x"].shape + (len(src.filter_indices),))
+        return h
+
     def dual(self):
         return DualFilter(self)
 

--- a/src/aspire/operators/filters.py
+++ b/src/aspire/operators/filters.py
@@ -33,14 +33,14 @@ def wavelength_to_voltage(wavelength):
     ) / (2 * 0.978466)
 
 
-def evaluate_grid_src(src, L, power=1):
+def evaluate_src_filters_on_grid(src, grid_size):
     """
     Given an ImageSource object, compute the source's unique filters
     at the filter_indices specified in its metadata.
-    :return: an `L x L x len(src.filter_indices)` array containing the evaluated
-    filters at each gridpoint
+    :return: an `grid_size x grid_size x len(src.filter_indices)`
+    array containing the evaluated filters at each gridpoint
     """
-    grid2d = grid_2d(L, dtype=src.dtype)
+    grid2d = grid_2d(grid_size, dtype=src.dtype)
     omega = np.pi * np.vstack((grid2d["x"].flatten(), grid2d["y"].flatten()))
 
     h = np.empty((omega.shape[-1], len(src.filter_indices)), dtype=src.dtype)
@@ -48,8 +48,6 @@ def evaluate_grid_src(src, L, power=1):
         idx_k = np.where(src.filter_indices == i)[0]
         if len(idx_k) > 0:
             filter_values = filt.evaluate(omega)
-            if power != 1:
-                filter_values **= power
             h[:, idx_k] = np.column_stack((filter_values,) * len(idx_k))
 
     h = np.reshape(h, grid2d["x"].shape + (len(src.filter_indices),))

--- a/src/aspire/operators/filters.py
+++ b/src/aspire/operators/filters.py
@@ -33,6 +33,30 @@ def wavelength_to_voltage(wavelength):
     ) / (2 * 0.978466)
 
 
+def evaluate_grid_src(src, L, power=1):
+    """
+    Given an ImageSource object, compute the source's unique filters
+    at the filter_indices specified in its metadata.
+    :return: an `L x L x len(src.filter_indices)` array containing the evaluated
+    filters at each gridpoint
+    """
+    grid2d = grid_2d(L, dtype=src.dtype)
+    omega = np.pi * np.vstack((grid2d["x"].flatten(), grid2d["y"].flatten()))
+
+    h = np.empty((omega.shape[-1], len(src.filter_indices)), dtype=src.dtype)
+    for i, filt in enumerate(src.unique_filters):
+        idx_k = np.where(src.filter_indices == i)[0]
+        if len(idx_k) > 0:
+            filter_values = filt.evaluate(omega)
+            if power != 1:
+                filter_values **= power
+            h[:, idx_k] = np.column_stack((filter_values,) * len(idx_k))
+
+    h = np.reshape(h, grid2d["x"].shape + (len(src.filter_indices),))
+
+    return h
+
+
 # TODO: filters should probably be dtyped...
 class Filter:
     def __init__(self, dim=None, radial=False):
@@ -114,20 +138,6 @@ class Filter:
 
         h = m_reshape(h, grid2d["x"].shape)
 
-        return h
-
-    def evaluate_grid_src(self, src, L, power=1):
-        grid2d = grid_2d(L, dtype=src.dtype)
-        omega = np.pi * np.vstack((grid2d["x"].flatten(), grid2d["y"].flatten()))
-        h = np.empty((omega.shape[-1], len(src.filter_indices)), dtype=src.dtype)
-        for i, filt, in enumerate(src.unique_filters):
-            idx_k = np.where(src.filter_indices == i)[0]
-            if len(idx_k) > 0:
-                filter_values = filt.evaluate(omega)
-                if power != 1:
-                    filter_values **= power
-                h[:, idx_k] = np.column_stack((filter_values,)*len(idx_k))
-        h = np.reshape(h, grid2d["x"].shape + (len(src.filter_indices),))
         return h
 
     def dual(self):

--- a/src/aspire/operators/filters.py
+++ b/src/aspire/operators/filters.py
@@ -33,14 +33,14 @@ def wavelength_to_voltage(wavelength):
     ) / (2 * 0.978466)
 
 
-def evaluate_src_filters_on_grid(src, grid_size):
+def evaluate_src_filters_on_grid(src):
     """
     Given an ImageSource object, compute the source's unique filters
     at the filter_indices specified in its metadata.
-    :return: an `grid_size x grid_size x len(src.filter_indices)`
+    :return: an `src.L x src.L x len(src.filter_indices)`
     array containing the evaluated filters at each gridpoint
     """
-    grid2d = grid_2d(grid_size, dtype=src.dtype)
+    grid2d = grid_2d(src.L, dtype=src.dtype)
     omega = np.pi * np.vstack((grid2d["x"].flatten(), grid2d["y"].flatten()))
 
     h = np.empty((omega.shape[-1], len(src.filter_indices)), dtype=src.dtype)

--- a/src/aspire/reconstruction/mean.py
+++ b/src/aspire/reconstruction/mean.py
@@ -4,7 +4,7 @@ import numpy as np
 from scipy.fftpack import fft2
 
 from aspire.nufft import anufft
-from aspire.operators import evaluate_grid_src
+from aspire.operators import evaluate_src_filters_on_grid
 from aspire.reconstruction import Estimator, FourierKernel
 from aspire.utils.fft import mdim_ifftshift
 from aspire.utils.matlab_compat import m_flatten, m_reshape
@@ -17,7 +17,7 @@ class MeanEstimator(Estimator):
     def compute_kernel(self):
         _2L = 2 * self.L
         kernel = np.zeros((_2L, _2L, _2L), dtype=self.dtype)
-        sq_filters_f = evaluate_grid_src(self.src, self.L, power=2)
+        sq_filters_f = np.square(evaluate_src_filters_on_grid(self.src, self.L))
 
         for i in range(0, self.n, self.batch_size):
             _range = np.arange(i, min(self.n, i + self.batch_size), dtype=int)

--- a/src/aspire/reconstruction/mean.py
+++ b/src/aspire/reconstruction/mean.py
@@ -17,7 +17,7 @@ class MeanEstimator(Estimator):
     def compute_kernel(self):
         _2L = 2 * self.L
         kernel = np.zeros((_2L, _2L, _2L), dtype=self.dtype)
-        sq_filters_f = np.square(evaluate_src_filters_on_grid(self.src, self.L))
+        sq_filters_f = np.square(evaluate_src_filters_on_grid(self.src))
 
         for i in range(0, self.n, self.batch_size):
             _range = np.arange(i, min(self.n, i + self.batch_size), dtype=int)

--- a/src/aspire/reconstruction/mean.py
+++ b/src/aspire/reconstruction/mean.py
@@ -4,6 +4,7 @@ import numpy as np
 from scipy.fftpack import fft2
 
 from aspire.nufft import anufft
+from aspire.operators import evaluate_grid_src
 from aspire.reconstruction import Estimator, FourierKernel
 from aspire.utils.fft import mdim_ifftshift
 from aspire.utils.matlab_compat import m_flatten, m_reshape
@@ -16,7 +17,7 @@ class MeanEstimator(Estimator):
     def compute_kernel(self):
         _2L = 2 * self.L
         kernel = np.zeros((_2L, _2L, _2L), dtype=self.dtype)
-        sq_filters_f = self.src.eval_filter_grid(self.L, power=2)
+        sq_filters_f = evaluate_grid_src(self.src, self.L, power=2)
 
         for i in range(0, self.n, self.batch_size):
             _range = np.arange(i, min(self.n, i + self.batch_size), dtype=int)

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -358,23 +358,6 @@ class ImageSource:
 
         return im
 
-    def eval_filter_grid(self, L, power=1):
-        grid2d = grid_2d(L, dtype=self.dtype)
-        omega = np.pi * np.vstack((grid2d["x"].flatten(), grid2d["y"].flatten()))
-
-        h = np.empty((omega.shape[-1], len(self.filter_indices)), dtype=self.dtype)
-        for i, filt in enumerate(self.unique_filters):
-            idx_k = np.where(self.filter_indices == i)[0]
-            if len(idx_k) > 0:
-                filter_values = filt.evaluate(omega)
-                if power != 1:
-                    filter_values **= power
-                h[:, idx_k] = np.column_stack((filter_values,) * len(idx_k))
-
-        h = np.reshape(h, grid2d["x"].shape + (len(self.filter_indices),))
-
-        return h
-
     def cache(self):
         logger.info("Caching source images")
         self._cached_im = self.images(start=0, num=np.inf)


### PR DESCRIPTION
Address #38 

I'm not sure if this method is unnecessary. The code in `eval_filter_grid` does some manipulation with the `filter_indices` of the source that is only applicable within that class. 

It is only used in two implementations of the `Estimator.compute_kernel` method: in `aspire.reconstruction.mean` and `aspire.covariance.covar`
