### PR TITLE
`CoordinateSource` patches

### DIFF
--- a/src/aspire/source/coordinates.py
+++ b/src/aspire/source/coordinates.py
@@ -168,8 +168,8 @@ class CoordinateSource(ImageSource, ABC):
         return [
             # centers may be represented as floats in STAR files
             # chop off the non integer part to account for this
-            int(x) - r,
-            int(y) - r,
+            int(float(x)) - r,
+            int(float(y)) - r,
             particle_size,
             particle_size,
         ]
@@ -363,7 +363,7 @@ class BoxesCoordinateSource(CoordinateSource):
         with open(box_file, "r") as box:
             first_line = box.readlines()[0].split()
             if len(first_line) >= 4:
-                box_size = int(first_line[2])  # x size or y size works
+                box_size = int(float(first_line[2]))  # x size or y size works
                 return box_size
             else:
                 logger.error(f"Problem with coordinate file: {box_file}")
@@ -395,7 +395,7 @@ class BoxesCoordinateSource(CoordinateSource):
                     )
 
                 # we can only accept square particles
-                size_x, size_y = int(line.split()[2]), int(line.split()[3])
+                size_x, size_y = float(line.split()[2]), float(line.split()[3])
                 if size_x != size_y:
                     logger.error(f"Problem with coordinate file: {box_file}")
                     raise ValueError(
@@ -437,7 +437,7 @@ class BoxesCoordinateSource(CoordinateSource):
         with open(coord_file, "r") as infile:
             lines = [line.split() for line in infile.readlines()]
         # coords are already in box format, so simply cast to int
-        return [[int(x) for x in line] for line in lines]
+        return [[int(float(x)) for x in line] for line in lines]
 
     def _force_new_particle_size(self, new_size):
         """

--- a/src/aspire/source/coordinates.py
+++ b/src/aspire/source/coordinates.py
@@ -95,7 +95,7 @@ class CoordinateSource(ImageSource, ABC):
             f"{self.__class__.__name__} from {os.path.dirname(self.mrc_paths[0])} contains {len(mrc_paths)} micrographs, {len(self.particles)} picked particles."
         )
         # report different mrc shapes
-        logger.info(f"Micrographs have the following shapes: {*self.mrc_shapes,}")
+        logger.info(f"Micrographs have the following shapes: {*set(self.mrc_shapes),}")
 
         # remove particles whose boxes do not fit at given particle_size
         # and get number removed

--- a/src/aspire/source/coordinates.py
+++ b/src/aspire/source/coordinates.py
@@ -325,6 +325,14 @@ class CoordinateSource(ImageSource, ABC):
 
         return Image(im)
 
+    @staticmethod
+    def _is_number(text):
+        """
+        Used in validation of coordinate files. We allow strings containing
+        - or . to account for negative values and floats.
+        """
+        return text.replace("-", "1").replace(".", "1").isdigit()
+
 
 class BoxesCoordinateSource(CoordinateSource):
     """
@@ -380,7 +388,7 @@ class BoxesCoordinateSource(CoordinateSource):
                         "flag in aspire extract-particles."
                     )
 
-                if not all(p.isnumeric() for p in line.split()):
+                if not all(self._is_number(p) for p in line.split()):
                     logger.error(f"Problem with coordinate file: {box_file}")
                     raise ValueError(
                         "Coordinate file contains non-numeric coordinate values."
@@ -485,7 +493,7 @@ class CentersCoordinateSource(CoordinateSource):
                         "Coordinate file contains a line with less than 2 numbers."
                     )
                 # check that the coordinate has numeric values
-                if not all(c.isnumeric() for c in line.split()):
+                if not all(self._is_number(c) for c in line.split()):
                     logger.error(f"Problem with coordinate file: {coord_file}")
                     raise ValueError(
                         "Coordinate file contains non-numeric coordinate values."
@@ -504,7 +512,7 @@ class CentersCoordinateSource(CoordinateSource):
             )
         # check that all values in each column are numeric
         if not all(
-            all(df[col].str.isnumeric())
+            all(df[col].apply(self._is_number))
             for col in ["_rlnCoordinateX", "_rlnCoordinateY"]
         ):
             logger.error(f"Problem with coordinate file: {coord_file}")

