### PR TITLE
Simplify `gaussian_` functions

### DIFF
--- a/gallery/tutorials/class_averaging.py
+++ b/gallery/tutorials/class_averaging.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 L = 100
-round_disc = gaussian_2d(L, sigma=(L / 4, L / 4))
+round_disc = gaussian_2d(L, sigma=L / 4)
 plt.imshow(round_disc, cmap="gray")
 plt.show()
 

--- a/gallery/tutorials/class_averaging.py
+++ b/gallery/tutorials/class_averaging.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 L = 100
-round_disc = gaussian_2d(L, sigma_x=L / 4, sigma_y=L / 4)
+round_disc = gaussian_2d(L, sigma=(L / 4, L / 4))
 plt.imshow(round_disc, cmap="gray")
 plt.show()
 
@@ -37,7 +37,7 @@ plt.show()
 # Oval 2D Gaussian Image
 # ^^^^^^^^^^^^^^^^^^^^^^
 
-oval_disc = gaussian_2d(L, sigma_x=L / 20, sigma_y=L / 5)
+oval_disc = gaussian_2d(L, sigma=(L / 20, L / 5))
 plt.imshow(oval_disc, cmap="gray")
 plt.show()
 
@@ -48,7 +48,7 @@ plt.show()
 # Create richer test set by including an asymmetric image.
 
 # Create a second oval.
-oval_disc2 = gaussian_2d(L, L / 5, L / 6, sigma_x=L / 15, sigma_y=L / 20)
+oval_disc2 = gaussian_2d(L, mu=(L / 5, L / 6), sigma=(L / 15, L / 20))
 
 # Strategically add it to `oval_disc`.
 yoval_discL = oval_disc.copy()

