### PR TITLE
upstream Pipeline example

### DIFF
--- a/gallery/experiments/simulated_abinitio_pipeline.py
+++ b/gallery/experiments/simulated_abinitio_pipeline.py
@@ -1,0 +1,222 @@
+"""
+ASPIRE-Python Abinitio Pipeline
+================================
+
+In this notebook we will introduce a selection of
+components corresponding to a pipeline.
+"""
+
+# %%
+# Imports
+# -------
+# First we import some of the usual suspects.
+# In addition, we import some classes from
+# the ASPIRE package that we will use throughout this experiment.
+
+import logging
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from aspire.abinitio import CLSyncVoting
+from aspire.basis import FFBBasis3D
+from aspire.classification import RIRClass2D
+from aspire.denoising import DenoiserCov2D
+from aspire.noise import AnisotropicNoiseEstimator
+from aspire.operators import FunctionFilter, RadialCTFFilter
+from aspire.reconstruction import MeanEstimator
+from aspire.source import ArrayImageSource, Simulation
+from aspire.utils.coor_trans import (
+    get_aligned_rotations,
+    get_rots_mse,
+    register_rotations,
+)
+from aspire.volume import Volume
+
+logger = logging.getLogger(__name__)
+
+# Do we want to draw blocking interactive plots?
+interactive = False
+
+# %%
+# Simulation Data
+# ---------------
+# We'll start with a fairly hi-res volume available from EMPIAR/EMDB.
+# https://www.ebi.ac.uk/emdb/EMD-2660
+# https://ftp.ebi.ac.uk/pub/databases/emdb/structures/EMD-2660/map/emd_2660.map.gz
+og_v = Volume.load("emd_2660.map", dtype=np.float64)
+logger.info("Original volume map data" f" shape: {og_v.shape} dtype:{og_v.dtype}")
+
+# Downsample the volume to a desired resolution
+img_size = 64
+
+logger.info(f"Downsampling to {(img_size,)*3}")
+v = og_v.downsample(img_size)
+L = v.resolution
+
+num_imgs = 20000  # How many images in our source.
+n_classes = 2000  # How many class averages to compute.
+n_nbor = 10  # How many neighbors to stack
+
+# Set a target noise variance
+noise_variance = 1e-4
+
+
+# Then create a filter based on that variance
+# This is an example of a custom noise profile
+def noise_function(x, y):
+    alpha = 1
+    beta = 1
+    # White
+    f1 = noise_variance
+    # Violet-ish
+    f2 = noise_variance * (x * x + y * y) / L * L
+    return (alpha * f1 + beta * f2) / 2.0
+
+
+custom_noise_filter = FunctionFilter(noise_function)
+
+logger.info("Initialize CTF filters.")
+# Create some CTF effects
+pixel_size = 5 * 65 / img_size  # Pixel size of the images (in angstroms)
+voltage = 200  # Voltage (in KV)
+defocus_min = 1.5e4  # Minimum defocus value (in angstroms)
+defocus_max = 2.5e4  # Maximum defocus value (in angstroms)
+defocus_ct = 7  # Number of defocus groups.
+Cs = 2.0  # Spherical aberration
+alpha = 0.1  # Amplitude contrast
+
+# Create filters
+ctf_filters = [
+    RadialCTFFilter(pixel_size, voltage, defocus=d, Cs=2.0, alpha=0.1)
+    for d in np.linspace(defocus_min, defocus_max, defocus_ct)
+]
+
+# Finally create the Simulation
+src = Simulation(
+    L=v.resolution,
+    n=num_imgs,
+    vols=v,
+    noise_filter=custom_noise_filter,
+    unique_filters=ctf_filters,
+)
+# Peek
+if interactive:
+    src.images(0, 10).show()
+
+# # TODO: Seemed to cause a crash, maybe dtype/blkdiag related
+# logger.info("Normalize images to background noise.")
+# src.normalize_background()
+# # Peek
+# if interactive: src.images(0, 10).show()
+
+# Currently we use phase_flip to attempt correcting for CTF.
+logger.info("Perform phase flip to input images.")
+src.phase_flip()
+
+# We should estimate the noise and `Whiten` based on the estimated noise
+aiso_noise_estimator = AnisotropicNoiseEstimator(src)
+src.whiten(aiso_noise_estimator.filter)
+
+# Plot the noise profile for inspection
+if interactive:
+    plt.imshow(aiso_noise_estimator.filter.evaluate_grid(L))
+    plt.show()
+
+# Peek, what do the whitened images look like...
+if interactive:
+    src.images(0, 10).show()
+
+# logger.info("Invert the global density contrast")
+# src.invert_contrast()
+
+# Use CWF denoising
+cwf_denoiser = DenoiserCov2D(src)
+src = cwf_denoiser.denoise()
+
+# Peek, what do the denoised images look like...
+if interactive:
+    src.images(0, 10).show()
+
+
+# Cache to memory for some speedup
+src = ArrayImageSource(src.images(0, num_imgs).asnumpy(), angles=src.angles)
+
+# %%
+# Class Averaging
+# ----------------------
+#
+# Now we perform classification and averaging for each class.
+
+logger.info("Begin Class Averaging")
+
+rir = RIRClass2D(
+    src,
+    fspca_components=400,
+    bispectrum_components=300,  # Compressed Features after last PCA stage.
+    n_nbor=n_nbor,
+    n_classes=n_classes,
+    large_pca_implementation="legacy",
+    nn_implementation="sklearn",
+    bispectrum_implementation="legacy",
+)
+
+classes, reflections, distances = rir.classify()
+# Only care about the averages returned right now.
+avgs = rir.averages(classes, reflections, distances)[0]
+if interactive:
+    avgs.images(0, 10).show()
+
+# %%
+# Common Line Estimation
+# ----------------------
+#
+# Now we can create a CL instance for estimating orientation of projections
+# using the Common Line with Synchronization Voting method.
+
+logger.info("Begin Orientation Estimation")
+
+# Stash true rotations for later comparison,
+#   note this line only works with naive class selection...
+true_rotations = src.rots[:n_classes]
+
+orient_est = CLSyncVoting(avgs, n_theta=36)
+# Get the estimated rotations
+orient_est.estimate_rotations()
+rots_est = orient_est.rotations
+
+logger.info("Compare with known rotations")
+# Compare with known true rotations
+Q_mat, flag = register_rotations(rots_est, true_rotations)
+regrot = get_aligned_rotations(rots_est, Q_mat, flag)
+mse_reg = get_rots_mse(regrot, true_rotations)
+logger.info(
+    f"MSE deviation of the estimated rotations using register_rotations : {mse_reg}\n"
+)
+
+# %%
+# Volume Reconstruction
+# ----------------------
+#
+# Using the estimated rotations, attempt to reconstruct a volume.
+
+logger.info("Begin Volume reconstruction")
+
+# Assign the estimated rotations to the class averages
+avgs.rots = rots_est
+
+# Create a reasonable Basis for the 3d Volume
+basis = FFBBasis3D((v.resolution,) * 3, dtype=v.dtype)
+
+# Setup an estimator to perform the back projection.
+estimator = MeanEstimator(avgs, basis)
+
+# Perform the estimation and save the volume.
+estimated_volume = estimator.estimate()
+fn = f"estimated_volume_n{num_imgs}_c{n_classes}_m{n_nbor}_{img_size}.mrc"
+estimated_volume.save(fn, overwrite=True)
+
+# Peek at result
+if interactive:
+    plt.imshow(np.sum(estimated_volume[0], axis=-1))
+    plt.show()

