### PR TITLE
ImageSource Length

### DIFF
--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -128,9 +128,12 @@ class ImageSource:
         self.generation_pipeline = Pipeline(xforms=None, memory=memory)
         self._metadata_out = None
 
-        logger.info(f"Creating {self.__class__.__name} with {len(self)} images.")
+        logger.info(f"Creating {self.__class__.__name__} with {len(self)} images.")
 
     def __len__(self):
+        """
+        Returns total number of images in source.
+        """
         return self.n
         
     @property

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -135,7 +135,7 @@ class ImageSource:
         Returns total number of images in source.
         """
         return self.n
-        
+
     @property
     def states(self):
         return np.atleast_1d(self.get_metadata("_rlnClassNumber"))
@@ -817,7 +817,6 @@ class ArrayImageSource(ImageSource):
             #   which is exposed by properties `angles` and `rots`.
             self.angles = angles
 
-    
     def _rots(self):
         """
         Private method, checks if `_rotations` has been set,

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -128,6 +128,11 @@ class ImageSource:
         self.generation_pipeline = Pipeline(xforms=None, memory=memory)
         self._metadata_out = None
 
+        logger.info(f"Creating {self.__class__.__name} with {len(self)} images.")
+
+    def __len__(self):
+        return self.n
+        
     @property
     def states(self):
         return np.atleast_1d(self.get_metadata("_rlnClassNumber"))
@@ -809,6 +814,7 @@ class ArrayImageSource(ImageSource):
             #   which is exposed by properties `angles` and `rots`.
             self.angles = angles
 
+    
     def _rots(self):
         """
         Private method, checks if `_rotations` has been set,

--- a/src/aspire/source/relion.py
+++ b/src/aspire/source/relion.py
@@ -146,9 +146,6 @@ class RelionSource(ImageSource):
         self.unique_filters = filters
         self.filter_indices = filter_indices
 
-    def __len__(self):
-        return self.n
-
     def __str__(self):
         return f"RelionSource ({self.n} images of size {self.L}x{self.L})"
 

--- a/src/aspire/source/relion.py
+++ b/src/aspire/source/relion.py
@@ -146,6 +146,9 @@ class RelionSource(ImageSource):
         self.unique_filters = filters
         self.filter_indices = filter_indices
 
+    def __len__(self):
+        return self.n
+
     def __str__(self):
         return f"RelionSource ({self.n} images of size {self.L}x{self.L})"
 


### PR DESCRIPTION
This PR adds a `__len__` method to `ImageSource` that returns the total number of images from a source. In addition, a logger message with the source type and number of images is produced during `ImageSource` instantiation.

This resolves issue #407.