### PR TITLE
Bessel zero finding cleanup

### DIFF
--- a/src/aspire/basis/basis.py
+++ b/src/aspire/basis/basis.py
@@ -61,6 +61,9 @@ class Basis:
 
         # generate zeros of Bessel functions for each ell
         for ell in range(upper_bound):
+            # for each ell, num_besselj_zeros returns the zeros of the
+            # order ell Bessel function which are less than 2*pi*c*R = nres*pi/2,
+            # the truncation rule for the Fourier-Bessel expansion
             _n, _zeros = num_besselj_zeros(
                 ell + (self.ndim - 2) / 2, self.nres * np.pi / 2
             )

--- a/src/aspire/basis/basis_utils.py
+++ b/src/aspire/basis/basis_utils.py
@@ -157,6 +157,15 @@ def real_sph_harmonic(j, m, theta, phi):
 
 
 def besselj_zeros(nu, k):
+    """
+    Finds the first `k` zeros of the Bessel Function of the first kind
+    of order `nu`, i.e. J_nu.
+    Adapted from "zerobess.m" by Jonas Lundgren <splinefit@gmail.com>
+
+    :param nu: The real number order of the Bessel Function. (must be positive and <10e7)
+    :param k: The number of zeros to return. (must be >= 3)
+    :return z: A 1D numpy array of the first `k` zeros.
+    """
     assert k >= 3, "k must be >= 3"
     assert 0 <= nu <= 1e7, "nu must be between 0 and 1e7"
 

--- a/src/aspire/basis/basis_utils.py
+++ b/src/aspire/basis/basis_utils.py
@@ -49,8 +49,7 @@ def check_besselj_zeros(nu, z):
 def besselj_newton(nu, z0, max_iter=10):
     """
     Uses the Newton-Raphson method to compute the zero(s) of the
-    Bessel function of the First Kind with order `nu` with initial
-    guess(es) `z0`.
+    Bessel function with order `nu` with initial guess(es) `z0`.
 
     :param nu: The real number order of the Bessel function.
     :param z0: (Array-like) The initial guess(es) for the root-finding algorithm.
@@ -183,11 +182,10 @@ def real_sph_harmonic(j, m, theta, phi):
 
 def besselj_zeros(nu, k):
     """
-    Finds the first `k` zeros of the Bessel function of the First Kind
-    of order `nu`, i.e. J_nu.
+    Finds the first `k` zeros of the Bessel function of order `nu`, i.e. J_nu.
     Adapted from "zerobess.m" by Jonas Lundgren <splinefit@gmail.com>
 
-    :param nu: The real number order of the Bessel Function. (must be positive and <10e7)
+    :param nu: The real number order of the Bessel function. (must be positive and <1e7)
     :param k: The number of zeros to return. (must be >= 3)
     :return z: A 1D numpy array of the first `k` zeros.
     """
@@ -251,8 +249,7 @@ def besselj_zeros(nu, k):
 
 def num_besselj_zeros(ell, r):
     """
-    Compute the zeros of the order `ell` Bessel function of
-    the First Kind, which are less than `r`.
+    Compute the zeros of the order `ell` Bessel function which are less than `r`.
 
     :param ell: The real number order of the Bessel function.
     :param r: The upper bound for zeros returned.

--- a/src/aspire/basis/basis_utils.py
+++ b/src/aspire/basis/basis_utils.py
@@ -250,12 +250,24 @@ def besselj_zeros(nu, k):
 
 
 def num_besselj_zeros(ell, r):
+    """
+    Compute the zeros of the order `ell` Bessel function
+    which are less than `r`.
+    :param ell: The real number order of the Bessel function.
+    :param r: The upper bound for zeros returned.
+    :return n, r0: The number of zeros and the zeros themselves 
+    as a numpy array.
+    """
     k = 4
+    # get the first 4 zeros
     r0 = besselj_zeros(ell, k)
     while all(r0 < r):
+        # increase the number of zeros sought
+        # until one of the zeros is greater than `r`
         k *= 2
         r0 = besselj_zeros(ell, k)
     r0 = r0[r0 < r]
+    # return the number of zeros and the zeros themselves
     return len(r0), r0
 
 

--- a/src/aspire/basis/basis_utils.py
+++ b/src/aspire/basis/basis_utils.py
@@ -225,9 +225,6 @@ def besselj_zeros(nu, k):
 
         # Guess and refine
         z0 = z[n - 1] + np.cumsum(dz)
-        import pdb
-
-        pdb.set_trace()
         z[n : n + j] = besselj_newton(nu, z0)
 
         # Check to see that the sequence of zeros makes sense

