### PR TITLE
expose cls avg alignment estimates

### DIFF
--- a/gallery/tutorials/class_averaging.py
+++ b/gallery/tutorials/class_averaging.py
@@ -198,3 +198,54 @@ Image(noisy_src.images(0, np.inf)[classes[review_class]]).show()
 
 # Display the averaged result
 avgs.images(review_class, 1).show()
+
+# %%
+# Alignment Details
+# -----------------
+#
+# Alignment details are exposed when avaialable from an underlying ``averager``.
+# In this case, we'll get the estimated alignments for the ``review_class``.
+# These alignment arrays are indexed the same as ``classes``,
+# having shape (n_classes, n_nbor).
+
+est_rotations = rir.averager.rotations[review_class]
+est_shifts = rir.averager.shifts[review_class]
+est_correlations = rir.averager.correlations[review_class]
+
+logger.info(f"Estimated Rotations: {est_rotations}")
+logger.info(f"Estimated Shifts: {est_shifts}")
+logger.info(f"Estimated Correlations: {est_correlations}")
+
+# Compare the original unaligned images with the estimated alignment.
+# Get the indices from the classification results.
+nbr = 3
+original_img_0_idx = classes[review_class][0]
+original_img_nbr_idx = classes[review_class][nbr]
+
+# Lookup the images.
+original_img_0 = src.images(original_img_0_idx, 1).asnumpy()[0]
+original_img_nbr = src.images(original_img_nbr_idx, 1).asnumpy()[0]
+
+
+# Rotate using estimated rotations.
+rotated_img_nbr = np.asarray(
+    PILImage.fromarray(original_img_nbr).rotate(est_rotations[nbr])
+)
+plt.subplot(1, 2, 1)
+plt.title("Original Images")
+plt.imshow(original_img_0)
+plt.xlabel("Img 0")
+plt.subplot(1, 2, 2)
+plt.imshow(original_img_nbr)
+plt.xlabel(f"Img {nbr}")
+plt.show()
+
+
+plt.subplot(1, 2, 1)
+plt.title("Est Rotation Applied")
+plt.imshow(original_img_0)
+plt.xlabel("Img 0")
+plt.subplot(1, 2, 2)
+plt.imshow(rotated_img_nbr)
+plt.xlabel(f"Img {nbr} rotated {est_rotations[nbr]:.4}*")
+plt.show()

--- a/gallery/tutorials/class_averaging.py
+++ b/gallery/tutorials/class_averaging.py
@@ -208,9 +208,9 @@ avgs.images(review_class, 1).show()
 # These alignment arrays are indexed the same as ``classes``,
 # having shape (n_classes, n_nbor).
 
-est_rotations = rir.averager.rotations[review_class]
-est_shifts = rir.averager.shifts[review_class]
-est_correlations = rir.averager.correlations[review_class]
+est_rotations = noisy_rir.averager.rotations[review_class]
+est_shifts = noisy_rir.averager.shifts[review_class]
+est_correlations = noisy_rir.averager.correlations[review_class]
 
 logger.info(f"Estimated Rotations: {est_rotations}")
 logger.info(f"Estimated Shifts: {est_shifts}")
@@ -223,29 +223,27 @@ original_img_0_idx = classes[review_class][0]
 original_img_nbr_idx = classes[review_class][nbr]
 
 # Lookup the images.
-original_img_0 = src.images(original_img_0_idx, 1).asnumpy()[0]
-original_img_nbr = src.images(original_img_nbr_idx, 1).asnumpy()[0]
-
+original_img_0 = noisy_src.images(original_img_0_idx, 1).asnumpy()[0]
+original_img_nbr = noisy_src.images(original_img_nbr_idx, 1).asnumpy()[0]
 
 # Rotate using estimated rotations.
-rotated_img_nbr = np.asarray(
-    PILImage.fromarray(original_img_nbr).rotate(est_rotations[nbr])
-)
-plt.subplot(1, 2, 1)
+angle = -est_rotations[nbr] * 180 / np.pi
+rotated_img_nbr = np.asarray(PILImage.fromarray(original_img_nbr).rotate(angle))
+
+plt.subplot(2, 2, 1)
 plt.title("Original Images")
 plt.imshow(original_img_0)
 plt.xlabel("Img 0")
-plt.subplot(1, 2, 2)
+plt.subplot(2, 2, 2)
 plt.imshow(original_img_nbr)
 plt.xlabel(f"Img {nbr}")
-plt.show()
 
-
-plt.subplot(1, 2, 1)
+plt.subplot(2, 2, 3)
 plt.title("Est Rotation Applied")
 plt.imshow(original_img_0)
 plt.xlabel("Img 0")
-plt.subplot(1, 2, 2)
+plt.subplot(2, 2, 4)
 plt.imshow(rotated_img_nbr)
-plt.xlabel(f"Img {nbr} rotated {est_rotations[nbr]:.4}*")
+plt.xlabel(f"Img {nbr} rotated {angle:.4}*")
+plt.tight_layout()
 plt.show()

