### PR TITLE
Docstring for `ImageSource.eval_filters()`

### DIFF
--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -338,10 +338,21 @@ class ImageSource:
             "Subclasses should implement this and return an Image object"
         )
 
-    def eval_filters(self, im_orig, start=0, num=np.inf, indices=None):
+    def _apply_filters(self, im_orig, start=0, num=np.inf, indices=None):
+        """
+        For each image in `im_orig` specified by start, num, or indices,
+        the unique_filters associated with the corresponding index in the
+        `ImageSource` are applied. The images are then returned as an `Image`
+        stack.
+        :param im_orig: An `Image` object
+        :param start: Starting index of images in `im_orig`.
+        :param num: Number of images to work on, starting at `start`.
+        :param indices: A numpy array of image indices. If specified,`start` and `num` are ignored.
+        :return: An `Image` instance with the unique filters of the source applied at the given indices.
+        """
         if not isinstance(im_orig, Image):
             logger.warning(
-                f"eval_filters passed {type(im_orig)} instead of Image instance"
+                f"_apply_filters() passed {type(im_orig)} instead of Image instance"
             )
             # for now just convert it
             im = Image(im_orig)
@@ -530,7 +541,7 @@ class ImageSource:
         all_idx = np.arange(start, min(start + num, self.n))
         im *= self.amplitudes[all_idx, np.newaxis, np.newaxis]
         im = im.shift(-self.offsets[all_idx, :])
-        im = self.eval_filters(im, start=start, num=num)
+        im = self._apply_filters(im, start=start, num=num)
 
         vol = im.backproject(self.rots[start : start + num, :, :])[0]
 
@@ -552,7 +563,7 @@ class ImageSource:
             logger.warning(f"Volume.dtype {vol.dtype} inconsistent with {self.dtype}")
 
         im = vol.project(0, self.rots[all_idx, :, :])
-        im = self.eval_filters(im, start, num)
+        im = self._apply_filters(im, start, num)
         im = im.shift(self.offsets[all_idx, :])
         im *= self.amplitudes[all_idx, np.newaxis, np.newaxis]
         return im

--- a/src/aspire/source/simulation.py
+++ b/src/aspire/source/simulation.py
@@ -183,7 +183,7 @@ class Simulation(ImageSource):
 
         im = self.projections(start=start, num=num, indices=indices)
 
-        im = self.eval_filters(im, start=start, num=num, indices=indices)
+        im = self._apply_filters(im, start=start, num=num, indices=indices)
         im = im.shift(self.offsets[indices, :])
 
         im *= self.amplitudes[indices].reshape(len(indices), 1, 1).astype(self.dtype)


### PR DESCRIPTION
Closes #43 

This method applies the `unique_filters` of an `ImageSource` object to an `Image` passed in via `Image.filter()`. It is used in both `ImageSource.vol_forward()` and `ImageSource.im_backward()`. I don't believe it is unnecessary, but I could see some confusion arising from its placement next to `eval_filter_grid` (#38 #517), which does something a bit different and maybe doesn't belong. 

To close out this issue I propose to add a docstring for clarity, as I don't see a need to alter or remove the method. 