--- a/src/aspire/source/coordinates.py
+++ b/src/aspire/source/coordinates.py
@@ -168,8 +168,8 @@ class CoordinateSource(ImageSource, ABC):
         return [
             # centers may be represented as floats in STAR files
             # chop off the non integer part to account for this
-            int(float(x)) - r,
-            int(float(y)) - r,
+            int(x) - r,
+            int(y) - r,
             particle_size,
             particle_size,
         ]
@@ -539,5 +539,5 @@ class CentersCoordinateSource(CoordinateSource):
             return self._coords_list_from_star(coord_file)
         # otherwise we assume text file format with one coord per line:
         with open(coord_file, "r") as infile:
-            lines = [line.split() for line in infile.readlines()]
+            lines = [[float(c) for c in line.split()] for line in infile.readlines()]
         return [self._box_coord_from_center(line, self.particle_size) for line in lines]

--- a/tests/test_coordinate_source.py
+++ b/tests/test_coordinate_source.py
@@ -152,7 +152,7 @@ class CoordinateSourceTestCase(TestCase):
                     f"{lower_left_corners[0]}\t{lower_left_corners[1]}\t256\t100\n"
                 )
 
-    def createTestCoordFiles(self, centers, index, dtype=int):
+    def createTestCoordFiles(self, centers, index):
         # create a coord file (only particle centers listed)
         coord_fp = os.path.join(self.data_folder, f"sample{index+1}.coord")
         # populate coord file with particle centers
@@ -161,7 +161,7 @@ class CoordinateSourceTestCase(TestCase):
                 # .coord file usually contains just the centers
                 coord.write(f"{center[0]}\t{center[1]}\n")
 
-    def createTestStarFiles(self, centers, index, dtype=int):
+    def createTestStarFiles(self, centers, index):
         # create a star file (only particle centers listed)
         star_fp = os.path.join(self.data_folder, f"sample{index+1}.star")
         # populate star file with particle centers

--- a/tests/test_coordinate_source.py
+++ b/tests/test_coordinate_source.py
@@ -128,9 +128,11 @@ class CoordinateSourceTestCase(TestCase):
             for center in centers:
                 # to make a box file, we convert the centers to lower left
                 # corners by subtracting half the particle size (here: 256)
+                # make some of the values floats to ensure floats/ints are loaded
+                # correctly
                 lower_left_corners = (center[0] - 128, center[1] - 128)
                 box.write(
-                    f"{lower_left_corners[0]}\t{lower_left_corners[1]}\t256\t256\n"
+                    f"{lower_left_corners[0]}\t{lower_left_corners[1]}.0\t256\t256.0\n"
                 )
         # populate the second box file with nonsquare coordinates
         with open(box_fp_nonsquare, "w") as box_nonsquare:
@@ -145,10 +147,12 @@ class CoordinateSourceTestCase(TestCase):
         # create a coord file (only particle centers listed)
         coord_fp = os.path.join(self.data_folder, f"sample{index+1}.coord")
         # populate coord file with particle centers
+        # make some of the values floats to ensure floats/ints are loaded
+        # correctly
         with open(coord_fp, "w") as coord:
             for center in centers:
                 # .coord file usually contains just the centers
-                coord.write(f"{center[0]}\t{center[1]}\n")
+                coord.write(f"{center[0]}\t{center[1]}.0\n")
 
     def createTestStarFiles(self, centers, index):
         # create a star file (only particle centers listed)

--- a/tests/test_coordinate_source.py
+++ b/tests/test_coordinate_source.py
@@ -180,7 +180,7 @@ class CoordinateSourceTestCase(TestCase):
     def createFloatBoxFile(self, centers):
         # for testing float coordinates
         # create a box file (lower left corner and X/Y sizes)
