### PR TITLE
Fix `Image.set_metadata()` bug

### DIFF
--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -202,7 +202,6 @@ class ImageSource:
 
         if indices is None:
             indices = self._metadata.index.values
-
         df = pd.DataFrame(values, columns=metadata_fields, index=indices)
         for metadata_field in metadata_fields:
             series = df[metadata_field]
@@ -211,7 +210,7 @@ class ImageSource:
                     series, how="left", left_index=True, right_index=True
                 )
             else:
-                self._metadata[metadata_field] = series
+                self._metadata.update(series.astype(object))
 
     def has_metadata(self, metadata_fields):
         """

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -202,6 +202,7 @@ class ImageSource:
 
         if indices is None:
             indices = self._metadata.index.values
+            
         df = pd.DataFrame(values, columns=metadata_fields, index=indices)
         for metadata_field in metadata_fields:
             series = df[metadata_field]

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -202,7 +202,7 @@ class ImageSource:
 
         if indices is None:
             indices = self._metadata.index.values
-            
+
         df = pd.DataFrame(values, columns=metadata_fields, index=indices)
         for metadata_field in metadata_fields:
             series = df[metadata_field]


### PR DESCRIPTION
`DataFrame.update()` takes care of what we were trying to do previously, which was including new data but setting old data to `NaN`.
https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.update.html

See #635 for the original issue.

Also, by casting the series to dtype `object`, when the same column exists in both the original DF, and the new DF it is being updated from, the dtype will default to that of the original DF. This fixes the second issue mentioned in #635.
https://stackoverflow.com/a/47145613/9584059