--- a/gallery/experiments/simulated_abinitio_pipeline.py
+++ b/gallery/experiments/simulated_abinitio_pipeline.py
@@ -35,8 +35,23 @@ from aspire.volume import Volume
 
 logger = logging.getLogger(__name__)
 
-# Do we want to draw blocking interactive plots?
-interactive = False
+
+# %%
+# Parameters
+# ---------------
+# Some example simulation configurations.
+# Small sim: img_size 32, num_imgs 10000, n_classes 1000, n_nbor 10
+# Medium sim: img_size 64, num_imgs 20000, n_classes 2000, n_nbor 10
+# Large sim: img_size 129, num_imgs 30000, n_classes 2000, n_nbor 20
+
+interactive = True  # Do we want to draw blocking interactive plots?
+do_cov2d = False  # Use CWF coefficients
+img_size = 32  # Downsample the volume to a desired resolution
+num_imgs = 10000  # How many images in our source.
+n_classes = 1000  # How many class averages to compute.
+n_nbor = 10  # How many neighbors to stack
+noise_variance = 1e-4  # Set a target noise variance
+
 
 # %%
 # Simulation Data
@@ -47,19 +62,9 @@ interactive = False
 og_v = Volume.load("emd_2660.map", dtype=np.float64)
 logger.info("Original volume map data" f" shape: {og_v.shape} dtype:{og_v.dtype}")
 
-# Downsample the volume to a desired resolution
-img_size = 64
-
 logger.info(f"Downsampling to {(img_size,)*3}")
 v = og_v.downsample(img_size)
 L = v.resolution
-
-num_imgs = 20000  # How many images in our source.
-n_classes = 2000  # How many class averages to compute.
-n_nbor = 10  # How many neighbors to stack
-
-# Set a target noise variance
-noise_variance = 1e-4
 
 
 # Then create a filter based on that variance
@@ -130,9 +135,11 @@ if interactive:
 # logger.info("Invert the global density contrast")
 # src.invert_contrast()
 
-# Use CWF denoising
-cwf_denoiser = DenoiserCov2D(src)
-src = cwf_denoiser.denoise()
+# # On Simulation data, better results so far were achieved without cov2d.
+if do_cov2d:
+    # Use CWF denoising
+    cwf_denoiser = DenoiserCov2D(src)
+    src = cwf_denoiser.denoise()
 
 # Peek, what do the denoised images look like...
 if interactive:

--- a/gallery/tutorials/class_averaging.py
+++ b/gallery/tutorials/class_averaging.py
@@ -116,13 +116,15 @@ rir = RIRClass2D(
     bispectrum_implementation="legacy",
 )
 
-classes, reflections, rotations, shifts, corr = rir.classify()
+classes, reflections, dists = rir.classify()
+avgs, classes, reflections, rotations, shifts, corrs = rir.averages(
+    classes, reflections, dists
+)
 
 # %%
 # Display Classes
 # ^^^^^^^^^^^^^^^
 
-avgs = rir.output(classes, reflections, rotations)
 avgs.images(0, 10).show()
 
 # %%
@@ -169,13 +171,15 @@ noisy_rir = RIRClass2D(
     bispectrum_implementation="legacy",
 )
 
-classes, reflections, rotations, shifts, corr = noisy_rir.classify()
+classes, reflections, dists = noisy_rir.classify()
+avgs, classes, reflections, rotations, shifts, corrs = noisy_rir.averages(
+    classes, reflections, dists
+)
 
 # %%
 # Display Classes
 # ^^^^^^^^^^^^^^^
 
-avgs = noisy_rir.output(classes, reflections, rotations)
 avgs.images(0, 10).show()
 
 

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         "pillow",
         "scipy==1.7.3",
         "scikit-learn",
+        "scikit-image",
         "setuptools>=0.41",
         "tqdm",
     ],

--- a/src/aspire/basis/basis_utils.py
+++ b/src/aspire/basis/basis_utils.py
@@ -98,18 +98,10 @@ def norm_assoc_legendre(j, m, x):
         y = (-1) ** m * norm_assoc_legendre(j, m, x)
     else:
         y = lpmv(m, j, x)
-        # Beware of using just np.prod in the denominator here
-        # Unless we use float64, values in the denominator > 13! will be incorrect
-        try:
-            y = (
-                np.sqrt(
-                    (2 * j + 1)
-                    / (2 * np.prod(range(j - m + 1, j + m + 1), dtype=np.float64))
-                )
-                * y
-            )
-        except RuntimeWarning:
-            logger.error("debug")
+        y *= np.sqrt((2 * j + 1) / 2)
+        # Beware of overflow here.
+        y /= np.prod(np.sqrt(np.arange(j - m + 1, j + m + 1), dtype=np.float64))
+
     return y
 
 

--- a/src/aspire/classification/__init__.py
+++ b/src/aspire/classification/__init__.py
@@ -3,8 +3,10 @@ from .align2d import (
     AveragedAlign2D,
     BFRAlign2D,
     BFSRAlign2D,
+    BFSReddyChatterjiAlign2D,
     EMAlign2D,
     FTKAlign2D,
+    ReddyChatterjiAlign2D,
 )
 from .class2d import Class2D
 from .rir_class2d import RIRClass2D

--- a/src/aspire/classification/__init__.py
+++ b/src/aspire/classification/__init__.py
@@ -1,3 +1,10 @@
-from .align2d import Align2D, BFRAlign2D, BFSRAlign2D, EMAlign2D, FTKAlign2D
+from .align2d import (
+    Align2D,
+    AveragedAlign2D,
+    BFRAlign2D,
+    BFSRAlign2D,
+    EMAlign2D,
+    FTKAlign2D,
+)
 from .class2d import Class2D
 from .rir_class2d import RIRClass2D

--- a/src/aspire/classification/align2d.py
+++ b/src/aspire/classification/align2d.py
@@ -2,11 +2,17 @@ import logging
 from abc import ABC, abstractmethod
 from itertools import product
 
+import matplotlib.pyplot as plt
 import numpy as np
+from skimage.filters import difference_of_gaussians, window
+
+# import skimage.io
+from skimage.transform import rotate, warp_polar
 from tqdm import tqdm, trange
 
 from aspire.image import Image
 from aspire.source import ArrayImageSource
+from aspire.utils.coor_trans import grid_2d
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +22,9 @@ class Align2D(ABC):
     Base class for 2D Image Alignment methods.
     """
 
-    def __init__(self, alignment_basis, source, composite_basis=None, dtype=None):
+    def __init__(
+        self, alignment_basis, source, composite_basis=None, batch_size=512, dtype=None
+    ):
         """
         :param alignment_basis: Basis to be used during alignment (eg FSPCA)
         :param source: Source of original images.
@@ -28,14 +36,27 @@ class Align2D(ABC):
         # if composite_basis is None, use alignment_basis
         self.composite_basis = composite_basis or self.alignment_basis
         self.src = source
+        self.batch_size = batch_size
         if dtype is None:
-            self.dtype = self.alignment_basis.dtype
+            if self.composite_basis:
+                self.dtype = self.composite_basis.dtype
+            elif self.src:
+                self.dtype = self.src.dtype
+            else:
+                raise RuntimeError("You must supply a basis/src/dtype.")
         else:
             self.dtype = np.dtype(dtype)
