### PR TITLE
Remove orientation estimation setting from config

### DIFF
--- a/src/aspire/abinitio/commonline_base.py
+++ b/src/aspire/abinitio/commonline_base.py
@@ -45,7 +45,7 @@ class CLOrient3D:
         self.n_theta = n_theta
         self.n_check = n_check
         self.clmatrix = None
-        self.max_shift = max_shift * self.n_res
+        self.max_shift = math.ceil(max_shift * self.n_res)
         self.shift_step = shift_step
         self.rotations = None
 

--- a/src/aspire/abinitio/commonline_base.py
+++ b/src/aspire/abinitio/commonline_base.py
@@ -18,16 +18,24 @@ class CLOrient3D:
     Define a base class for estimating 3D orientations using common lines methods
     """
 
-    def __init__(self, src, n_rad=None, n_theta=None, n_check=None):
+    def __init__(
+        self, src, n_rad=None, n_theta=360, n_check=None, max_shift=0.15, shift_step=1
+    ):
         """
         Initialize an object for estimating 3D orientations using common lines
 
         :param src: The source object of 2D denoised or class-averaged imag
-        :param n_rad: The number of points in the radial direction
-        :param n_theta: The number of points in the theta direction
+        :param n_rad: The number of points in the radial direction. If None,
+            n_rad will default to the ceiling of half the resolution of the source.
+        :param n_theta: The number of points in the theta direction.
+            Default is 360.
         :param n_check: For each image/projection find its common-lines with
             n_check images. If n_check is less than the total number of images,
             a random subset of n_check images is used.
+        :param max_shift: Determines maximum range for shifts as a proportion
+            of the resolution. Default is 0.15.
+        :param shift_step: Resolution of shift estimation in pixels.
+            Default is 1 pixel.
         """
         self.src = src
         # Note dtype is inferred from self.src
@@ -38,7 +46,8 @@ class CLOrient3D:
         self.n_theta = n_theta
         self.n_check = n_check
         self.clmatrix = None
-
+        self.max_shift = max_shift * self.n_res
+        self.shift_step = shift_step
         self.rotations = None
 
         self._build()
@@ -48,14 +57,9 @@ class CLOrient3D:
         Build the internal data structure for orientation estimation
         """
         if self.n_rad is None:
-            self.n_rad = math.ceil(config.orient.r_ratio * self.n_res)
-        if self.n_theta is None:
-            self.n_theta = config.orient.n_theta
+            self.n_rad = math.ceil(0.5 * self.n_res)
         if self.n_check is None:
             self.n_check = self.n_img
-
-        self.max_shift = math.ceil(config.orient.max_shift * self.n_res)
-        self.shift_step = config.orient.shift_step
 
         imgs = self.src.images(start=0, num=np.inf)
 

--- a/src/aspire/abinitio/commonline_base.py
+++ b/src/aspire/abinitio/commonline_base.py
@@ -4,7 +4,6 @@ import math
 import numpy as np
 import scipy.sparse as sparse
 
-from aspire import config
 from aspire.abinitio.orientation_src import OrientEstSource
 from aspire.basis import PolarBasis2D
 from aspire.utils.coor_trans import common_line_from_rots

--- a/src/aspire/abinitio/commonline_sync.py
+++ b/src/aspire/abinitio/commonline_sync.py
@@ -179,7 +179,7 @@ class CLSyncVoting(CLOrient3D):
 
         rots = self._rotratio_eulerangle_vec(clmatrix, i, j, good_k, n_theta)
 
-        if rots.shape[0] > 0:
+        if rots is not None:
             rot_mean = np.mean(rots, 0)
             # The error to mean value can be calculated as
             #    rot_block = rots[:2, :2]
@@ -230,6 +230,8 @@ class CLSyncVoting(CLOrient3D):
 
         # Calculate the cos values of rotation angles between i an j images for good k images
         c_alpha, good_idx = self._get_cos_phis(cl_diff1, cl_diff2, cl_diff3, n_theta)
+        if len(c_alpha) == 0:
+            return None
         alpha = np.arccos(c_alpha)
 
         # Convert the Euler angles with ZXZ conversion to rotation matrices

--- a/src/aspire/abinitio/commonline_sync.py
+++ b/src/aspire/abinitio/commonline_sync.py
@@ -24,15 +24,25 @@ class CLSyncVoting(CLOrient3D):
     Journal of Structural Biology, 169, 312-322 (2010).
     """
 
-    def __init__(self, src, n_rad=None, n_theta=None):
+    def __init__(self, src, n_rad=None, n_theta=360, max_shift=0.15, shift_step=1):
         """
         Initialize an object for estimating 3D orientations using synchronization matrix
 
         :param src: The source object of 2D denoised or class-averaged images with metadata
         :param n_rad: The number of points in the radial direction
