### PR TITLE
update scikit-learn workaround 

### DIFF
--- a/src/aspire/numeric/complex_pca/validation.py
+++ b/src/aspire/numeric/complex_pca/validation.py
@@ -21,6 +21,7 @@ from sklearn.utils.validation import _assert_all_finite
 
 FLOAT_DTYPES = (np.float64, np.float32, np.float16)
 
+
 def _num_samples(x):
     """Return number of samples in array-like x."""
     message = "Expected sequence or array-like, got %s" % type(x)

--- a/src/aspire/numeric/complex_pca/validation.py
+++ b/src/aspire/numeric/complex_pca/validation.py
@@ -16,15 +16,10 @@ import warnings
 import numpy as np
 import scipy.sparse as sp
 from numpy.core.numeric import ComplexWarning
-from sklearn.exceptions import DataConversionWarning, NonBLASDotWarning
+from sklearn.exceptions import DataConversionWarning
 from sklearn.utils.validation import _assert_all_finite
 
 FLOAT_DTYPES = (np.float64, np.float32, np.float16)
-
-# Silenced by default to reduce verbosity. Turn on at runtime for
-# performance profiling.
-warnings.simplefilter("ignore", NonBLASDotWarning)
-
 
 def _num_samples(x):
     """Return number of samples in array-like x."""

--- a/tests/test_complexPCA.py
+++ b/tests/test_complexPCA.py
@@ -52,7 +52,9 @@ class ComplexPCACase(TestCase):
         Smoke test a more realistic size.
         """
 
-        pca = ComplexPCA(n_components=self.components_large, copy=False)
+        pca = ComplexPCA(
+            n_components=self.components_large, copy=False, svd_solver="full"
+        )
 
         # Input data matrix X should be (n_samples, m_features)
         X = self.X_large


### PR DESCRIPTION
Pins scikit to the version used in testing/development until we decide how to manage the ComplexPCA problem.

Backstory, some code was lifted and wrapped to support a Complex workaround for scikit.  Generally speaking, sk doesn't support complex numbers, but complex numbers are important to our work in some places at this time.  There is a larger issue about dealing with that already.

In #624 , a user reported a crash that occurred against the latest scikit. This was an oversight on my part.