-            if self.dtype != self.alignment_basis.dtype:
-                logger.warning(
-                    f"Align2D alignment_basis.dtype {self.alignment_basis.dtype} does not match self.dtype {self.dtype}."
-                )
+
+        if self.src and self.dtype != self.src.dtype:
+            logger.warning(
+                f"{self.__class__.__name__} dtype {dtype}"
+                "does not match dtype of source {self.src.dtype}."
+            )
+        if self.composite_basis and self.dtype != self.composite_basis.dtype:
+            logger.warning(
+                f"{self.__class__.__name__} dtype {dtype}"
+                "does not match dtype of basis {self.composite_basis.dtype}."
+            )
 
     @abstractmethod
     def align(self, classes, reflections, basis_coefficients):
@@ -44,10 +65,10 @@ class Align2D(ABC):
         and return aligned images.
 
         During this process `rotations`, `reflections`, `shifts` and
-        `correlations` propeties will be computed for aligners
+        `correlations` properties will be computed for aligners
         that implement them.
 
-        `rotations` would be an (n_classes, n_nbor) array of angles,
+        `rotations` is an (n_classes, n_nbor) array of angles,
         which should represent the rotations needed to align images within
         that class. `rotations` is measured in Radians.
 
@@ -67,6 +88,46 @@ class Align2D(ABC):
 
         :returns: Image instance (stack of images)
         """
+
+    def _images(self, cls):
+        """
+        Util to return images as an array for class k (provided as array `cls` ),
+        preserving the class/nbor order.
+
+        :param cls: An iterable (0/1-D array or list) that holds the indices of images to align. In Class Averaging, this would be a class.
+        """
+
+        n_nbor = cls.shape[-1]  # Includes zero'th neighbor
+
+        # Get the images. We'll loop over the source in batches.
+        #  Note one day when the Source.images is more flexible,
+        #  this code would mostly go away.
+        images = np.empty((n_nbor, self.src.L, self.src.L), dtype=self.dtype)
+
+        # We want to only process batches that actually
+        # contain images for this class.
+        #   First compute the batches' indices.
+        for start in range(0, self.src.n + 1, self.batch_size):
+            # First cook up the batch boundaries
+            end = start + self.batch_size
+            # UBound, these are inclusive bounds
+            start = min(start, self.src.n - 1)
+            end = min(end, self.src.n - 1)
+            num = end - start + 1
+
+            # Second, loop over the cls members
+            image_batch = None
+            for i, index in enumerate(cls):
+                # Check if the member is in this chunk
+                if start <= index <= end:
+                    # Get and cache this image_batch on first hit.
+                    if image_batch is None:
+                        image_batch = self.src.images(start, num)
+                    # Translate the cls's index into this batch's
+                    batch_index = index % self.batch_size
+                    images[i] = image_batch[batch_index]
+
+        return images
 
 
 class AveragedAlign2D(Align2D):
@@ -104,21 +165,23 @@ class AveragedAlign2D(Align2D):
         """
         n_classes, n_nbor = classes.shape
 
-        # TODO: don't load all the images here.
-        imgs = self.src.images(0, self.src.n)
         b_avgs = np.empty((n_classes, self.composite_basis.count), dtype=self.src.dtype)
 
         for i in tqdm(range(n_classes)):
-            # Get the neighbors
-            neighbors_ids = classes[i]
 
-            # Get coefs in Composite_Basis if not provided as an argument.
+            # Get coefs in Composite_Basis if not provided as an argumen.
             if coefs is None:
-                neighbors_imgs = Image(imgs[neighbors_ids])
+                # Retrieve relavent images directly from source.
+                neighbors_imgs = Image(self._images(classes[i]))
+
+                # Do shifts
                 if shifts is not None:
                     neighbors_imgs.shift(shifts[i])
+
                 neighbors_coefs = self.composite_basis.evaluate_t(neighbors_imgs)
             else:
+                # Get the neighbors
+                neighbors_ids = classes[i]
                 neighbors_coefs = coefs[neighbors_ids]
                 if shifts is not None:
                     neighbors_coefs = self.composite_basis.shift(
@@ -147,14 +210,20 @@ class BFRAlign2D(AveragedAlign2D):
     """
 
     def __init__(
-        self, alignment_basis, source, composite_basis=None, n_angles=359, dtype=None
+        self,
+        alignment_basis,
+        source,
+        composite_basis=None,
+        n_angles=359,
+        batch_size=512,
+        dtype=None,
     ):
         """
         :params alignment_basis: Basis providing a `rotate` method.
         :param source: Source of original images.
         :params n_angles: Number of brute force rotations to attempt, defaults 359.
         """
-        super().__init__(alignment_basis, source, composite_basis, dtype)
+        super().__init__(alignment_basis, source, composite_basis, batch_size, dtype)
 
         self.n_angles = n_angles
 
@@ -230,6 +299,7 @@ class BFSRAlign2D(BFRAlign2D):
         n_angles=359,
         n_x_shifts=1,
         n_y_shifts=1,
+        batch_size=512,
         dtype=None,
     ):
         """
@@ -245,7 +315,14 @@ class BFSRAlign2D(BFRAlign2D):
         :params n_x_shifts: +- Number of brute force xshifts to attempt, defaults 1.
         :params n_y_shifts: +- Number of brute force xshifts to attempt, defaults 1.
         """
-        super().__init__(alignment_basis, source, composite_basis, n_angles, dtype)
+        super().__init__(
+            alignment_basis,
+            source,
+            composite_basis,
+            n_angles,
+            batch_size=batch_size,
+            dtype=dtype,
+        )
 
         self.n_x_shifts = n_x_shifts
         self.n_y_shifts = n_y_shifts
@@ -293,7 +370,7 @@ class BFSRAlign2D(BFRAlign2D):
         # Loop over shift search space, updating best result
         for x, y in product(x_shifts, y_shifts):
             shift = np.array([x, y], dtype=int)
-            logger.info(f"Computing Rotational alignment after shift ({x},{y}).")
+            logger.debug(f"Computing Rotational alignment after shift ({x},{y}).")
 
             # Shift the coef representing the first (base) entry in each class
             #   by the negation of the shift
@@ -317,16 +394,584 @@ class BFSRAlign2D(BFRAlign2D):
             basis_coefficients[classes[:, 0], :] = original_coef
 
             if (x, y) == (0, 0):
-                logger.info("Initial rotational alignment complete (shift (0,0))")
+                logger.debug("Initial rotational alignment complete (shift (0,0))")
                 assert np.sum(improved_indices) == np.size(
                     classes
                 ), f"{np.sum(improved_indices)} =?= {np.size(classes)}"
             else:
-                logger.info(
+                logger.debug(
                     f"Shift ({x},{y}) complete. Improved {np.sum(improved_indices)} alignments."
                 )
 
         return classes, reflections, rotations, shifts, correlations
+
+
+class ReddyChatterjiAlign2D(AveragedAlign2D):
+    """
+    Attempts rotational estimation using Reddy Chatterji log polar Fourier cross correlation.
+    Then attempts shift (translational) estimation using cross correlation.
+
+    When averaging, performs rotations then shifts.
+
+    Note, it may be possible to iterate this algorithm...
+
+    Adopted from Reddy Chatterji  (1996)
+    An FFT-Based Technique for Translation,
+    Rotation, and Scale-Invariant Image Registration
+    IEEE TRANSACTIONS ON IMAGE PROCESSING, VOL. 5, NO. 8, AUGUST 1996
+
+    This method intentionally does not use any of ASPIRE's basis
+    so that it may be used as a reference for more ASPIRE approaches.
+    """
+
+    def __init__(
+        self,
+        alignment_basis,
+        source,
+        composite_basis=None,
+        diagnostics=False,
+        batch_size=512,
+        dtype=None,
+    ):
+        """
+        :param alignment_basis: Basis to be used during alignment (eg FSPCA)
+        :param source: Source of original images.
+        :param composite_basis:  Basis to be used during class average composition (eg FFB2D)
+        :param dtype: Numpy dtype to be used during alignment.
+        """
+
+        self.__cache = dict()
+        self.diagnostics = diagnostics
+        self.do_cross_corr_translations = True
+
+        super().__init__(
+            alignment_basis, source, composite_basis, batch_size=batch_size, dtype=dtype
+        )
+
+    def _phase_cross_correlation(self, img0, img1):
+        """
+        # Adapted from skimage.registration.phase_cross_correlation
+
+        :param img0: Fixed image.
+        :param img1: Translated image.
+        :returns: (cross-correlation magnitudes (2D array), shifts)
+        """
+
+        # Cache img0 transform, this saves n_classes*(n_nbor-1) transforms
+        # Note we use the `id` because ndarray are unhashable
+        src_f = self.__cache.setdefault(id(img0), np.fft.fft2(img0))
+
+        target_f = np.fft.fft2(img1)
+
+        # Whole-pixel shifts - Compute cross-correlation by an IFFT
+        shape = src_f.shape
+        image_product = src_f * target_f.conj()
+        cross_correlation = np.fft.ifft2(image_product)
+
+        # Locate maximum
+        maxima = np.unravel_index(
+            np.argmax(np.abs(cross_correlation)), cross_correlation.shape
+        )
+        midpoints = np.array([np.fix(axis_size / 2) for axis_size in shape])
+
+        shifts = np.array(maxima, dtype=np.float64)
+        shifts[shifts > midpoints] -= np.array(shape)[shifts > midpoints]
+
+        return np.abs(cross_correlation), shifts
+
+    def _align(self, classes, reflections, basis_coefficients):
+        """
+        Performs the actual rotational alignment estimation,
+        returning parameters needed for averaging.
+        """
+
+        # Admit simple case of single case alignment
+        classes = np.atleast_2d(classes)
+        reflections = np.atleast_2d(reflections)
+
+        n_classes = classes.shape[0]
+
+        # Instantiate matrices for results
+        rotations = np.zeros(classes.shape, dtype=self.dtype)
+        correlations = np.zeros(classes.shape, dtype=self.dtype)
+        shifts = np.zeros((*classes.shape, 2), dtype=int)
+
+        for k in trange(n_classes):
+            # # Get the array of images for this class
+            images = self._images(classes[k])
+
+            self._reddychatterji(
+                k, images, classes, reflections, rotations, correlations, shifts
+            )
+
+        return classes, reflections, rotations, shifts, correlations
+
+    def _reddychatterji(
+        self, k, images, classes, reflections, rotations, correlations, shifts
+    ):
+        """
+        Compute the Reddy Chatterji registering  images[1:] to image[0].
+
+        This differs from papers and published scikit implimentations by
+        computing the fixed base image[0] pipeline once then reusing.
+        """
+
+        # De-Mean
+        images -= images.mean(axis=(-1, -2))[:, np.newaxis, np.newaxis]
+
+        # Precompute fixed_img data used repeatedly in the loop below.
+        fixed_img = images[0]
+        # Difference of Gaussians (Band Filter)
+        fixed_img_dog = difference_of_gaussians(fixed_img, 1, 4)
+        # Window Images (Fix spectral boundary)
+        wfixed_img = fixed_img_dog * window("hann", fixed_img.shape)
+        # Transform image to Fourier space
+        fixed_img_fs = np.abs(np.fft.fftshift(np.fft.fft2(wfixed_img))) ** 2
+        # Compute Log Polar Transform
+        radius = fixed_img_fs.shape[0] // 8  # Low Pass
+        warped_fixed_img_fs = warp_polar(
+            fixed_img_fs,
+            radius=radius,
+            output_shape=fixed_img_fs.shape,
+            scaling="log",
+        )
+        # Only use half of FFT, because it's symmetrical
+        warped_fixed_img_fs = warped_fixed_img_fs[: fixed_img_fs.shape[0] // 2, :]
+
+        # Now prepare for rotating original images,
+        #   and searching for translations.
+        # We start back at the raw fixed_img.
+        twfixed_img = fixed_img * window("hann", fixed_img.shape)
+
+        # Register image `m` against image[0]
+        for m in range(1, len(images)):
+            # Get the image to register
+            regis_img = images[m]
+
+            # Reflect images when nessecary
+            if reflections[k][m]:
+                regis_img = np.flipud(regis_img)
+
+            # Difference of Gaussians (Band Filter)
+            regis_img_dog = difference_of_gaussians(regis_img, 1, 4)
+
+            # Window Images (Fix spectral boundary)
+            wregis_img = regis_img_dog * window("hann", regis_img.shape)
+
+            self._input_images_diagnostic(
+                classes[k][0], wfixed_img, classes[k][m], wregis_img
+            )
+
+            # Transform image to Fourier space
+            regis_img_fs = np.abs(np.fft.fftshift(np.fft.fft2(wregis_img))) ** 2
+
+            self._windowed_psd_diagnostic(
+                classes[k][0], fixed_img_fs, classes[k][m], regis_img_fs
+            )
+
+            # Compute Log Polar Transform
+            warped_regis_img_fs = warp_polar(
+                regis_img_fs,
+                radius=radius,  # Low Pass
+                output_shape=fixed_img_fs.shape,
+                scaling="log",
+            )
+
+            self._log_polar_diagnostic(
+                classes[k][0], warped_fixed_img_fs, classes[k][m], warped_regis_img_fs
+            )
+
+            # Only use half of FFT, because it's symmetrical
+            warped_regis_img_fs = warped_regis_img_fs[: fixed_img_fs.shape[0] // 2, :]
+
+            # Compute the Cross_Correlation to estimate rotation
+            # Note that _phase_cross_correlation uses the mangnitudes (abs()),
+            #  ie it is using both freq and phase information.
+            cross_correlation, shift = self._phase_cross_correlation(
+                warped_fixed_img_fs, warped_regis_img_fs
+            )
+
+            cross_correlation_score = cross_correlation[:, 0].ravel()
+
+            self._rotation_cross_corr_diagnostic(
+                cross_correlation, cross_correlation_score
+            )
+
+            # Recover the angle from index representing maximal cross_correlation
+            recovered_angle_degrees = (360 / regis_img_fs.shape[0]) * np.argmax(
+                cross_correlation_score
+            )
+
+            if recovered_angle_degrees > 90:
+                r = 180 - recovered_angle_degrees
+            else:
+                r = -recovered_angle_degrees
+
+            # Dont like this, but I got stumped/frustrated.
+            # For now, try the hack below, attempting two cases ...
+            # Most of the papers mention running the whole algo /twice/,
+            #   when admitting reflections, so this hack is not
+            #   the worst you could do :).
+            # if reflections[k][m]:
+            #     if 0<= r < 90:
+            #         r -= 180
+            # Hack
+            regis_img_estimated = rotate(regis_img, r)
+            regis_img_rotated_p180 = rotate(regis_img, r + 180)
+            da = np.dot(fixed_img.flatten(), regis_img_estimated.flatten())
+            db = np.dot(fixed_img.flatten(), regis_img_rotated_p180.flatten())
+            if db > da:
+                regis_img_estimated = regis_img_rotated_p180
+                r += 180
+
+            self._rotated_diagnostic(
+                classes[k][0],
+                fixed_img,
+                classes[k][m],
+                regis_img_estimated,
+                reflections[k][m],
+                r,
+            )
+
+            # Assign estimated rotations results
+            rotations[k][m] = -r * np.pi / 180  # Reverse rot and convert to radians
+
+            if self.do_cross_corr_translations:
+                # Prepare for searching over translations using cross-correlation with the rotated image.
+                twregis_img = regis_img_estimated * window("hann", regis_img.shape)
+                cross_correlation, shift = self._phase_cross_correlation(
+                    twfixed_img, twregis_img
+                )
+
+                self._translation_cross_corr_diagnostic(cross_correlation)
+
+                # Compute the shifts as integer number of pixels,
+                shift_x, shift_y = int(shift[1]), int(shift[0])
+                # then apply the shifts
+                regis_img_estimated = np.roll(regis_img_estimated, shift_y, axis=0)
+                regis_img_estimated = np.roll(regis_img_estimated, shift_x, axis=1)
+                # Assign estimated shift to results
+                shifts[k][m] = shift[::-1].astype(int)
+
+                self._averaged_diagnostic(
+                    classes[k][0],
+                    fixed_img,
+                    classes[k][m],
+                    regis_img_estimated,
+                    reflections[k][m],
+                    r,
+                )
+            else:
+                shift = None  # For logger line
+
+            # Estimated `corr` metric
+            corr = np.dot(fixed_img.flatten(), regis_img_estimated.flatten())
+            correlations[k][m] = corr
+
+            logger.debug(
+                f"Class {k}, ref {classes[k][0]}, Neighbor {m} Index {classes[k][m]}"
+                f" Estimates: {r}*, Shift: {shift},"
+                f" Corr: {corr}, Refl?: {reflections[k][m]}"
+            )
+
+        # Cleanup some cached stuff for this class
+        self.__cache.pop(id(warped_fixed_img_fs), None)
+        self.__cache.pop(id(twfixed_img), None)
+
+    def average(
+        self,
+        classes,
+        reflections,
+        rotations,
+        shifts=None,
+        coefs=None,
+    ):
+        """
+        This averages classes performing rotations then shifts.
+        Otherwise is similar to `AveragedAlign2D.average`.
+        """
+        n_classes, n_nbor = classes.shape
+
+        b_avgs = np.empty((n_classes, self.composite_basis.count), dtype=self.src.dtype)
+
+        for i in tqdm(range(n_classes)):
+
+            # Get coefs in Composite_Basis if not provided as an argument.
+            if coefs is None:
+                # Retrieve relavent images directly from source.
+                neighbors_imgs = Image(self._images(classes[i]))
+                neighbors_coefs = self.composite_basis.evaluate_t(neighbors_imgs)
+            else:
+                # Get the neighbors
+                neighbors_ids = classes[i]
+                neighbors_coefs = coefs[neighbors_ids]
+
+            # Rotate in composite_basis
+            neighbors_coefs = self.composite_basis.rotate(
+                neighbors_coefs, rotations[i], reflections[i]
+            )
+
+            # Note shifts are after rotation for this approach!
+            if shifts is not None:
+                neighbors_coefs = self.composite_basis.shift(neighbors_coefs, shifts[i])
+
+            # Averaging in composite_basis
+            b_avgs[i] = np.mean(neighbors_coefs, axis=0)
+
+        # Now we convert the averaged images from Basis to Cartesian.
+        return ArrayImageSource(self.composite_basis.evaluate(b_avgs))
+
+    def _input_images_diagnostic(self, ia, a, ib, b):
+        if not self.diagnostics:
+            return
+        fig, axes = plt.subplots(1, 2)
+        ax = axes.ravel()
+        ax[0].set_title(f"Image {ia}")
+        ax[0].imshow(a)
+        ax[1].set_title(f"Image {ib}")
+        ax[1].imshow(b)
+        plt.show()
+
+    def _windowed_psd_diagnostic(self, ia, a, ib, b):
+        if not self.diagnostics:
+            return
+        fig, axes = plt.subplots(1, 2)
+        ax = axes.ravel()
+        ax[0].set_title(f"Image {ia} PSD")
+        ax[0].imshow(np.log(a))
+        ax[1].set_title(f"Image {ib} PSD")
+        ax[1].imshow(np.log(b))
+        plt.show()
+
+    def _log_polar_diagnostic(self, ia, a, ib, b):
+        if not self.diagnostics:
+            return
+        labels = np.arange(0, 360, 60)
+        y = labels / (360 / a.shape[0])
+
+        fig, axes = plt.subplots(1, 2)
+        ax = axes.ravel()
+        ax[0].set_title(f"Image {ia}")
+        ax[0].imshow(a)
+        ax[0].set_yticks(y, minor=False)
+        ax[0].set_yticklabels(labels)
+        ax[0].set_ylabel("Theta (Degrees)")
+
+        ax[1].set_title(f"Image {ib}")
+        ax[1].imshow(b)
+        ax[1].set_yticks(y, minor=False)
+        ax[1].set_yticklabels(labels)
+        plt.show()
+
+    def _rotation_cross_corr_diagnostic(
+        self, cross_correlation, cross_correlation_score
+    ):
+        if not self.diagnostics:
+            return
+        labels = [0, 30, 60, 90, -60, -30]
+        x = y = np.arange(0, 180, 30) / (180 / cross_correlation.shape[0])
+        plt.title("Rotation Cross Correlation Map")
+        plt.imshow(cross_correlation)
+        plt.xlabel("Scale")
+        plt.yticks(y, labels, rotation="vertical")
+        plt.ylabel("Theta (Degrees)")
+        plt.show()
+
+        plt.plot(cross_correlation_score)
+        plt.title("Angle vs Cross Correlation Score")
+        plt.xticks(x, labels)
+        plt.xlabel("Theta (Degrees)")
+        plt.ylabel("Cross Correlation Score")
+        plt.grid()
+        plt.show()
+
+    def _rotated_diagnostic(self, ia, a, ib, b, sb, rb):
+        """
+        Plot the image after estimated rotation and reflection.
+
+        :param ia: index image `a`
+        :param a: image `a`
+        :param ib: index image `b`
+        :param b: image `b` after reflection `sb` and rotion `rb`
+        :param sb: Reflection, Boolean
+        :param rb: Estimated rotation, degrees
+        """
+
+        if not self.diagnostics:
+            return
+
+        fig, axes = plt.subplots(1, 2)
+        ax = axes.ravel()
+        ax[0].set_title(f"Image {ia}")
+        ax[0].imshow(a)
+        ax[0].grid()
+        ax[1].set_title(f"Image {ib} Refl: {str(sb)[0]} Rotated {rb:.1f}")
+        ax[1].imshow(b)
+        ax[1].grid()
+        plt.show()
+
+    def _translation_cross_corr_diagnostic(self, cross_correlation):
+        if not self.diagnostics:
+            return
+        plt.title("Translation Cross Correlation Map")
+        plt.imshow(cross_correlation)
+        plt.xlabel("x shift (pixels)")
+        plt.ylabel("y shift (pixels)")
+        L = self.src.L
+        labels = [0, 10, 20, 30, 0, -10, -20, -30]
+        tick_location = [0, 10, 20, 30, L, L - 10, L - 20, L - 30]
+        plt.xticks(tick_location, labels)
+        plt.yticks(tick_location, labels)
+        plt.show()
+
+    def _averaged_diagnostic(self, ia, a, ib, b, sb, rb):
+        """
+        Plot the stacked average image after
+        estimated rotation and reflections.
+
+        Compare in a three way plot.
+
+        :param ia: index image `a`
+        :param a: image `a`
+        :param ib: index image `b`
+        :param b: image `b` after reflection `sb` and rotion `rb`
+        :param sb: Reflection, Boolean
+        :param rb: Estimated rotation, degrees
+        """
+        if not self.diagnostics:
+            return
+        fig, axes = plt.subplots(1, 3)
+        ax = axes.ravel()
+        ax[0].set_title(f"{ia}")
+        ax[0].imshow(a)
+        ax[0].grid()
+        ax[1].set_title(f"{ib} Refl: {str(sb)[0]} Rot: {rb:.1f}")
+        ax[1].imshow(b)
+        ax[1].grid()
+        ax[2].set_title("Stacked Avg")
+        plt.imshow((a + b) / 2.0)
+        ax[2].grid()
+        plt.show()
+
+
+class BFSReddyChatterjiAlign2D(ReddyChatterjiAlign2D):
+    """
+    Brute Force Shifts (Translations) - ReddyChatterji (Log-Polar) Rotations
+
+    For each shift within `radius`, attempts rotational match using ReddyChatterji.
+    When averaging, performs shift before rotations,
+
+    Adopted from Reddy Chatterji  (1996)
+    An FFT-Based Technique for Translation,
+    Rotation, and Scale-Invariant Image Registration
+    IEEE TRANSACTIONS ON IMAGE PROCESSING, VOL. 5, NO. 8, AUGUST 1996
+
+    This method intentionally does not use any of ASPIRE's basis
+    so that it may be used as a reference for more ASPIRE approaches.
+    """
+
+    def __init__(
+        self,
+        alignment_basis,
+        source,
+        composite_basis=None,
+        radius=None,
+        diagnostics=False,
+        batch_size=512,
+        dtype=None,
+    ):
+        """
+        :param alignment_basis: Basis to be used during alignment (eg FSPCA)
+        :param source: Source of original images.
+        :param composite_basis:  Basis to be used during class average composition (eg FFB2D)
+        :param radius: Brute force translation search radius.
+        Defaults to source.L//8.
+        :param diagnostics: Plot interactive diagnostic graphics (for debugging).
+        :param dtype: Numpy dtype to be used during alignment.
+        """
+
+        super().__init__(
+            alignment_basis,
+            source,
+            composite_basis,
+            diagnostics,
+            batch_size=batch_size,
+            dtype=dtype,
+        )
+
+        # For brute force we disable the cross_corr translation code
+        self.do_cross_corr_translations = False
+        # Assign search radius
+        self.radius = radius or source.L // 8
+
+    def _align(self, classes, reflections, basis_coefficients):
+        """
+        Performs the actual rotational alignment estimation,
+        returning parameters needed for averaging.
+        """
+
+        # Admit simple case of single case alignment
+        classes = np.atleast_2d(classes)
+        reflections = np.atleast_2d(reflections)
+
+        n_classes, n_nbor = classes.shape
+        L = self.src.L
+
+        # Instantiate matrices for inner loop, and best results.
+        _rotations = np.zeros(classes.shape, dtype=self.dtype)
+        rotations = np.zeros(classes.shape, dtype=self.dtype)
+        _correlations = np.zeros(classes.shape, dtype=self.dtype)
+        correlations = np.ones(classes.shape, dtype=self.dtype) * -np.inf
+        _shifts = np.zeros((*classes.shape, 2), dtype=int)
+        shifts = np.zeros((*classes.shape, 2), dtype=int)
+
+        # We'll brute force all shifts in a grid.
+        g = grid_2d(L, normalized=False)
+        disc = g["r"] <= L // 8  # make param later
+        X, Y = g["x"][disc], g["y"][disc]
+
+        for k in trange(n_classes):
+            unshifted_images = self._images(classes[k])
+
+            for xs, ys in zip(X, Y):
+                s = np.array([xs, ys])
+                # Get the array of images for this class
+
+                images = unshifted_images.copy()
+                # Don't shift the base image
+                images[1:] = Image(unshifted_images[1:]).shift(s).asnumpy()
+
+                self._reddychatterji(
+                    k, images, classes, reflections, _rotations, _correlations, _shifts
+                )
+
+                # Where corr has improved
+                #  update our rolling best results with this loop.
+                improved = _correlations > correlations
+                correlations = np.where(improved, _correlations, correlations)
+                rotations = np.where(improved, _rotations, rotations)
+                shifts = np.where(shifts, _shifts, shifts)
+                logger.debug(f"Shift {s} has improved {np.sum(improved)} results")
+
+        return classes, reflections, rotations, shifts, correlations
+
+    def average(
+        self,
+        classes,
+        reflections,
+        rotations,
+        shifts=None,
+        coefs=None,
+    ):
+        """
+        See AveragedAlign2D.average.
+        """
+        # ReddyChatterjiAlign2D does rotations then shifts.
+        # For brute force, we'd like shifts then rotations,
+        #   as is done in gerneral via AveragedAlign2D.
+        return AveragedAlign2D.average(
+            self, classes, reflections, rotations, shifts, coefs
+        )
 
 
 class EMAlign2D(Align2D):

--- a/src/aspire/classification/align2d.py
+++ b/src/aspire/classification/align2d.py
@@ -107,9 +107,9 @@ class Align2D(ABC):
         # We want to only process batches that actually
         # contain images for this class.
         #   First compute the batches' indices.
-        for start in range(0, self.src.n + 1, self.batch_size):
+        for start in range(0, self.src.n, self.batch_size):
             # First cook up the batch boundaries
-            end = start + self.batch_size
+            end = start + self.batch_size - 1
             # UBound, these are inclusive bounds
             start = min(start, self.src.n - 1)
             end = min(end, self.src.n - 1)

--- a/src/aspire/classification/class2d.py
+++ b/src/aspire/classification/class2d.py
@@ -1,11 +1,12 @@
 import logging
+from abc import ABC
 
 import numpy as np
 
 logger = logging.getLogger(__name__)
 
 
-class Class2D:
+class Class2D(ABC):
     """
     Base class for 2D Image Classification methods.
     """
@@ -41,3 +42,15 @@ class Class2D:
         self.n_nbor = n_nbor
         self.n_classes = n_classes
         self.seed = seed
+
+    def classify(self):
+        """
+        Classify the images from Source into classes with similar viewing angles.
+
+        Returns classes and associated metadata (classes, reflections, distances)
+        """
+
+    def averages(self, classes, refl, distances):
+        """
+        Returns class averages using prescribed `aligner`.
+        """

--- a/src/aspire/classification/rir_class2d.py
+++ b/src/aspire/classification/rir_class2d.py
@@ -6,11 +6,10 @@ from sklearn.neighbors import NearestNeighbors
 from tqdm import tqdm
 
 from aspire.basis import FSPCABasis
-from aspire.classification import BFRAlign2D, Class2D
+from aspire.classification import Class2D
+from aspire.classification.align2d import BFSReddyChatterjiAlign2D
 from aspire.classification.legacy_implementations import bispec_2drot_large, pca_y
-from aspire.image import Image
 from aspire.numeric import ComplexPCA
-from aspire.source import ArrayImageSource
 from aspire.utils.random import rand
 
 logger = logging.getLogger(__name__)
@@ -173,8 +172,8 @@ class RIRClass2D(Class2D):
         # When not provided by a user, the aligner is instantiated after
         #  we are certain our pca_basis has been constructed.
         if self.aligner is None:
-            self.aligner = BFRAlign2D(
-                self.pca_basis, self.src, self.fb_basis, dtype=self.dtype
+            self.aligner = BFSReddyChatterjiAlign2D(
+                None, self.src, self.fb_basis, dtype=self.dtype
             )
 
         # Get the expanded coefs in the compressed FSPCA space.

--- a/src/aspire/classification/rir_class2d.py
+++ b/src/aspire/classification/rir_class2d.py
@@ -165,7 +165,6 @@ class RIRClass2D(Class2D):
         #  default of 400 components was taken from legacy code.
         # Instantiate a new compressed (truncated) basis.
         if self.pca_basis is None:
-            # self.pca_basis = self.pca_basis.compress(self.fspca_components)
             self.pca_basis = FSPCABasis(self.src, components=self.fspca_components)
 
         # For convenience, assign the fb_basis used in the pca_basis.
@@ -174,7 +173,9 @@ class RIRClass2D(Class2D):
         # When not provided by a user, the aligner is instantiated after
         #  we are certain our pca_basis has been constructed.
         if self.aligner is None:
-            self.aligner = BFRAlign2D(self.pca_basis, dtype=self.dtype)
+            self.aligner = BFRAlign2D(
+                self.pca_basis, self.src, self.fb_basis, dtype=self.dtype
+            )
 
         # Get the expanded coefs in the compressed FSPCA space.
         self.fspca_coef = self.pca_basis.spca_coef
@@ -184,7 +185,7 @@ class RIRClass2D(Class2D):
 
         # # Stage 2: Compute Nearest Neighbors
         logger.info("Calculate Nearest Neighbors")
-        classes, refl, distances = self.nn_classification(coef_b, coef_b_r)
+        classes, reflections, distances = self.nn_classification(coef_b, coef_b_r)
 
         if diagnostics:
             # Lets peek at the distribution of distances
@@ -193,8 +194,14 @@ class RIRClass2D(Class2D):
             plt.show()
 
             # Report some information about reflections
-            logger.info(f"Count reflected: {np.sum(refl)}" f" {100 * np.mean(refl) } %")
+            logger.info(
+                f"Count reflected: {np.sum(reflections)}"
+                f" {100 * np.mean(reflections) } %"
+            )
 
+        return classes, reflections, distances
+
+    def averages(self, classes, reflections, distances):
         # # Stage 3: Class Selection
         logger.info(f"Select {self.n_classes} Classes from Nearest Neighbors")
         # This is an area open to active research.
@@ -206,11 +213,21 @@ class RIRClass2D(Class2D):
         logger.info(
             f"Begin Rotational Alignment of {classes.shape[0]} Classes using {self.aligner}."
         )
-        if not self.aligner.basis == self.pca_basis:
-            raise RuntimeError(
-                f"Aligner {self.aligner} basis does not match FSPCA basis."
-            )
-        return self.aligner.align(classes, refl, self.fspca_coef)
+
+        logger.info(f"Select {self.n_classes} Classes from Nearest Neighbors")
+        classes, reflections = self.select_classes(classes, reflections)
+
+        return self.aligner.align(classes, reflections, self.fspca_coef)
+
+    def select_classes(self, classes, reflections):
+        """
+        Select the `n_classes` to align from the (n_images) population of classes.
+        """
+        # generate indices for random sample (can do something smart with corr later).
+        # For testing just take the first n_classes so it matches earlier plots for manual comparison
+        # This is assumed to be reasonably random.
+        selection = np.arange(self.n_classes)
+        return classes[selection], reflections[selection]
 
     def pca(self, M):
         """
@@ -297,61 +314,6 @@ class RIRClass2D(Class2D):
         return classes, refl, distances
 
         return indices
-
-    def output(
-        self,
-        classes,
-        classes_refl,
-        rot,
-        shifts=None,
-        coefs=None,
-    ):
-        """
-        Return class averages.
-
-        :param classes: class indices (refering to src). (n_img, n_nbor)
-        :param classes_refl: Bool representing whether to reflect image in `classes`
-        :param rot: Array of in-plane rotation angles (Radians) of image in `classes`
-        :param shifts: Optional array of shifts for image in `classes`.
-        :coefs: Optional Fourier bessel coefs (avoids recomputing).
-        :return: Stack of Synthetic Class Average images as Image instance.
-        """
-
-        logger.info(f"Select {self.n_classes} Classes from Nearest Neighbors")
-        # generate indices for random sample (can do something smart with corr later).
-        # For testing just take the first n_classes so it matches earlier plots for manual comparison
-        # This is assumed to be reasonably random.
-        selection = np.arange(self.n_classes)
-
-        imgs = self.src.images(0, self.src.n)
-        fb_avgs = np.empty((self.n_classes, self.fb_basis.count), dtype=self.src.dtype)
-
-        for i in tqdm(range(self.n_classes)):
-            j = selection[i]
-            # Get the neighbors
-            neighbors_ids = classes[j]
-
-            # Get coefs in Fourier Bessel Basis if not provided as an argument.
-            if coefs is None:
-                neighbors_imgs = Image(imgs[neighbors_ids])
-                if shifts is not None:
-                    neighbors_imgs.shift(shifts[i])
-                neighbors_coefs = self.fb_basis.evaluate_t(neighbors_imgs)
-            else:
-                neighbors_coefs = coefs[neighbors_ids]
-                if shifts is not None:
-                    neighbors_coefs = self.fb_basis.shift(neighbors_coefs, shifts[i])
-
-            # Rotate in Fourier Bessel
-            neighbors_coefs = self.fb_basis.rotate(
-                neighbors_coefs, rot[j], classes_refl[j]
-            )
-
-            # Averaging in FB
-            fb_avgs[i] = np.mean(neighbors_coefs, axis=0)
-
-        # Now we convert the averaged images from FB to Cartesian.
-        return ArrayImageSource(self.fb_basis.evaluate(fb_avgs))
 
     def _legacy_nn_classification(self, coeff_b, coeff_b_r, batch_size=2000):
         """

--- a/src/aspire/denoising/__init__.py
+++ b/src/aspire/denoising/__init__.py
@@ -1,3 +1,4 @@
 from .adaptive_support import adaptive_support
+from .denoised_src import DenoisedImageSource
 from .denoiser import Denoiser
-from .denoiser_cov2d import src_wiener_coords
+from .denoiser_cov2d import DenoiserCov2D, src_wiener_coords

--- a/src/aspire/denoising/denoised_src.py
+++ b/src/aspire/denoising/denoised_src.py
@@ -45,6 +45,9 @@ class DenoisedImageSource(ImageSource):
         nimgs = len(indices)
         im = np.empty((nimgs, self.L, self.L))
 
+        # If we request less than a whole batch, don't crash
+        batch_size = min(nimgs, batch_size)
+
         logger.info(f"Loading {nimgs} images complete")
         for batch_start in range(start, end + 1, batch_size):
             imgs_denoised = self.denoiser.images(batch_start, batch_size)

--- a/src/aspire/denoising/denoiser_cov2d.py
+++ b/src/aspire/denoising/denoiser_cov2d.py
@@ -103,7 +103,7 @@ class DenoiserCov2D(Denoiser):
     Define a derived class for denoising 2D images using Cov2D method
     """
 
-    def __init__(self, src, basis, var_noise=None):
+    def __init__(self, src, basis=None, var_noise=None):
         """
         Initialize an object for denoising 2D images using Cov2D method
 
@@ -121,6 +121,9 @@ class DenoiserCov2D(Denoiser):
             var_noise = noise_estimator.estimate()
             logger.info(f"Estimated Noise Variance: {var_noise}")
         self.var_noise = var_noise
+
+        if basis is None:
+            basis = FFBBasis2D((self.src.L, self.src.L))
 
         if not isinstance(basis, FFBBasis2D):
             raise NotImplementedError("Currently only fast FB method is supported")

--- a/tests/test_FFBbasis3D.py
+++ b/tests/test_FFBbasis3D.py
@@ -4,13 +4,15 @@ from unittest import TestCase
 import numpy as np
 
 from aspire.basis import FFBBasis3D
+from aspire.utils import utest_tolerance
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "saved_test_data")
 
 
 class FFBBasis3DTestCase(TestCase):
     def setUp(self):
-        self.basis = FFBBasis3D((8, 8, 8))
+        self.dtype = np.float32
+        self.basis = FFBBasis3D((8, 8, 8), dtype=self.dtype)
 
     def tearDown(self):
         pass
@@ -463,39 +465,31 @@ class FFBBasis3DTestCase(TestCase):
                 -7.98651783e-04,
                 -9.82705453e-04,
                 6.46337066e-05,
-            ]
+            ],
+            dtype=self.dtype,
         )
         result = self.basis.evaluate(coeffs)
 
-        self.assertTrue(
-            np.allclose(
-                result,
-                np.load(
-                    os.path.join(DATA_DIR, "ffbbasis3d_xcoeff_out_8_8_8.npy")
-                ).T,  # RCOPT
-            )
-        )
+        ref = np.load(
+            os.path.join(DATA_DIR, "ffbbasis3d_xcoeff_out_8_8_8.npy")
+        ).T  # RCOPT
+
+        self.assertTrue(np.allclose(result, ref, atol=utest_tolerance(self.dtype)))
 
     def testFFBBasis3DEvaluate_t(self):
         x = np.load(os.path.join(DATA_DIR, "ffbbasis3d_xcoeff_in_8_8_8.npy")).T  # RCOPT
         result = self.basis.evaluate_t(x)
-        self.assertTrue(
-            np.allclose(
-                result,
-                np.load(os.path.join(DATA_DIR, "ffbbasis3d_vcoeff_out_8_8_8.npy"))[
-                    ..., 0
-                ],
-            )
-        )
+
+        ref = np.load(os.path.join(DATA_DIR, "ffbbasis3d_vcoeff_out_8_8_8.npy"))[..., 0]
+
+        self.assertTrue(np.allclose(result, ref, atol=utest_tolerance(self.dtype)))
 
     def testFFBBasis3DExpand(self):
         x = np.load(os.path.join(DATA_DIR, "ffbbasis3d_xcoeff_in_8_8_8.npy")).T  # RCOPT
         result = self.basis.expand(x)
-        self.assertTrue(
-            np.allclose(
-                result,
-                np.load(os.path.join(DATA_DIR, "ffbbasis3d_vcoeff_out_exp_8_8_8.npy"))[
-                    ..., 0
-                ],
-            )
-        )
+
+        ref = np.load(os.path.join(DATA_DIR, "ffbbasis3d_vcoeff_out_exp_8_8_8.npy"))[
+            ..., 0
+        ]
+
+        self.assertTrue(np.allclose(result, ref, atol=utest_tolerance(self.dtype)))

--- a/tests/test_align2d.py
+++ b/tests/test_align2d.py
@@ -62,8 +62,8 @@ class Align2DTestCase(TestCase):
             test_dtype = np.float32
 
         with self._caplog.at_level(logging.WARN):
-            self.aligner(self.basis, self._getSrc, dtype=test_dtype)
-            assert " does not match self.dtype" in self._caplog.text
+            self.aligner(self.basis, self._getSrc(), dtype=test_dtype)
+            assert "does not match dtype" in self._caplog.text
 
     def _construct_rotations(self):
         """

--- a/tests/test_class2D.py
+++ b/tests/test_class2D.py
@@ -191,8 +191,8 @@ class RIRClass2DTestCase(TestCase):
             bispectrum_implementation="legacy",
         )
 