--- a/src/aspire/basis/basis_utils.py
+++ b/src/aspire/basis/basis_utils.py
@@ -35,8 +35,11 @@ def check_besselj_zeros(nu, z):
     # Spacing between zeros is greater than 3
     result = result and all(dz > 3)
 
+    # Second order differences should be zero or just barely increasing to
+    # within 16x machine precision.
     if nu >= 0.5:
         result = result and all(ddz < 16 * np.spacing(z[1:-1]))
+    # For nu < 0.5 the spacing will be slightly decreasing, so flip the sign.
     else:
         result = result and all(ddz > -16 * np.spacing(z[1:-1]))
 

--- a/src/aspire/basis/basis_utils.py
+++ b/src/aspire/basis/basis_utils.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 def check_besselj_zeros(nu, z):
     """
-    Verify a sequence of estimated zeros of the Bessel Function with order `nu`
+    Verify a sequence of estimated zeros of the Bessel function with order `nu`.
     :param nu: The real number order of the Bessel function.
     :param z: (Array-like) A sequence of postulated zeros.
     :return result: True or False.
@@ -39,7 +39,7 @@ def check_besselj_zeros(nu, z):
     # within 16x machine precision.
     if nu >= 0.5:
         result = result and all(ddz < 16 * np.spacing(z[1:-1]))
-    # For nu < 0.5 the spacing will be slightly decreasing, so flip the sign.
+    # For nu < 0.5 the spacing will be slightly decreasing, so flip the sign
     else:
         result = result and all(ddz > -16 * np.spacing(z[1:-1]))
 
@@ -49,13 +49,13 @@ def check_besselj_zeros(nu, z):
 def besselj_newton(nu, z0, max_iter=10):
     """
     Uses the Newton-Raphson method to compute the zero(s) of the
-    Bessel Function of the First Kind with order `nu` with initial
+    Bessel function of the First Kind with order `nu` with initial
     guess(es) `z0`.
 
-    :param nu: The real number order of the Bessel Function.
+    :param nu: The real number order of the Bessel function.
     :param z0: (Array-like) The initial guess(es) for the root-finding algorithm.
     :param max_iter: Maximum number of iterations for Newton-Raphson
-    (default: 10)
+    (default: 10).
     :return z: (Array-like) The estimated root(s).
     """
     z = z0
@@ -183,7 +183,7 @@ def real_sph_harmonic(j, m, theta, phi):
 
 def besselj_zeros(nu, k):
     """
-    Finds the first `k` zeros of the Bessel Function of the first kind
+    Finds the first `k` zeros of the Bessel function of the First Kind
     of order `nu`, i.e. J_nu.
     Adapted from "zerobess.m" by Jonas Lundgren <splinefit@gmail.com>
 
@@ -251,8 +251,9 @@ def besselj_zeros(nu, k):
 
 def num_besselj_zeros(ell, r):
     """
-    Compute the zeros of the order `ell` Bessel function
-    which are less than `r`.
+    Compute the zeros of the order `ell` Bessel function of
+    the First Kind, which are less than `r`.
+
     :param ell: The real number order of the Bessel function.
     :param r: The upper bound for zeros returned.
     :return n, r0: The number of zeros and the zeros themselves

--- a/src/aspire/basis/basis_utils.py
+++ b/src/aspire/basis/basis_utils.py
@@ -255,7 +255,7 @@ def num_besselj_zeros(ell, r):
     which are less than `r`.
     :param ell: The real number order of the Bessel function.
     :param r: The upper bound for zeros returned.
-    :return n, r0: The number of zeros and the zeros themselves 
+    :return n, r0: The number of zeros and the zeros themselves
     as a numpy array.
     """
     k = 4

--- a/src/aspire/basis/basis_utils.py
+++ b/src/aspire/basis/basis_utils.py
@@ -16,12 +16,23 @@ logger = logging.getLogger(__name__)
 
 
 def check_besselj_zeros(nu, z):
+    """
+    Verify a sequence of estimated zeros of the Bessel Function with order `nu`
+    :param nu: The real number order of the Bessel function.
+    :param z: (Array-like) A sequence of postulated zeros.
+    :return result: True or False.
+    """
+    # Compute first and second order differences of the sequence of zeros
     dz = np.diff(z)
     ddz = np.diff(dz)
 
+    # Check criteria for acceptable zeros
     result = True
+    # Real roots
     result = result and all(np.isreal(z))
+    # All roots should be > 0, check first of increasing sequence
     result = result and z[0] > 0
+    # Spacing between zeros is greater than 3
     result = result and all(dz > 3)
 
     if nu >= 0.5:
@@ -33,6 +44,17 @@ def check_besselj_zeros(nu, z):
 
 
 def besselj_newton(nu, z0, max_iter=10):
