### PR TITLE
`Basis` size fixes

### DIFF
--- a/src/aspire/basis/basis.py
+++ b/src/aspire/basis/basis.py
@@ -180,14 +180,15 @@ class Basis:
         if isinstance(x, Image) or isinstance(x, Volume):
             x = x.asnumpy()
 
-        # ensure the first dimensions with size of self.sz
-        sz_roll = x.shape[: -self.ndim]
-
-        x = x.reshape((-1, *self.sz))
-
+        # check that last ndim values of input shape match
+        # the shape of this basis
         assert (
             x.shape[-self.ndim :] == self.sz
         ), f"Last {self.ndim} dimensions of x must match {self.sz}."
+        # extract number of images/volumes, or () if only one
+        sz_roll = x.shape[: -self.ndim]
+        # convert to standardized shape e.g. (L,L) to (1,L,L)
+        x = x.reshape((-1, *self.sz))
 
         operator = LinearOperator(
             shape=(self.count, self.count),

--- a/src/aspire/basis/dirac.py
+++ b/src/aspire/basis/dirac.py
@@ -14,7 +14,7 @@ class DiracBasis(Basis):
     Define a derived class for Dirac basis
     """
 
-    def __init__(self, sz, mask=None, dtype=np.float32):
+    def __init__(self, size, mask=None, dtype=np.float32):
         """
         Initialize an object for Dirac basis
         :param sz: The shape of the vectors for which to define the basis.
@@ -22,13 +22,13 @@ class DiracBasis(Basis):
         :param mask: A boolean _mask of size sz indicating which coordinates
             to include in the basis (default np.full(sz, True)).
         """
-        if isinstance(sz, int):
-            sz = (sz, sz)
+        if isinstance(size, int):
+            size = (size, size)
         if mask is None:
-            mask = np.full(sz, True)
+            mask = np.full(size, True)
         self._mask = m_flatten(mask)
 
-        super().__init__(sz, dtype=dtype)
+        super().__init__(size, dtype=dtype)
 
     def _build(self):
         """

--- a/src/aspire/basis/dirac.py
+++ b/src/aspire/basis/dirac.py
@@ -17,7 +17,7 @@ class DiracBasis(Basis):
     def __init__(self, size, mask=None, dtype=np.float32):
         """
         Initialize an object for Dirac basis
-        :param sz: The shape of the vectors for which to define the basis.
+        :param size: The shape of the vectors for which to define the basis.
         May be a 2-tuple or an integer, in which case, a square basis is assumed.
         :param mask: A boolean _mask of size sz indicating which coordinates
             to include in the basis (default np.full(sz, True)).

--- a/src/aspire/basis/dirac.py
+++ b/src/aspire/basis/dirac.py
@@ -18,9 +18,12 @@ class DiracBasis(Basis):
         """
         Initialize an object for Dirac basis
         :param sz: The shape of the vectors for which to define the basis.
+        May be a 2-tuple or an integer, in which case, a square basis is assumed.
         :param mask: A boolean _mask of size sz indicating which coordinates
             to include in the basis (default np.full(sz, True)).
         """
+        if isinstance(sz, int):
+            sz = (sz, sz)
         if mask is None:
             mask = np.full(sz, True)
         self._mask = m_flatten(mask)

--- a/src/aspire/basis/fb_2d.py
+++ b/src/aspire/basis/fb_2d.py
@@ -29,6 +29,7 @@ class FBBasis2D(SteerableBasis2D):
         Initialize an object for the 2D Fourier-Bessel basis class
 
         :param size: The size of the vectors for which to define the basis.
+            May be a 2-tuple or an integer, in which case a square basis is assumed.
             Currently only square images are supported.
         :ell_max: The maximum order ell of the basis elements. If no input
             (= None), it will be set to np.Inf and the basis includes all
@@ -36,6 +37,8 @@ class FBBasis2D(SteerableBasis2D):
             below the Nyquist frequency (default Inf).
         """
 
+        if isinstance(size, int):
+            size = (size, size)
         ndim = len(size)
         assert ndim == 2, "Only two-dimensional basis functions are supported."
         assert len(set(size)) == 1, "Only square domains are supported."

--- a/src/aspire/basis/fb_3d.py
+++ b/src/aspire/basis/fb_3d.py
@@ -23,12 +23,15 @@ class FBBasis3D(Basis):
         Initialize an object for the 3D Fourier-Bessel basis class
 
         :param size: The size of the vectors for which to define the basis.
+            May be a 3-tuple or an integer, in which case a cubic basis is assumed.
             Currently only cubic images are supported.
         :ell_max: The maximum order ell of the basis elements. If no input
             (= None), it will be set to np.Inf and the basis includes all
             ell such that the resulting basis vectors are concentrated
             below the Nyquist frequency (default Inf).
         """
+        if isinstance(size, int):
+            size = (size, size, size)
         ndim = len(size)
         assert ndim == 3, "Only three-dimensional basis functions are supported."
         assert len(set(size)) == 1, "Only cubic domains are supported."

--- a/src/aspire/basis/fpswf_2d.py
+++ b/src/aspire/basis/fpswf_2d.py
@@ -34,7 +34,7 @@ class FPSWFBasis2D(PSWFBasis2D):
         Initialize an object for 2D prolate spheroidal wave function (PSWF) basis expansion using fast method.
 
         :param size: The size of the vectors for which to define the basis
-            and the image resultion. May be a 2-tuple or an integer, in which case
+            and the image resolution. May be a 2-tuple or an integer, in which case
             a square basis is assumed. Currently only square images are supported.
         :param gamma_trunc: Truncation parameter of PSWFs, between 0 and 1e6,
             which controls the length of the expansion and the approximation error.

--- a/src/aspire/basis/fpswf_2d.py
+++ b/src/aspire/basis/fpswf_2d.py
@@ -34,7 +34,8 @@ class FPSWFBasis2D(PSWFBasis2D):
         Initialize an object for 2D prolate spheroidal wave function (PSWF) basis expansion using fast method.
 
         :param size: The size of the vectors for which to define the basis
-            and the image resultion. Currently only square images are supported.
+            and the image resultion. May be a 2-tuple or an integer, in which case
+            a square basis is assumed. Currently only square images are supported.
         :param gamma_trunc: Truncation parameter of PSWFs, between 0 and 1e6,
             which controls the length of the expansion and the approximation error.
             Smaller values (close to zero) guarantee smaller errors, yet longer

--- a/src/aspire/basis/polar_2d.py
+++ b/src/aspire/basis/polar_2d.py
@@ -19,12 +19,14 @@ class PolarBasis2D(Basis):
         """
         Initialize an object for the 2D polar Fourier grid class
 
-        :param size: The shape of the vectors for which to define the grid.
+        :param size: The shape of the vectors for which to define the grid. 
+            May be a 2-tuple or an integer, in which case a square basis is assumed.
             Currently only square images are supported.
-        :param nrad: The number of points in the radial dimension. Default is resoltuion // 2.
+        :param nrad: The number of points in the radial dimension. Default is resolution // 2.
         :param ntheta: The number of points in the angular dimension. Default is 8 * nrad.
         """
-
+        if isinstance(size, int):
+            size = (size, size)
         ndim = len(size)
         assert ndim == 2, "Only two-dimensional grids are supported."
         assert len(set(size)) == 1, "Only square domains are supported."

--- a/src/aspire/basis/polar_2d.py
+++ b/src/aspire/basis/polar_2d.py
@@ -19,7 +19,7 @@ class PolarBasis2D(Basis):
         """
         Initialize an object for the 2D polar Fourier grid class
 
-        :param size: The shape of the vectors for which to define the grid. 
+        :param size: The shape of the vectors for which to define the grid.
             May be a 2-tuple or an integer, in which case a square basis is assumed.
             Currently only square images are supported.
         :param nrad: The number of points in the radial dimension. Default is resolution // 2.

--- a/src/aspire/basis/pswf_2d.py
+++ b/src/aspire/basis/pswf_2d.py
@@ -39,7 +39,7 @@ class PSWFBasis2D(Basis):
         Initialize an object for 2D PSWF basis expansion using direct method
 
         :param size: The size of the vectors for which to define the basis
-            and the image resultion. May be a 2-tuple or an integer, in which case
+            and the image resolution. May be a 2-tuple or an integer, in which case
             a square basis is assumed. Currently only square images are supported.
         :param gamma_trunc: Truncation parameter of PSWFs, between 0 and 1e6,
             which controls the length of the expansion and the approximation error.

--- a/src/aspire/basis/pswf_2d.py
+++ b/src/aspire/basis/pswf_2d.py
@@ -39,7 +39,8 @@ class PSWFBasis2D(Basis):
         Initialize an object for 2D PSWF basis expansion using direct method
 
         :param size: The size of the vectors for which to define the basis
-            and the image resultion. Currently only square images are supported.
+            and the image resultion. May be a 2-tuple or an integer, in which case
+            a square basis is assumed. Currently only square images are supported.
         :param gamma_trunc: Truncation parameter of PSWFs, between 0 and 1e6,
             which controls the length of the expansion and the approximation error.
             Smaller values (close to zero) guarantee smaller errors, yet longer
@@ -51,7 +52,8 @@ class PSWFBasis2D(Basis):
             parameter controls the bandlimit of the PSWFs.
         :param dtype: Internal ndarray datatype.
         """
-
+        if isinstance(size, int):
+            size = (size, size)
         self.rcut = size[0] // 2
         self.gmcut = gamma_trunc
         self.beta = beta

--- a/tests/test_Diracbasis.py
+++ b/tests/test_Diracbasis.py
@@ -189,3 +189,7 @@ class DiracBasisTestCase(TestCase):
         )
         result = self.basis.evaluate_t(x)
         self.assertTrue(np.allclose(result, m_flatten(x)))
+
+    def testInitWithIntSize(self):
+        # make sure we can instantiate with just an int as a shortcut
+        self.assertEqual((8, 8), DiracBasis(8).sz)

--- a/tests/test_FBbasis2D.py
+++ b/tests/test_FBbasis2D.py
@@ -389,3 +389,7 @@ class FBBasis2DTestCase(TestCase):
 
         # Try a 0d vector, should not crash.
         _ = self.basis.to_real(cv1.reshape(-1))
+
+    def testInitWithIntSize(self):
+        # make sure we can instantiate with just an int as a shortcut
+        self.assertEqual((8, 8), FBBasis2D(8).sz)

--- a/tests/test_FBbasis3D.py
+++ b/tests/test_FBbasis3D.py
@@ -697,3 +697,7 @@ class FBBasis3DTestCase(TestCase):
                 atol=utest_tolerance(self.dtype),
             )
         )
+
+    def testInitWithIntSize(self):
+        # make sure we can instantiate with just an int as a shortcut
+        self.assertEqual((8, 8, 8), FBBasis3D(8).sz)

--- a/tests/test_FPSWFbasis2D.py
+++ b/tests/test_FPSWFbasis2D.py
@@ -45,3 +45,7 @@ class FPSWFBasis2DTestCase(TestCase):
         result = self.basis.evaluate(coeffs)
         images = np.load(os.path.join(DATA_DIR, "pswf2d_xcoeff_out_8_8.npy")).T  # RCOPT
         self.assertTrue(np.allclose(result.asnumpy(), images))
+
+    def testInitWithIntSize(self):
+        # make sure we can instantiate with just an int as a shortcut
+        self.assertEqual((8, 8), FPSWFBasis2D(8).sz)

--- a/tests/test_PSWFbasis2D.py
+++ b/tests/test_PSWFbasis2D.py
@@ -45,3 +45,7 @@ class PSWFBasis2DTestCase(TestCase):
         result = self.basis.evaluate(coeffs)
         images = np.load(os.path.join(DATA_DIR, "pswf2d_xcoeff_out_8_8.npy")).T  # RCOPT
         self.assertTrue(np.allclose(result.asnumpy(), images))
+
+    def testInitWithIntSize(self):
+        # make sure we can instantiate with just an int as a shortcut
+        self.assertEqual((8, 8), PSWFBasis2D(8).sz)

--- a/tests/test_PolarBasis2D.py
+++ b/tests/test_PolarBasis2D.py
@@ -502,3 +502,7 @@ class PolarBasis2DTestCase(TestCase):
         )
 
         self.assertTrue(np.isclose(lhs, rhs, atol=utest_tolerance(self.dtype)))
+
+    def testInitWithIntSize(self):
+        # make sure we can instantiate with just an int as a shortcut
+        self.assertEqual((8, 8), PolarBasis2D(8).sz)


### PR DESCRIPTION
#### 1. Bug in #593 

There is a check in `Basis.expand()`, but it was not working properly. The input image was resized in such a way that it is it always passed the check (as can be seen from the `Files changed`). 

For instance, a 32x32 image passed to a 16x16 basis was resized to (4,16,16), and since the last two dimensions match 16x16, it was allowed.

Simply moving the check before the resizing means that images that do not have the same dimension as the basis will be caught before the resizing.

#### 2. Allow scalar `size` in `__init__` for bases