--- a/src/aspire/classification/averager2d.py
+++ b/src/aspire/classification/averager2d.py
@@ -163,7 +163,9 @@ class AligningAverager2D(Averager2D):
         This subclass assumes we get alignment details from `align` method. Otherwise. see Averager2D.average
         """
 
-        rotations, shifts, _ = self.align(classes, reflections, coefs)
+        self.rotations, self.shifts, self.correlations = self.align(
+            classes, reflections, coefs
+        )
 
         n_classes, n_nbor = classes.shape
 
@@ -177,22 +179,22 @@ class AligningAverager2D(Averager2D):
                 neighbors_imgs = Image(self._cls_images(classes[i]))
 
                 # Do shifts
-                if shifts is not None:
-                    neighbors_imgs.shift(shifts[i])
+                if self.shifts is not None:
+                    neighbors_imgs.shift(self.shifts[i])
 
                 neighbors_coefs = self.composite_basis.evaluate_t(neighbors_imgs)
             else:
                 # Get the neighbors
                 neighbors_ids = classes[i]
                 neighbors_coefs = coefs[neighbors_ids]
-                if shifts is not None:
+                if self.shifts is not None:
                     neighbors_coefs = self.composite_basis.shift(
-                        neighbors_coefs, shifts[i]
+                        neighbors_coefs, self.shifts[i]
                     )
 
             # Rotate in composite_basis
             neighbors_coefs = self.composite_basis.rotate(
-                neighbors_coefs, rotations[i], reflections[i]
+                neighbors_coefs, self.rotations[i], reflections[i]
             )
 
             # Averaging in composite_basis
@@ -730,7 +732,9 @@ class ReddyChatterjiAverager2D(AligningAverager2D):
         Otherwise is similar to `AligningAverager2D.average`.
         """
 
-        rotations, shifts, _ = self.align(classes, reflections, coefs)
+        self.rotations, self.shifts, self.correlations = self.align(
+            classes, reflections, coefs
+        )
 
         n_classes, n_nbor = classes.shape
 
@@ -750,12 +754,14 @@ class ReddyChatterjiAverager2D(AligningAverager2D):
 
             # Rotate in composite_basis
             neighbors_coefs = self.composite_basis.rotate(
-                neighbors_coefs, rotations[i], reflections[i]
+                neighbors_coefs, self.rotations[i], reflections[i]
             )
 
             # Note shifts are after rotation for this approach!
-            if shifts is not None:
-                neighbors_coefs = self.composite_basis.shift(neighbors_coefs, shifts[i])
+            if self.shifts is not None:
+                neighbors_coefs = self.composite_basis.shift(
+                    neighbors_coefs, self.shifts[i]
+                )
 
             # Averaging in composite_basis
             b_avgs[i] = np.mean(neighbors_coefs, axis=0)

--- a/tests/test_averager2d.py
+++ b/tests/test_averager2d.py
@@ -7,6 +7,7 @@ import pytest
 
 from aspire.basis import DiracBasis, FFBBasis2D
 from aspire.classification import (
+    AligningAverager2D,
     Averager2D,
     BFRAverager2D,
     BFSRAverager2D,
@@ -25,7 +26,13 @@ DATA_DIR = os.path.join(os.path.dirname(__file__), "saved_test_data")
 
 # Ignore Gimbal lock warning for our in plane rotations.
 @pytest.mark.filterwarnings("ignore:Gimbal lock detected")
-class Averager2DTestCase(TestCase):
+class Averager2DBase:
+    """
+    Configure and setup a unit test case bypassing pytest execution.
+
+    Base class will become inherited into concrete TestCase.
+    """
+
     # Subclasses should override `averager` with a different class.
     averager = Averager2D
 
@@ -106,13 +113,28 @@ class Averager2DTestCase(TestCase):
 
 
 @pytest.mark.filterwarnings("ignore:Gimbal lock detected")
-class BFRAverager2DTestCase(Averager2DTestCase):
+class Averager2DTestCase(Averager2DBase, TestCase):
+    """
+    Concrete TestCase
+    """
 
-    averager = BFRAverager2D
+
+class AligningAverager2DBase(Averager2DBase):
+    """
+    Configure and setup a unit test case bypassing pytest execution.
+
+    Base class will become inherited into concrete TestCase.
+
+    Aligning Averagers are expected to expose
+
+    `.rotations`
+    `.shifts`
+    `.correlations`
+    """
+
+    averager = AligningAverager2D
 
     def setUp(self):
-
-        self.n_search_angles = 360
 
         super().setUp()
 
@@ -124,6 +146,26 @@ class BFRAverager2DTestCase(Averager2DTestCase):
 
         # Get the image coef
         self.coefs = self.basis.evaluate_t(self.src.images(0, self.n_img))
+
+    def _call_averager(self):
+        # Construct the Averager
+        avgr = self.averager(self.basis, self._getSrc())
+        # Call the `align` method
+        _ = avgr.align(self.classes, self.reflections, self.coefs)
+        _ = avgr.average(self.classes, self.reflections, self.coefs)
+        return avgr
+
+    def test_rotations_estimate(self):
+        avgr = self._call_averager()
+        self.assertTrue(hasattr(avgr, "rotations"))
+
+    def test_shifts_estimate(self):
+        avgr = self._call_averager()
+        self.assertTrue(hasattr(avgr, "shifts"))
+
+    def test_correlations_estimate(self):
+        avgr = self._call_averager()
+        self.assertTrue(hasattr(avgr, "correlations"))
 
     def _getSrc(self):
         if not hasattr(self, "shifts"):
@@ -140,6 +182,13 @@ class BFRAverager2DTestCase(Averager2DTestCase):
             seed=12345,
             dtype=self.dtype,
         )
+
+
+@pytest.mark.filterwarnings("ignore:Gimbal lock detected")
+class BFRAverager2DTestCase(AligningAverager2DBase, TestCase):
+
+    averager = BFRAverager2D
+    n_search_angles = 360
 
     def testNoRot(self):
         """


### PR DESCRIPTION
A user explcitly calling align would get these variables in hand, but if using the built in calls this patch would expose.  In that case, after performing the averaging, a user could get rotations as `self.averager.rotations`. Similar for `shifts` and `correlations`.

If this is satisfactory we should add to one of the tutorials/examples and pytest.

Closes #643 