### PR TITLE
Radial quadrature points of `FFBBasis3D` should scale with resolution.

### DIFF
--- a/src/aspire/basis/ffb_3d.py
+++ b/src/aspire/basis/ffb_3d.py
@@ -54,7 +54,7 @@ class FFBBasis3D(FBBasis3D):
         Gaussian quadrature points and weights are also generated
         in radical and phi dimensions.
         """
-        n_r = int(self.ell_max + 1)
+        n_r = int(np.ceil(4 * self.rcut * self.kcut))
         n_theta = int(2 * self.sz[0])
         n_phi = int(self.ell_max + 1)
 


### PR DESCRIPTION
We found that #528 was caused by too few radial quadrature points. Here we have given `FFBBasis3D` the same number as `FFBBasis2D`. This comes directly from https://arxiv.org/pdf/1412.0781.pdf, and is a rule of thumb (see the passage below Equation 19). Here `rcut` is an approximation of the radius of the disc of support for the Fourier-Bessel basis functions. (Of course in this case it's a ball I suppose). `kcut` is the frequency bandlimit (called `c` in the paper). 

It's not clear whether the rule of thumb can apply equally to 3D, but it does solve the ill-conditioning. See #555

`n_r = int(np.ceil(4 * self.rcut * self.kcut))`