### PR TITLE
Avoid deprecation warnings in `importlib_resources`

### DIFF
--- a/src/aspire/__init__.py
+++ b/src/aspire/__init__.py
@@ -3,11 +3,10 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from importlib_resources import read_text
-
 import aspire
 from aspire.config import Config
 from aspire.exceptions import handle_exception
+from aspire.utils.importlib_legacy import read_text
 
 # version in maj.min.bld format
 __version__ = "0.8.1"

--- a/src/aspire/utils/importlib_legacy.py
+++ b/src/aspire/utils/importlib_legacy.py
@@ -21,9 +21,6 @@ Resource = str
 
 def normalize_path(path):
     # type: (Any) -> str
-    """Normalize a path by ensuring it is a string.
-    If the resulting string contains path separators, an exception is raised.
-    """
     str_path = str(path)
     parent, file_name = os.path.split(str_path)
     if parent:
@@ -37,7 +34,6 @@ def open_text(
     encoding: str = "utf-8",
     errors: str = "strict",
 ) -> TextIO:
-    """Return a file-like object opened for text reading of the resource."""
     return (importlib_resources.files(package) / normalize_path(resource)).open(
         "r", encoding=encoding, errors=errors
     )
@@ -49,10 +45,6 @@ def read_text(
     encoding: str = "utf-8",
     errors: str = "strict",
 ) -> str:
-    """Return the decoded string of the resource.
-    The decoding-related arguments have the same semantics as those of
-    bytes.decode().
-    """
     with open_text(package, resource, encoding, errors) as fp:
         return fp.read()
 
@@ -61,13 +53,6 @@ def path(
     package: Package,
     resource: Resource,
 ) -> ContextManager[pathlib.Path]:
-    """A context manager providing a file path object to the resource.
-    If the resource does not already exist on its own on the file system,
-    a temporary file will be created. If the file was created, the file
-    will be deleted upon exiting the context manager (no exception is
-    raised if the file was deleted prior to the context manager
-    exiting).
-    """
     return importlib_resources.as_file(
         importlib_resources.files(package) / normalize_path(resource)
     )

--- a/src/aspire/utils/importlib_legacy.py
+++ b/src/aspire/utils/importlib_legacy.py
@@ -13,10 +13,20 @@ Resource = str
 # The methods below are still supported in importlib_resources._legacy
 # but they raise warnings alerting that the new API should be used.
 
+# Details on the deprecation can be found at:
+# https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy
+
+# We have copied the methods required as a temporary measure from:
+# from https://github.com/python/importlib_resources/blob/main/importlib_resources/_legacy.py
+# These are wrappers for code using the preferred files() API that can be
+# dropped in to replace the deprecated methods
+
 # We plan to move to importlib.resources, which importlib_resources is a
 # backport of, once we have dropped support for Python 3.6. At that point
 # the package resource management code in the tests will need to be
 # rewritten with importlib.resources. This file will then be deleted.
+# importlib.resources is in the standard library from 3.7 on:
+# https://docs.python.org/3/library/importlib.html
 
 
 def normalize_path(path):

