### PR TITLE
Roll stable MacOS tests to 10.15 from 10.14

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -86,9 +86,9 @@ jobs:
     displayName: pytest
 
 - job:
-  displayName: macOS-10.14
+  displayName: macOS-10.15
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-10.15'
   strategy:
     matrix:
       Python36:


### PR DESCRIPTION
Azure MacOS-10.14 is deprecated.  (This is to force people onto 10.15, which is the currently "latest" afaict).

Soon (maybe even today) Azure will roll "latest" to MacOS-11.

Closes #511 