-        :param n_theta: The number of points in the theta direction
+        :param n_theta: The number of points in the theta direction.
+            Default is 360.
+        :param max_shift: Determines maximum range for shifts as a proportion
+            of the resolution. Default is 0.15.
+        :param shift_step: Resolution for shift estimation in pixels. Default is 1 pixel.
         """
-        super().__init__(src, n_rad=n_rad, n_theta=n_theta)
+        super().__init__(
+            src,
+            n_rad=n_rad,
+            n_theta=n_theta,
+            max_shift=max_shift,
+            shift_step=shift_step,
+        )
         self.syncmatrix = None
 
     def estimate_rotations(self):

--- a/src/aspire/commands/orient3d.py
+++ b/src/aspire/commands/orient3d.py
@@ -29,7 +29,41 @@ logger = logging.getLogger(__name__)
     type=int,
     help="Max number of image rows to read from STAR file",
 )
-def orient3d(data_folder, starfile_in, starfile_out, pixel_size, max_rows):
+@click.option(
+    "--n_rad",
+    default=None,
+    type=int,
+    help="Number of points in the radial direction. If None, defaults to half the resolution of the source.",
+)
+@click.option(
+    "--n_theta",
+    default=360,
+    type=int,
+    help="Number of points in the theta direction",
+)
+@click.option(
+    "--max_shift",
+    default=0.15,
+    type=float,
+    help="Maximum range for shifts as a proportion of resolution",
+)
+@click.option(
+    "--shift_step",
+    default=1,
+    type=int,
+    help="Resolution for shift estimation in pixels",
+)
+def orient3d(
+    data_folder,
+    starfile_in,
+    starfile_out,
+    pixel_size,
+    max_rows,
+    n_rad,
+    n_theta,
+    max_shift,
+    shift_step,
+):
     """
     Input images from STAR file and estimate orientational angles
     """
@@ -41,7 +75,9 @@ def orient3d(data_folder, starfile_in, starfile_out, pixel_size, max_rows):
 
     # Estimate rotation matrices
     logger.info("Estimate rotation matrices.")
-    orient_est = CLSyncVoting(source)
+    orient_est = CLSyncVoting(
+        source, n_rad=n_rad, n_theta=n_theta, max_shift=max_shift, shift_step=shift_step
+    )
     orient_est.estimate_rotations()
 
     # Create new source object and save Estimate rotation matrices

--- a/src/aspire/config.ini
+++ b/src/aspire/config.ini
@@ -23,13 +23,5 @@ regularizer = 0.
 cg_tol = 1e-5
 regularizer = 0.
 
-[orient]
-n_theta = 360
-r_ratio = 0.5
-max_shift = 0.15
-shift_step = 1
-fuzzy_mask_dims = 2
-rise_time = 2
-
 [nfft]
 backends = finufft, cufinufft, pynfft

--- a/tests/test_orient_sync.py
+++ b/tests/test_orient_sync.py
@@ -1,10 +1,13 @@
 import os
 import os.path
+import tempfile
 from unittest import TestCase
 
 import numpy as np
+from click.testing import CliRunner
 
 from aspire.abinitio import CLSyncVoting
+from aspire.commands.orient3d import orient3d
 from aspire.operators import RadialCTFFilter
 from aspire.source.simulation import Simulation
 from aspire.utils import utest_tolerance
@@ -82,3 +85,24 @@ class OrientSyncTestCase(TestCase):
         self.assertTrue(
             np.allclose(results, self.est_shifts, atol=utest_tolerance(self.dtype))
         )
+
+    def testCommandLine(self):
+        # Ensure that the command line tool works as expected
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Save the simulation object into STAR and MRCS files
+            starfile_out = os.path.join(tmpdir, "save_test.star")
+            starfile_in = os.path.join(DATA_DIR, "sample_relion_data.star")
+            result = runner.invoke(
+                orient3d,
+                [
+                    f"--starfile_in={starfile_in}",
+                    "--n_rad=10",
+                    "--n_theta=60",
+                    "--max_shift=0.15",
+                    "--shift_step=1",
+                    f"--starfile_out={starfile_out}",
+                ],
+            )
+            # check that the command completed successfully
+            self.assertTrue(result.exit_code == 0)


### PR DESCRIPTION
Remove orientation estimation settings from [orient] section of config.ini and add to default settings to `CLOrient3d` `__init__`. 

Will also update command line arguments for `aspire orient3d` command.

This will resolve issue #506.