### PR TITLE
Refactor `ainner` to handle complex values

### DIFF
--- a/src/aspire/utils/matrix.py
+++ b/src/aspire/utils/matrix.py
@@ -364,7 +364,7 @@ def ainner(x, y, axes=None):
     if axes is not None:
         axes = tuple(axes)  # Unrolls any generators, like `range`.
 
-    return np.sum(x * y, axis=axes)
+    return np.sum(x * np.conj(y), axis=axes)
 
 
 def eigs(A, k):


### PR DESCRIPTION
During the port of the common lines method for symmetric molecules (#616) it was revealed that `anorm()` does not handle complex values when given a set of axes (see #646). This is due to `ainner()` not using the complex conjugate to compute the inner product.

In this PR we refactor `ainner()` to handle complex values.