### PR TITLE
`Filter.sign` method

### DIFF
--- a/src/aspire/operators/filters.py
+++ b/src/aspire/operators/filters.py
@@ -139,6 +139,8 @@ class Filter:
     def dual(self):
         return DualFilter(self)
 
+    def sign(self):
+        return LambdaFilter(self, np.sign)
 
 class DualFilter(Filter):
     """

--- a/src/aspire/operators/filters.py
+++ b/src/aspire/operators/filters.py
@@ -139,8 +139,10 @@ class Filter:
     def dual(self):
         return DualFilter(self)
 
+    @property
     def sign(self):
         return LambdaFilter(self, np.sign)
+
 
 class DualFilter(Filter):
     """

--- a/src/aspire/operators/filters.py
+++ b/src/aspire/operators/filters.py
@@ -141,6 +141,9 @@ class Filter:
 
     @property
     def sign(self):
+        """
+        A Filter object to evaluate the signs of the underlying filter.
+        """
         return LambdaFilter(self, np.sign)
 
 

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -15,12 +15,7 @@ from aspire.image.xform import (
     Multiply,
     Pipeline,
 )
-from aspire.operators import (
-    IdentityFilter,
-    LambdaFilter,
-    MultiplicativeFilter,
-    PowerFilter,
-)
+from aspire.operators import IdentityFilter, MultiplicativeFilter, PowerFilter
 from aspire.storage import MrcStats, StarFile
 from aspire.utils import Rotation, grid_2d
 
@@ -377,9 +372,7 @@ class ImageSource:
         """
         logger.info("Perform phase flip on source object")
         logger.info("Adding Phase Flip Xform to end of generation pipeline")
-        unique_xforms = [
-            FilterXform(LambdaFilter(f, np.sign)) for f in self.unique_filters
-        ]
+        unique_xforms = [FilterXform(f.sign) for f in self.unique_filters]
         self.generation_pipeline.add_xform(
             IndexedXform(unique_xforms, self.filter_indices)
         )

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -313,3 +313,9 @@ class SimTestCase(TestCase):
         dual_filter = ctf_filter.dual()
         dual_result = dual_filter.evaluate(self.omega)
         self.assertTrue(np.allclose(result, dual_result))
+
+    def testFilterSigns(self):
+        ctf_filter = CTFFilter(defocus_u=1.5e4, defocus_v=1.5e4)
+        signs = np.sign(ctf_filter.evaluate(self.omega))
+        sign_filter = ctf_filter.sign
+        self.assertTrue(np.allclose(sign_filter.evaluate(self.omega), signs))


### PR DESCRIPTION
This PR creates a `Filter.sign` method that returns `LambdaFilter(self, np.sign)`, ie. a filter object which can later be evaluated to determine the signs of the evaluation over the underlying filter (mentioned in issue #308).

Additionally, a test for the method was added and the use of the `LambdaFilter` for this purpose in `phase_flip()` was replaced: https://github.com/ComputationalCryoEM/ASPIRE-Python/blob/1bff8d3884183203bd77695a76bccb1efc909fd3/src/aspire/source/image.py#L374-L385  