+    """
+    Uses the Newton-Raphson method to compute the zero(s) of the
+    Bessel Function of the First Kind with order `nu` with initial
+    guess(es) `z0`.
+
+    :param nu: The real number order of the Bessel Function.
+    :param z0: (Array-like) The initial guess(es) for the root-finding algorithm.
+    :param max_iter: Maximum number of iterations for Newton-Raphson
+    (default: 10)
+    :return z: (Array-like) The estimated root(s).
+    """
     z = z0
 
     # Factor worse than machine precision
@@ -203,6 +225,9 @@ def besselj_zeros(nu, k):
 
         # Guess and refine
         z0 = z[n - 1] + np.cumsum(dz)
+        import pdb
+
+        pdb.set_trace()
         z[n : n + j] = besselj_newton(nu, z0)
 
         # Check to see that the sequence of zeros makes sense

--- a/src/aspire/basis/basis_utils.py
+++ b/src/aspire/basis/basis_utils.py
@@ -254,7 +254,7 @@ def num_besselj_zeros(ell, r):
     :param ell: The real number order of the Bessel function.
     :param r: The upper bound for zeros returned.
     :return n, r0: The number of zeros and the zeros themselves
-    as a numpy array.
+    as a NumPy array.
     """
     k = 4
     # get the first 4 zeros

--- a/src/aspire/basis/basis_utils.py
+++ b/src/aspire/basis/basis_utils.py
@@ -185,8 +185,8 @@ def besselj_zeros(nu, k):
     Finds the first `k` zeros of the Bessel function of order `nu`, i.e. J_nu.
     Adapted from "zerobess.m" by Jonas Lundgren <splinefit@gmail.com>
 
-    :param nu: The real number order of the Bessel function. (must be positive and <1e7)
-    :param k: The number of zeros to return. (must be >= 3)
+    :param nu: The real number order of the Bessel function (must be positive and <1e7).
+    :param k: The number of zeros to return (must be >= 3).
     :return z: A 1D NumPy array of the first `k` zeros.
     """
     assert k >= 3, "k must be >= 3"

--- a/src/aspire/basis/basis_utils.py
+++ b/src/aspire/basis/basis_utils.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 def check_besselj_zeros(nu, z):
     """
-    Verify a sequence of estimated zeros of the Bessel function with order `nu`.
+    Sanity-check a sequence of estimated zeros of the Bessel function with order `nu`.
     :param nu: The real number order of the Bessel function.
     :param z: (Array-like) A sequence of postulated zeros.
     :return result: True or False.

--- a/src/aspire/basis/basis_utils.py
+++ b/src/aspire/basis/basis_utils.py
@@ -187,7 +187,7 @@ def besselj_zeros(nu, k):
 
     :param nu: The real number order of the Bessel function. (must be positive and <1e7)
     :param k: The number of zeros to return. (must be >= 3)
-    :return z: A 1D numpy array of the first `k` zeros.
+    :return z: A 1D NumPy array of the first `k` zeros.
     """
     assert k >= 3, "k must be >= 3"
     assert 0 <= nu <= 1e7, "nu must be between 0 and 1e7"


### PR DESCRIPTION
The functions `num_besselj_zeros`, `besselj_zeros`, `check_besselj_zeros` are almost exact ports from the MATLAB code, but are lacking clear comments.

These in turn are modifications of this script by Jonas Lundgren:

https://www.mathworks.com/matlabcentral/mlc-downloads/downloads/submissions/26639/versions/5/previews/zerobess.m/index.html

When attempting to work out what exactly these functions are doing to estimate the first few zeros, I came across several tricks that I haven't been able to find a single definitive source for. e.g.,

https://github.com/ComputationalCryoEM/ASPIRE-Python/blob/6cb389edf21e811224cc98f4fde0d63ed778b9a7/src/aspire/basis/basis_utils.py#L165-L174

Roughly, this computes initial guesses based on powers of `nu`, the real number order of the Bessel function. The closest literature I could find for this is in the following paper:

Elbert, Árpád. “Some recent results on the zeros of Bessel functions and orthogonal polynomials.” Journal of Computational and Applied Mathematics 133 (2001): 65-83.

(Section 1.3 starting around eqn 1.7)

The powers as well as the hardcoded values in our code also appear here. 

See also: https://www.boost.org/doc/libs/1_63_0/libs/math/doc/html/math_toolkit/bessel/bessel_root.html

It may be a lesser concern to be able to find the theoretical justification here, but it would probably be ideal if we could. Regardless, I'm going to use this PR to comment and clean up these functions as much as possible so that it is easier to understand in the future

