### PR TITLE
fix shape index order

### DIFF
--- a/src/aspire/ctf/ctf_estimator.py
+++ b/src/aspire/ctf/ctf_estimator.py
@@ -147,8 +147,8 @@ class CtfEstimator:
         # verify block_size is even
         assert block_size % 2 == 0
 
-        size_x = micrograph.shape[1]
-        size_y = micrograph.shape[0]
+        size_x = micrograph.shape[0]
+        size_y = micrograph.shape[1]
 
         step_size = block_size // 2
         range_y = size_y // step_size - 1


### PR DESCRIPTION
currently the first axis and the second axis are reversed. When input micrograph is not square but rectangular, it will cause error "setting an array element with a sequence." during runtime, because the blocks with psd_size are not in same size.