### PR TITLE
Zenodo file with authors and affiliations

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,7 +1,7 @@
 {
     "creators": [
 	{
-	    "affiliation": "Gestalt Group LLC",
+	    "affiliation": "Princeton University",
 	    "name": "Garrett Wright"
 	},
 	{
@@ -28,7 +28,6 @@
 	    "orcid": "0000-0001-9889-349X"
 	},
         {
-            "affiliation": "Princeton University",
             "name": "Robbie Brook"
         },
 	{

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -24,13 +24,13 @@
 	},
 	{
 	    "affiliation": "Princeton University",
-	    "name": "Robbie Brook"
-	},
-	{
-	    "affiliation": "Princeton University",
 	    "name": "Josh Carmichael",
 	    "orcid": "0000-0001-9889-349X"
 	},
+        {
+            "affiliation": "Princeton University",
+            "name": "Robbie Brook"
+        },
 	{
 	    "affiliation": "Princeton University",
 	    "name": "Yunpeng Shi"

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -28,7 +28,8 @@
 	},
 	{
 	    "affiliation": "Princeton University",
-	    "name": "Josh Carmichael"
+	    "name": "Josh Carmichael",
+	    "orcid": "0000-0001-9889-349X"
 	},
 	{
 	    "affiliation": "Princeton University",

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -5,7 +5,9 @@
 	    "name": "Garrett Wright"
 	},
 	{
-	    "name": "Joakim And\u00e9n"
+	    "affiliation": "KTH Royal Institute of Technology",
+	    "name": "Joakim And\u00e9n",
+	    "orcid": "0000-0002-3377-813X"
 	},
 	{
 	    "affiliation": "Princeton University",
@@ -21,7 +23,8 @@
 	    "orcid": "0000-0003-4151-203X"
 	},
 	{
-	    "name": "Robby Brook"
+	    "affiliation": "Princeton University",
+	    "name": "Robbie Brook"
 	},
 	{
 	    "affiliation": "Princeton University",
@@ -32,18 +35,23 @@
 	    "name": "Yunpeng Shi"
 	},
 	{
+	    "affiliation": "Ariel University",
 	    "name": "Ayelet Heimowitz"
 	},
 	{
+	    "affiliation": "Tel Aviv University",
 	    "name": "Gabi Pragier"
 	},
 	{
+	    "affiliation": "Tel Aviv University",
 	    "name": "Itay Sason"
 	},
 	{
+	    "affiliation": "Tel Aviv University",
 	    "name": "Amit Moscovich"
 	},
 	{
+	    "affiliation": "Tel Aviv University",
 	    "name": "Yoel Shkolnisky"
 	},
 	{

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,3 +1,4 @@
+{
     "creators": [
 	{
 	    "affiliation": "Gestalt Group LLC",
@@ -22,7 +23,7 @@
 	    "name": "Robby Brook"
 	},
 	{
-	    "affiliation": "Princeton University"
+	    "affiliation": "Princeton University",
 	    "name": "Josh Carmichael"
 	},
 	{
@@ -49,3 +50,4 @@
 	    "name": "Amit Singer"
 	}
     ]
+}

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,51 @@
+    "creators": [
+	{
+	    "affiliation": "Gestalt Group LLC",
+	    "name": "Garrett Wright"
+	},
+	{
+	    "name": "Joakim And\u00e9n"
+	},
+	{
+	    "affiliation": "Princeton University",
+	    "name": "Vineet Bansal"
+	},
+	{
+	    "affiliation": "OpenEye Scientific Software Inc",
+	    "name": "Junchao Xia"
+	},
+	{
+	    "affiliation": "Princeton University",
+	    "name": "Chris Langfield"
+	},
+	{
+	    "name": "Robby Brook"
+	},
+	{
+	    "affiliation": "Princeton University"
+	    "name": "Josh Carmichael"
+	},
+	{
+	    "affiliation": "Princeton University",
+	    "name": "Yunpeng Shi"
+	},
+	{
+	    "name": "Ayelet Heimowitz"
+	},
+	{
+	    "name": "Gabi Pragier"
+	},
+	{
+	    "name": "itaysason"
+	},
+	{
+	    "name": "Amit Moscovich"
+	},
+	{
+	    "name": "Yoel Shkolnisky"
+	},
+	{
+	    "affiliation": "Princeton University",
+	    "name": "Amit Singer"
+	}
+    ]

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -17,7 +17,8 @@
 	},
 	{
 	    "affiliation": "Princeton University",
-	    "name": "Chris Langfield"
+	    "name": "Chris Langfield",
+	    "orcid": "0000-0003-4151-203X"
 	},
 	{
 	    "name": "Robby Brook"

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -36,7 +36,7 @@
 	    "name": "Gabi Pragier"
 	},
 	{
-	    "name": "itaysason"
+	    "name": "Itay Sason"
 	},
 	{
 	    "name": "Amit Moscovich"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,6 +11,7 @@ include pytest.ini
 include tox.ini
 include logging.conf
 include config.ini
+include .zenodo.json
 recursive-include docs *.bat
 recursive-include docs *.bib
 recursive-include docs *.py

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,7 @@ commands =
     flake8 .
     isort --check-only --diff .
     black --check --diff .
+    python -m json.tool .zenodo.json /dev/null
     check-manifest .
     python setup.py sdist
     twine check dist/*.*


### PR DESCRIPTION
#613 

The added `.zenodo.json` file comes from:

`https://zenodo.org/record/6248611/export/json` which can be run in browser to automatically generate a JSON of metadata that was used by Zenodo for version 0.9.0. Presumably, this is the last version that we manually edited. For this PR I modified it to include @j-c-c 's Princeton affiliation and @itaysason 's full name rather than Github username.

 We might want to query all authors as to their preferred "Affiliation" if we are going to make this file more or less permanent in the repo

According to the source below, Zenodo automatically extracts metadata from e.g. the Contributors tab on Github, but some of these fields can be overwritten by adding a `.zenodo.json` providing new values for the given fields. For example, we are updating the authors by giving a new value for the `"creators"` list.

https://developers.zenodo.org/#add-metadata-to-your-github-repository-release