--- a/src/aspire/utils/__init__.py
+++ b/src/aspire/utils/__init__.py
@@ -12,7 +12,9 @@ from .coor_trans import (  # isort:skip
 from .misc import (  # isort:skip
     abs2,
     circ,
+    gaussian_1d,
     gaussian_2d,
+    gaussian_3d,
     get_full_version,
     inverse_r,
     powerset,

--- a/src/aspire/utils/misc.py
+++ b/src/aspire/utils/misc.py
@@ -102,7 +102,7 @@ def sha256sum(filename):
     return h.hexdigest()
 
 
-def gaussian_1d(size, mu=0, sigma=1, peak=1, dtype=np.float64):
+def gaussian_1d(size, mu=0, sigma=1, dtype=np.float64):
     """
     Returns a 1d Gaussian in a 1D numpy array.
 
@@ -111,7 +111,6 @@ def gaussian_1d(size, mu=0, sigma=1, peak=1, dtype=np.float64):
     :param size: The height and width of returned array (pixels)
     :param mu: mean or center (pixels)
     :param sigma: spread
-    :param peak: peak height at center
     :param dtype: dtype of returned array
     :return: Numpy array (1D)
     """
@@ -121,47 +120,55 @@ def gaussian_1d(size, mu=0, sigma=1, peak=1, dtype=np.float64):
 
     p = (g["x"] - mu) ** 2 / (2 * sigma**2)
 
-    return (peak * np.exp(-p)).astype(dtype, copy=False)
+    return np.exp(-p).astype(dtype, copy=False)
 
 
-def gaussian_2d(size, x0=0, y0=0, sigma_x=1, sigma_y=1, peak=1, dtype=np.float64):
+def gaussian_2d(size, mu=(0, 0), sigma=(1, 1), dtype=np.float64):
     """
     Returns a 2d Gaussian in a square 2d numpy array.
 
-    Default is a centered disc of spread=peak=1.
+    Default is a centered disc of spread=1.
 
     :param size: The height and width of returned array (pixels)
-    :param x0: x coordinate of center (pixels)
-    :param y0: y coordinate of center (pixels)
-    :param sigma_x: spread in x direction
-    :param sigma_y: spread in y direction
-    :param peak: peak height at center
+    :param mu: A 2-tuple indicating the center of the Gaussian
+    :param sigma: A 2-tuple (or scalar) of spreads corresponding to mu
     :param dtype: dtype of returned array
     :return: Numpy array (2D)
     """
+    if np.ndim(sigma) == 0:
+        sigma = (sigma, sigma)
+    else:
+        assert (
+            isinstance(sigma, tuple) and len(sigma) == 2
+        ), "sigma must be a scalar or 2-tuple."
 
     # Construct centered mesh
     g = grid_2d(size, shifted=False, normalized=False, indexing="yx", dtype=dtype)
 
-    p = (g["x"] - x0) ** 2 / (2 * sigma_x**2) + (g["y"] - y0) ** 2 / (
-        2 * sigma_y**2
+    p = (g["x"] - mu[0]) ** 2 / (2 * sigma[0] ** 2) + (g["y"] - mu[1]) ** 2 / (
+        2 * sigma[1] ** 2
     )
-    return (peak * np.exp(-p)).astype(dtype, copy=False)
+    return np.exp(-p).astype(dtype, copy=False)
 
 
-def gaussian_3d(size, mu=(0, 0, 0), sigma=(1, 1, 1), peak=1, dtype=np.float64):
+def gaussian_3d(size, mu=(0, 0, 0), sigma=(1, 1, 1), dtype=np.float64):
     """
     Returns a 3d Gaussian in a size-by-size-by-size 3d numpy array.
 
-    Default is a centered volume of spread=peak=1.
+    Default is a centered volume of spread=1.
 
     :param size: The height and width of returned array (pixels)
     :param mu: A 3-tuple indicating the center of the Gaussian
-    :param sigma: A 3-tuple of spreads corresponding to mu
-    :param peak: peak height at center
+    :param sigma: A 3-tuple (or scalar) of spreads corresponding to mu
     :param dtype: dtype of returned array
     :return: Numpy array (3D)
     """
+    if np.ndim(sigma) == 0:
+        sigma = (sigma, sigma, sigma)
+    else:
+        assert (
+            isinstance(sigma, tuple) and len(sigma) == 3
+        ), "sigma must be a scalar or 3-tuple."
 
     # Construct centered mesh
     g = grid_3d(size, shifted=False, normalized=False, indexing="zyx", dtype=dtype)
@@ -171,7 +178,7 @@ def gaussian_3d(size, mu=(0, 0, 0), sigma=(1, 1, 1), peak=1, dtype=np.float64):
         + (g["y"] - mu[1]) ** 2 / (2 * sigma[1] ** 2)
         + (g["z"] - mu[2]) ** 2 / (2 * sigma[2] ** 2)
     )
-    return (peak * np.exp(-p)).astype(dtype, copy=False)
+    return np.exp(-p).astype(dtype, copy=False)
 
 
 def circ(size, x0=0, y0=0, radius=1, peak=1, dtype=np.float64):

--- a/src/aspire/utils/misc.py
+++ b/src/aspire/utils/misc.py
@@ -104,13 +104,16 @@ def sha256sum(filename):
 
 def gaussian_1d(size, mu=0, sigma=1, dtype=np.float64):
     """
-    Returns a 1d Gaussian in a 1D numpy array.
+    Returns the 1D Gaussian
 
-    Default is a centered disc of spread=peak=1.
+    .. math::
+        g(x)=\\exp\\left(\\frac{ -(x - \\mu)^2}{2\\sigma^2}\\right)
 
-    :param size: The height and width of returned array (pixels)
+    in a 1D numpy array.
+
+    :param size: The length of the returned array (pixels)
     :param mu: mean or center (pixels)
-    :param sigma: spread
+    :param sigma: standard deviation of the Gaussian
     :param dtype: dtype of returned array
     :return: Numpy array (1D)
     """
@@ -125,13 +128,19 @@ def gaussian_1d(size, mu=0, sigma=1, dtype=np.float64):
 
 def gaussian_2d(size, mu=(0, 0), sigma=(1, 1), dtype=np.float64):
     """
-    Returns a 2d Gaussian in a square 2d numpy array.
+    Returns the 2D Gaussian
 
-    Default is a centered disc of spread=1.
+    .. math::
+        g(x,y)=\\exp\\left(\\frac{-(x - \\mu_x)^2}{2\\sigma_x^2} +
+                \\frac{-(y - \\mu_y)^2}{2\\sigma_y^2}\\right)
 
-    :param size: The height and width of returned array (pixels)
-    :param mu: A 2-tuple indicating the center of the Gaussian
-    :param sigma: A 2-tuple (or scalar) of spreads corresponding to mu
+    in a square 2D numpy array.
+
+    :param size: The length of each dimension of the returned array (pixels)
+    :param mu: A 2-tuple, :math:`(\\mu_x, \\mu_y)`, indicating the center of the Gaussian
+    :param sigma: A 2-tuple, :math:`(\\sigma_x, \\sigma_y)`, of the standard
+            deviation in the x and y directions. A single value, :math:`\\sigma`, can be
+            used when :math:`\\sigma_x = \\sigma_y`.
     :param dtype: dtype of returned array
     :return: Numpy array (2D)
     """
@@ -153,13 +162,20 @@ def gaussian_2d(size, mu=(0, 0), sigma=(1, 1), dtype=np.float64):
 
 def gaussian_3d(size, mu=(0, 0, 0), sigma=(1, 1, 1), dtype=np.float64):
     """
-    Returns a 3d Gaussian in a size-by-size-by-size 3d numpy array.
+    Returns the 3D Gaussian
 
-    Default is a centered volume of spread=1.
+    .. math::
+        g(x,y,z)=\\exp\\left(\\frac{-(x - \\mu_x)^2}{2\\sigma_x^2} +
+                \\frac{-(y - \\mu_y)^2}{2\\sigma_y^2} +
+                \\frac{-(z - \\mu_z)^2}{2\\sigma_z^2}\\right)
 
-    :param size: The height and width of returned array (pixels)
-    :param mu: A 3-tuple indicating the center of the Gaussian
-    :param sigma: A 3-tuple (or scalar) of spreads corresponding to mu
+    in a 3D numpy array.
+
+    :param size: The length of each dimension of the returned array (pixels)
+    :param mu: A 3-tuple, :math:`(\\mu_x, \\mu_y, \\mu_z)`, indicating the center of the Gaussian
+    :param sigma: A 3-tuple, :math:`(\\sigma_x, \\sigma_y, \\sigma_z)`, of the standard deviation
+            in the x, y, and z directions. A single value, :math:`\\sigma`, can be
+            used when :math:`\\sigma_x = \\sigma_y = \\sigma_z`
     :param dtype: dtype of returned array
     :return: Numpy array (3D)
     """

--- a/src/aspire/utils/misc.py
+++ b/src/aspire/utils/misc.py
@@ -141,7 +141,7 @@ def gaussian_2d(size, x0=0, y0=0, sigma_x=1, sigma_y=1, peak=1, dtype=np.float64
     """
 
     # Construct centered mesh
-    g = grid_2d(size, shifted=False, normalized=False, indexing="xy", dtype=dtype)
+    g = grid_2d(size, shifted=False, normalized=False, indexing="yx", dtype=dtype)
 
     p = (g["x"] - x0) ** 2 / (2 * sigma_x**2) + (g["y"] - y0) ** 2 / (
         2 * sigma_y**2
@@ -164,7 +164,7 @@ def gaussian_3d(size, mu=(0, 0, 0), sigma=(1, 1, 1), peak=1, dtype=np.float64):
     """
 
     # Construct centered mesh
-    g = grid_3d(size, shifted=False, normalized=False, indexing="xyz", dtype=dtype)
+    g = grid_3d(size, shifted=False, normalized=False, indexing="zyx", dtype=dtype)
 
     p = (
         (g["x"] - mu[0]) ** 2 / (2 * sigma[0] ** 2)

--- a/tests/_basis_util.py
+++ b/tests/_basis_util.py
@@ -39,9 +39,7 @@ class Steerable2DMixin:
         # Want sigma to be as large as possible without the Gaussian
         # spilling too much outside the central disk.
         sigma = self.L / 8
-        im1 = gaussian_2d(
-            self.L, x0=x0, y0=y0, sigma_x=sigma, sigma_y=sigma, dtype=self.dtype
-        )
+        im1 = gaussian_2d(self.L, mu=(x0, y0), sigma=sigma, dtype=self.dtype)
 
         coef = self.basis.expand(im1)
         im2 = self.basis.evaluate(coef)
@@ -62,7 +60,7 @@ class Steerable2DMixin:
 
     def testIsotropic(self):
         sigma = self.L / 8
-        im = gaussian_2d(self.L, sigma_x=sigma, sigma_y=sigma, dtype=self.dtype)
+        im = gaussian_2d(self.L, sigma=sigma, dtype=self.dtype)
 
         coef = self.basis.expand(im)
 
@@ -82,7 +80,7 @@ class Steerable2DMixin:
         ell = 1
 
         sigma = self.L / 8
-        im = gaussian_2d(self.L, sigma_x=sigma, sigma_y=sigma, dtype=self.dtype)
+        im = gaussian_2d(self.L, sigma=sigma, dtype=self.dtype)
 
         g2d = grid_2d(self.L)
 

--- a/tests/test_adaptive_support.py
+++ b/tests/test_adaptive_support.py
@@ -63,7 +63,7 @@ class AdaptiveSupportTest(TestCase):
 
         # Generate stack of 2D Gaussian images.
         imgs = np.tile(
-            gaussian_2d(self.size, sigma_x=self.sigma, sigma_y=self.sigma),
+            gaussian_2d(self.size, sigma=self.sigma),
             (self.n_disc, 1, 1),
         )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -95,3 +95,20 @@ class UtilsTestCase(TestCase):
         self.assertTrue(np.allclose(G_x, g_1d_x))
         self.assertTrue(np.allclose(G_y, g_1d_y))
         self.assertTrue(np.allclose(G_z, g_1d_z))
+
+    def testGaussianScalarParam(self):
+        L = 100
+        sigma = 5
+        mu_2d = (2, 3)
+        sigma_2d = (sigma, sigma)
+        mu_3d = (2, 3, 5)
+        sigma_3d = (sigma, sigma, sigma)
+
+        g_2d = gaussian_2d(L, mu_2d, sigma_2d)
+        g_2d_scalar = gaussian_2d(L, mu_2d, sigma)
+
+        g_3d = gaussian_3d(L, mu_3d, sigma_3d)
+        g_3d_scalar = gaussian_3d(L, mu_3d, sigma)
+
+        self.assertTrue(np.allclose(g_2d, g_2d_scalar))
+        self.assertTrue(np.allclose(g_3d, g_3d_scalar))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -58,8 +58,8 @@ class UtilsTestCase(TestCase):
         g = gaussian_2d(L, x0=mu_x, y0=mu_y, sigma_x=s_x, sigma_y=s_y)
 
         # The normalized sum across an axis should correspond to a 1d gaussian with appropriate mu, sigma, peak.
-        g_x = np.sum(g, axis=1) / np.sum(g)
-        g_y = np.sum(g, axis=0) / np.sum(g)
+        g_x = np.sum(g, axis=0) / np.sum(g)
+        g_y = np.sum(g, axis=1) / np.sum(g)
 
         # Corresponding 1d gaussians
         peak_x = 1 / np.sqrt(2 * np.pi * s_x**2)
@@ -79,9 +79,9 @@ class UtilsTestCase(TestCase):
         G = gaussian_3d(L, mu, sigma)
 
         # The normalized sum across two axes should correspond to a 1d gaussian with appropriate mu, sigma, peak.
-        G_x = np.sum(G, axis=(1, 2)) / np.sum(G)
+        G_x = np.sum(G, axis=(0, 1)) / np.sum(G)
         G_y = np.sum(G, axis=(0, 2)) / np.sum(G)
-        G_z = np.sum(G, axis=(0, 1)) / np.sum(G)
+        G_z = np.sum(G, axis=(1, 2)) / np.sum(G)
 
         # Corresponding 1d gaussians
         peak_x = 1 / np.sqrt(2 * np.pi * sigma[0] ** 2)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -52,20 +52,20 @@ class UtilsTestCase(TestCase):
 
     def testGaussian2d(self):
         L = 100
-        mu_x, mu_y = 7, -3
-        s_x, s_y = 5, 6
+        mu = (7, -3)
+        sigma = (5, 6)
 
-        g = gaussian_2d(L, x0=mu_x, y0=mu_y, sigma_x=s_x, sigma_y=s_y)
+        g = gaussian_2d(L, mu=mu, sigma=sigma)
 
         # The normalized sum across an axis should correspond to a 1d gaussian with appropriate mu, sigma, peak.
         g_x = np.sum(g, axis=0) / np.sum(g)
         g_y = np.sum(g, axis=1) / np.sum(g)
 
         # Corresponding 1d gaussians
-        peak_x = 1 / np.sqrt(2 * np.pi * s_x**2)
-        peak_y = 1 / np.sqrt(2 * np.pi * s_y**2)
-        g_1d_x = gaussian_1d(L, mu=mu_x, sigma=s_x, peak=peak_x)
-        g_1d_y = gaussian_1d(L, mu=mu_y, sigma=s_y, peak=peak_y)
+        peak_x = 1 / np.sqrt(2 * np.pi * sigma[0] ** 2)
+        peak_y = 1 / np.sqrt(2 * np.pi * sigma[1] ** 2)
+        g_1d_x = peak_x * gaussian_1d(L, mu=mu[0], sigma=sigma[0])
+        g_1d_y = peak_y * gaussian_1d(L, mu=mu[1], sigma=sigma[1])
 
         # Assert all-close
         self.assertTrue(np.allclose(g_x, g_1d_x))
@@ -87,9 +87,9 @@ class UtilsTestCase(TestCase):
         peak_x = 1 / np.sqrt(2 * np.pi * sigma[0] ** 2)
         peak_y = 1 / np.sqrt(2 * np.pi * sigma[1] ** 2)
         peak_z = 1 / np.sqrt(2 * np.pi * sigma[2] ** 2)
-        g_1d_x = gaussian_1d(L, mu=mu[0], sigma=sigma[0], peak=peak_x)
-        g_1d_y = gaussian_1d(L, mu=mu[1], sigma=sigma[1], peak=peak_y)
-        g_1d_z = gaussian_1d(L, mu=mu[2], sigma=sigma[2], peak=peak_z)
+        g_1d_x = peak_x * gaussian_1d(L, mu=mu[0], sigma=sigma[0])
+        g_1d_y = peak_y * gaussian_1d(L, mu=mu[1], sigma=sigma[1])
+        g_1d_z = peak_z * gaussian_1d(L, mu=mu[2], sigma=sigma[2])
 
         # Assert all-close
         self.assertTrue(np.allclose(G_x, g_1d_x))


### PR DESCRIPTION
This PR addresses the issues raised in #603 related to the functions `gaussian_1d`, `gaussian_2d`, and `gaussian_3d`. Here is a summary of changes:

1. Switched axis indexing from `xy` and `xyz` to `yx` and `zyx` in `gaussian_2d` and `gaussian_3d`, respectively.
2. Removed the `peak` parameter from all `gaussian_` functions.
3. Replaced the centering parameters `x_0`, `y_0`, (`z_0`) with the single parameter `mu` that accepts a 2-tuple (3-tuple).
4. Also replaced the spread parameters `sigma_x` and `sigma_y` with the single parameter `sigma` which can be a 2-tuple (3-tuple for `gaussian_3d`) or a scalar. 
5. Made all `gaussian_` functions accessible from the `aspire.utils` package.
6.  Updated all uses of these `gaussian_` functions (ie. galleries and tests).