### PR TITLE
Force finufft signals to be complex

### DIFF
--- a/src/aspire/nufft/finufft.py
+++ b/src/aspire/nufft/finufft.py
@@ -103,6 +103,9 @@ class FinufftPlan(Plan):
             f"Signal frame to be transformed must have shape {self.sz}",
         )
 
+        # FINUFFT was designed for a complex input array
+        signal = np.array(signal, copy=False, dtype=self.complex_dtype, order="C")
+
         result = self._transform_plan.execute(signal)
 
         return result
@@ -134,6 +137,9 @@ class FinufftPlan(Plan):
             # finufft is expecting flat array for 1D case.
             if self.ntransforms == 1:
                 signal = signal.reshape(self.num_pts)
+
+        # FINUFFT was designed for a complex input array
+        signal = np.array(signal, copy=False, dtype=self.complex_dtype, order="C")
 
         result = self._adjoint_plan.execute(signal)
 


### PR DESCRIPTION
This should work around the changes put in FINUFFT v2.0.4. Also it seems like their project lead might prefer to enforce this instead of casting in the future.