-        box_fp = os.path.join(self.data_folder, f"float.box")
+        box_fp = os.path.join(self.data_folder, "float.box")
         # populate box file with coordinates in box format
         with open(box_fp, "w") as box:
             for center in centers:
@@ -194,7 +194,7 @@ class CoordinateSourceTestCase(TestCase):
     def createFloatCoordFile(self, centers):
         # for testing float coordinates
         # create a coord file (only particle centers listed)
-        coord_fp = os.path.join(self.data_folder, f"float.coord")
+        coord_fp = os.path.join(self.data_folder, "float.coord")
         # populate coord file with particle centers
         with open(coord_fp, "w") as coord:
             for center in centers:
@@ -204,7 +204,7 @@ class CoordinateSourceTestCase(TestCase):
     def createFloatStarFile(self, centers):
         # for testing float coordinates
         # create a star file (only particle centers listed)
-        star_fp = os.path.join(self.data_folder, f"float.star")
+        star_fp = os.path.join(self.data_folder, "float.star")
         # populate star file with particle centers
         x_coords = [str(center[0]) + ".000" for center in centers]
         y_coords = [str(center[1]) + ".000" for center in centers]

--- a/tests/test_coordinate_source.py
+++ b/tests/test_coordinate_source.py
@@ -139,8 +139,6 @@ class CoordinateSourceTestCase(TestCase):
             for center in centers:
                 # to make a box file, we convert the centers to lower left
                 # corners by subtracting half the particle size (here: 256)
-                # make some of the values floats to ensure floats/ints are loaded
-                # correctly
                 lower_left_corners = (center[0] - 128, center[1] - 128)
                 box.write(
                     f"{lower_left_corners[0]}\t{lower_left_corners[1]}\t256\t256\n"
@@ -158,8 +156,6 @@ class CoordinateSourceTestCase(TestCase):
         # create a coord file (only particle centers listed)
         coord_fp = os.path.join(self.data_folder, f"sample{index+1}.coord")
         # populate coord file with particle centers
-        # make some of the values floats to ensure floats/ints are loaded
-        # correctly
         with open(coord_fp, "w") as coord:
             for center in centers:
                 # .coord file usually contains just the centers
@@ -182,6 +178,7 @@ class CoordinateSourceTestCase(TestCase):
         starfile.write(star_fp)
 
     def createFloatBoxFile(self, centers):
+        # for testing float coordinates
         # create a box file (lower left corner and X/Y sizes)
         box_fp = os.path.join(self.data_folder, f"float.box")
         # populate box file with coordinates in box format
@@ -195,6 +192,7 @@ class CoordinateSourceTestCase(TestCase):
                 )
 
     def createFloatCoordFile(self, centers):
+        # for testing float coordinates
         # create a coord file (only particle centers listed)
         coord_fp = os.path.join(self.data_folder, f"float.coord")
         # populate coord file with particle centers
@@ -204,6 +202,7 @@ class CoordinateSourceTestCase(TestCase):
                 coord.write(f"{center[0]}.000\t{center[1]}.000\n")
 
     def createFloatStarFile(self, centers):
+        # for testing float coordinates
         # create a star file (only particle centers listed)
         star_fp = os.path.join(self.data_folder, f"float.star")
         # populate star file with particle centers


### PR DESCRIPTION
Some changes coming out of working with the `CoordinateSource` in the real world:

1. When printing out the different micrograph sizes, take the `set` of the list of sizes, otherwise it will print the same size 1000 times.

2. Address #581 by writing a quick method that does what we want. ("is_numeric" will fail even if the text can be parsed as a float)

3. In order to accomodate `float` coordinates in files, we have to cast to `float` prior to `int` in a few places. This is analogous to what we were already doing in:

https://github.com/ComputationalCryoEM/ASPIRE-Python/blob/11c3dcaeae830b86f0a491a97c7ba91e980c7695/src/aspire/source/coordinates.py#L193-L199

4. Make some of the values in the tests `floats` rather than ints to ensure that both can be processed. 