-        result = rir.classify()
-        _ = rir.output(*result[:3])
+        classification_results = rir.classify()
+        _ = rir.averages(*classification_results)
 
     def testRIRDevelBisp(self):
         """
@@ -207,8 +207,8 @@ class RIRClass2DTestCase(TestCase):
             bispectrum_implementation="devel",
         )
 
-        result = rir.classify()
-        _ = rir.output(*result[:3])
+        classification_results = rir.classify()
+        _ = rir.averages(*classification_results)
 
     def testRIRsk(self):
         """
@@ -226,11 +226,17 @@ class RIRClass2DTestCase(TestCase):
             large_pca_implementation="sklearn",
             nn_implementation="sklearn",
             bispectrum_implementation="devel",
-            aligner=BFSRAlign2D(self.noisy_fspca_basis, n_angles=100, n_x_shifts=0),
+            aligner=BFSRAlign2D(
+                self.noisy_fspca_basis,
+                self.noisy_src,
+                self.basis,
+                n_angles=100,
+                n_x_shifts=0,
+            ),
         )
 
-        result = rir.classify()
-        _ = rir.output(*result[:4])
+        classification_results = rir.classify()
+        _ = rir.averages(*classification_results)
 
     def testEigenImages(self):
         """


### PR DESCRIPTION
Adds a simulated abinitio pipeline to our `gallery/experiments`. This is covering ASPIRE code from simulating picked particles to estimated 3D volume reconstruction.

Specifically this includes the full compliment of simulated effects: CTF, custom colored noise, projections, amplitudes, and shifts.  From this data we phase flip, whiten, FFB2D CWF denoise, class average, BFS Reddy Chatterji 2D align, Common Lines (sync voting), finally running MeanEstimator using FFB3D then saving out to an `mrc`.

Requires upstream PRs #541 , #538  and some minor patches. #537 should probably relate to this too, but it doesn't block.

Currently I am running 20k images to 1000 class averages for a 64^3 volume on a laptop.  A smaller run, 10K,100,32, respectively appears superficially successful.

I would be interested in swapping out the sim for the real experimental data backing this and creating it as the first experimental pipeline (EMPIAR-10028). Maybe next week...