--- a/src/aspire/utils/importlib_legacy.py
+++ b/src/aspire/utils/importlib_legacy.py
@@ -1,0 +1,73 @@
+import os
+import pathlib
+import types
+from typing import Any, ContextManager, TextIO, Union
+
+import importlib_resources
+
+Package = Union[types.ModuleType, str]
+Resource = str
+
+# The purpose of this file is to suppress deprecation warnings arising
+# from using deprecated legacy methods in the importlib_resources library.
+# The methods below are still supported in importlib_resources._legacy
+# but they raise warnings alerting that the new API should be used.
+
+# We plan to move to importlib.resources, which importlib_resources is a
+# backport of, once we have dropped support for Python 3.6. At that point
+# the package resource management code in the tests will need to be
+# rewritten with importlib.resources. This file will then be deleted.
+
+
+def normalize_path(path):
+    # type: (Any) -> str
+    """Normalize a path by ensuring it is a string.
+    If the resulting string contains path separators, an exception is raised.
+    """
+    str_path = str(path)
+    parent, file_name = os.path.split(str_path)
+    if parent:
+        raise ValueError(f"{path!r} must be only a file name")
+    return file_name
+
+
+def open_text(
+    package: Package,
+    resource: Resource,
+    encoding: str = "utf-8",
+    errors: str = "strict",
+) -> TextIO:
+    """Return a file-like object opened for text reading of the resource."""
+    return (importlib_resources.files(package) / normalize_path(resource)).open(
+        "r", encoding=encoding, errors=errors
+    )
+
+
+def read_text(
+    package: Package,
+    resource: Resource,
+    encoding: str = "utf-8",
+    errors: str = "strict",
+) -> str:
+    """Return the decoded string of the resource.
+    The decoding-related arguments have the same semantics as those of
+    bytes.decode().
+    """
+    with open_text(package, resource, encoding, errors) as fp:
+        return fp.read()
+
+
+def path(
+    package: Package,
+    resource: Resource,
+) -> ContextManager[pathlib.Path]:
+    """A context manager providing a file path object to the resource.
+    If the resource does not already exist on its own on the file system,
+    a temporary file will be created. If the file was created, the file
+    will be deleted upon exiting the context manager (no exception is
+    raised if the file was deleted prior to the context manager
+    exiting).
+    """
+    return importlib_resources.as_file(
+        importlib_resources.files(package) / normalize_path(resource)
+    )

--- a/tests/test_apple.py
+++ b/tests/test_apple.py
@@ -3,9 +3,9 @@ import tempfile
 from shutil import copyfile
 from unittest import TestCase
 
-import importlib_resources
 import mrcfile
 
+import aspire.utils.importlib_legacy as importlib_resources
 import tests.saved_test_data
 from aspire.apple.apple import Apple
 

--- a/tests/test_micrograph.py
+++ b/tests/test_micrograph.py
@@ -1,7 +1,6 @@
 from unittest import TestCase
 
-import importlib_resources
-
+import aspire.utils.importlib_legacy as importlib_resources
 import tests.saved_test_data
 from aspire.storage import Micrograph
 

--- a/tests/test_mrc_stack.py
+++ b/tests/test_mrc_stack.py
@@ -1,8 +1,8 @@
 from unittest import TestCase
 
-import importlib_resources
 import numpy as np
 
+import aspire.utils.importlib_legacy as importlib_resources
 import tests.saved_test_data
 from aspire.image import Image
 from aspire.source.mrcstack import MrcStack

--- a/tests/test_starfile_stack.py
+++ b/tests/test_starfile_stack.py
@@ -2,10 +2,10 @@ import os
 import os.path
 from unittest import TestCase
 
-import importlib_resources
 import mrcfile
 import numpy as np
 
+import aspire.utils.importlib_legacy as importlib_resources
 import tests.saved_test_data
 from aspire.image import Image
 from aspire.operators import ScalarFilter

--- a/tests/test_starfileio.py
+++ b/tests/test_starfileio.py
@@ -4,11 +4,11 @@ from collections import OrderedDict
 from itertools import zip_longest
 from unittest import TestCase
 
-import importlib_resources
 import numpy as np
 from pandas import DataFrame
 from scipy import misc
 
+import aspire.utils.importlib_legacy as importlib_resources
 import tests.saved_test_data
 from aspire.image import Image
 from aspire.source import ArrayImageSource


### PR DESCRIPTION
Closes #503 

We have copied the methods that we still use from the legacy API of `importlib_resources` into a file in `aspire/utils`. This way, we can avoid the deprecation warnings.

We do this with the knowledge that `importlib_resources` will be replaced wholesale with `importlib.resources` once we drop support for Python 3.6. This is because `importlib.resources` was introduced in 3.7. Once that is done, this file will be deleted. 

The relevant methods are from https://github.com/python/importlib_resources/blob/main/importlib_resources/_legacy.py