### PR TITLE
`PolarBasis2D` bug.

### DIFF
--- a/src/aspire/basis/polar_2d.py
+++ b/src/aspire/basis/polar_2d.py
@@ -29,15 +29,8 @@ class PolarBasis2D(Basis):
         ensure(ndim == 2, "Only two-dimensional grids are supported.")
         ensure(len(set(size)) == 1, "Only square domains are supported.")
 
-        nres = size[0]
         self.nrad = nrad
-        if nrad is None:
-            self.nrad = nres // 2
-
         self.ntheta = ntheta
-        if ntheta is None:
-            # try to use the same number as Fast FB basis
-            self.ntheta = 8 * self.nrad
 
         super().__init__(size, dtype=dtype)
 
@@ -46,6 +39,13 @@ class PolarBasis2D(Basis):
         Build the internal data structure to 2D polar Fourier grid
         """
         logger.info("Represent 2D image in a polar Fourier grid")
+
+        if self.nrad is None:
+            self.nrad = self.nres // 2
+
+        if self.ntheta is None:
+            # try to use the same number as Fast FB basis
+            self.ntheta = 8 * self.nrad
 
         self.count = self.nrad * self.ntheta
         self._sz_prod = self.sz[0] * self.sz[1]

--- a/src/aspire/basis/polar_2d.py
+++ b/src/aspire/basis/polar_2d.py
@@ -21,15 +21,15 @@ class PolarBasis2D(Basis):
 
         :param size: The shape of the vectors for which to define the grid.
             Currently only square images are supported.
-        :param nrad: The number of points in the radial dimension.
-        :param ntheta: The number of points in the angular dimension.
+        :param nrad: The number of points in the radial dimension. Default is resoltuion // 2.
+        :param ntheta: The number of points in the angular dimension. Default is 8 * nrad.
         """
 
         ndim = len(size)
-        nres = size[0]
         ensure(ndim == 2, "Only two-dimensional grids are supported.")
         ensure(len(set(size)) == 1, "Only square domains are supported.")
 
+        nres = size[0]
         self.nrad = nrad
         if nrad is None:
             self.nrad = nres // 2

--- a/src/aspire/basis/polar_2d.py
+++ b/src/aspire/basis/polar_2d.py
@@ -26,12 +26,13 @@ class PolarBasis2D(Basis):
         """
 
         ndim = len(size)
+        nres = size[0]
         ensure(ndim == 2, "Only two-dimensional grids are supported.")
         ensure(len(set(size)) == 1, "Only square domains are supported.")
 
         self.nrad = nrad
         if nrad is None:
-            self.nrad = self.nres // 2
+            self.nrad = nres // 2
 
         self.ntheta = ntheta
         if ntheta is None:


### PR DESCRIPTION
This resolves issue #560. While creating a `PolarBasis2D` object `self.nrad` calls on `self.nres` prior to `self.nres` being initialized.  