### PR TITLE
Fix `bad_applepick.star` after running Apple test

### DIFF
--- a/tests/test_apple.py
+++ b/tests/test_apple.py
@@ -495,9 +495,7 @@ class ApplePickerTestCase(TestCase):
         with tempfile.TemporaryDirectory() as tmpdir_name:
 
             # Instantiate an Apple instance
-            apple_picker = Apple(
-                particle_size=42,
-            )
+            apple_picker = Apple(particle_size=42, output_dir=tmpdir_name)
 
             # Get the path of an input mrcfile
             with importlib.resources.path(


### PR DESCRIPTION
We just forgot to put the bad file in the temp directory so it never gets cleaned up. 

Closes #629 