### PR TITLE
Use multiprocessing for Class Averaging alignment

### DIFF
--- a/gallery/tutorials/class_averaging.py
+++ b/gallery/tutorials/class_averaging.py
@@ -114,6 +114,7 @@ rir = RIRClass2D(
     large_pca_implementation="legacy",
     nn_implementation="legacy",
     bispectrum_implementation="legacy",
+    num_procs=1,  # Change to "auto" if your machine has many processors
 )
 
 classes, reflections, dists = rir.classify()
@@ -167,6 +168,7 @@ noisy_rir = RIRClass2D(
     large_pca_implementation="legacy",
     nn_implementation="sklearn",
     bispectrum_implementation="legacy",
+    num_procs=1,  # Change to "auto" if your machine has many processors
 )
 
 classes, reflections, dists = noisy_rir.classify()

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         "matplotlib>=3.2.0",
         "mrcfile",
         "numpy==1.21.5",
+        "packaging",
         "pandas==1.3.5",
         "psutil",
         "pyfftw",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setup(
     author_email="devs.aspire@gmail.com",
     install_requires=[
         "click",
-        "dill",
         "finufft",
         "gemmi>=0.4.8",
         "joblib",

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     author_email="devs.aspire@gmail.com",
     install_requires=[
         "click",
+        "dill",
         "finufft",
         "gemmi>=0.4.8",
         "joblib",

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         "mrcfile",
         "numpy==1.21.5",
         "pandas==1.3.5",
+        "psutil",
         "pyfftw",
         "PyWavelets",
         "pillow",

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         "pyfftw",
         "PyWavelets",
         "pillow",
+        "ray",
         "scipy==1.7.3",
         "scikit-learn",
         "scikit-image",

--- a/src/aspire/classification/__init__.py
+++ b/src/aspire/classification/__init__.py
@@ -9,4 +9,5 @@ from .averager2d import (
     ReddyChatterjiAverager2D,
 )
 from .class2d import Class2D
+from .reddy_chatterji import reddy_chatterji_register
 from .rir_class2d import RIRClass2D

--- a/src/aspire/classification/__init__.py
+++ b/src/aspire/classification/__init__.py
@@ -9,5 +9,4 @@ from .averager2d import (
     ReddyChatterjiAverager2D,
 )
 from .class2d import Class2D
-from .reddy_chatterji import reddy_chatterji_register
 from .rir_class2d import RIRClass2D

--- a/src/aspire/classification/averager2d.py
+++ b/src/aspire/classification/averager2d.py
@@ -14,8 +14,6 @@ from aspire.utils.multiprocessing import get_num_multi_procs
 
 logger = logging.getLogger(__name__)
 
-__cache = dict()
-
 
 class Averager2D(ABC):
     """
@@ -477,7 +475,6 @@ class ReddyChatterjiAverager2D(AligningAverager2D):
         :param dtype: Numpy dtype to be used during alignment.
         """
 
-        self.do_cross_corr_translations = True
         self.alignment_src = alignment_src or src
 
         # TODO, for accomodating different resolutions we minimally need to adapt shifting.
@@ -521,9 +518,9 @@ class ReddyChatterjiAverager2D(AligningAverager2D):
             rotations[k], shifts[k], correlations[k] = reddy_chatterji_register(
                 images,
                 reflections[k],
-                self.mask,
-                self.do_cross_corr_translations,
-                self.dtype,
+                mask=self.mask,
+                do_cross_corr_translations=True,
+                dtype=self.dtype,
             )
 
         # else:
@@ -654,8 +651,6 @@ class BFSReddyChatterjiAverager2D(ReddyChatterjiAverager2D):
             dtype=dtype,
         )
 
-        # For brute force we disable the cross_corr translation code
-        self.do_cross_corr_translations = False
         # Assign search radius
         self.radius = radius or src.L // 8
 
@@ -705,9 +700,9 @@ class BFSReddyChatterjiAverager2D(ReddyChatterjiAverager2D):
                 _rotations, _, _correlations = reddy_chatterji_register(
                     images,
                     reflections[k],
-                    self.mask,
-                    self.do_cross_corr_translations,
-                    self.dtype,
+                    mask=self.mask,
+                    do_cross_corr_translations=False,  # For brute force we skip cross corr translation
+                    dtype=self.dtype,
                 )
 
                 # Where corr has improved

--- a/src/aspire/classification/averager2d.py
+++ b/src/aspire/classification/averager2d.py
@@ -247,6 +247,7 @@ class BFRAverager2D(AligningAverager2D):
         src,
         alignment_basis=None,
         n_angles=360,
+        num_procs=1,
         dtype=None,
     ):
         """
@@ -254,7 +255,9 @@ class BFRAverager2D(AligningAverager2D):
 
         :params n_angles: Number of brute force rotations to attempt, defaults 360.
         """
-        super().__init__(composite_basis, src, alignment_basis, dtype=dtype)
+        super().__init__(
+            composite_basis, src, alignment_basis, num_procs=num_procs, dtype=dtype
+        )
 
         self.n_angles = n_angles
 
@@ -336,6 +339,7 @@ class BFSRAverager2D(BFRAverager2D):
         n_angles=360,
         n_x_shifts=1,
         n_y_shifts=1,
+        num_procs=1,
         dtype=None,
     ):
         """
@@ -357,6 +361,7 @@ class BFSRAverager2D(BFRAverager2D):
             src,
             alignment_basis,
             n_angles,
+            num_procs=num_procs,
             dtype=dtype,
         )
 

--- a/src/aspire/classification/averager2d.py
+++ b/src/aspire/classification/averager2d.py
@@ -1,7 +1,7 @@
 import logging
 from abc import ABC, abstractmethod
-from concurrent.futures import ThreadPoolExecutor
-from itertools import product
+from itertools import product, repeat
+from multiprocessing import get_context, Pool
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -17,6 +17,230 @@ from aspire.utils.multiprocessing import get_num_multi_procs
 
 logger = logging.getLogger(__name__)
 
+__cache = dict()
+
+def _phase_cross_correlation(img0, img1):
+    """
+    # Adapted from skimage.registration.phase_cross_correlation
+
+    :param img0: Fixed image.
+    :param img1: Translated image.
+    :returns: (cross-correlation magnitudes (2D array), shifts)
+    """
+
+    # Cache img0 transform, this saves n_classes*(n_nbor-1) transforms
+    # Note we use the `id` because ndarray are unhashable
+    key = id(img0)
+    if key not in __cache:
+        __cache[key] = fft.fft2(img0)
+    src_f = __cache[key]
+
+    target_f = fft.fft2(img1)
+
+    # Whole-pixel shifts - Compute cross-correlation by an IFFT
+    shape = src_f.shape
+    image_product = src_f * target_f.conj()
+    cross_correlation = fft.ifft2(image_product)
+
+    # Locate maximum
+    maxima = np.unravel_index(
+        np.argmax(np.abs(cross_correlation)), cross_correlation.shape
+    )
+    midpoints = np.array([np.fix(axis_size / 2) for axis_size in shape])
+
+    shifts = np.array(maxima, dtype=np.float64)
+    shifts[shifts > midpoints] -= np.array(shape)[shifts > midpoints]
+
+    return np.abs(cross_correlation), shifts
+
+
+def _reddychatterji(images, class_k, reflection_k, mask, do_cross_corr_translations, dtype):
+    """
+    Compute the Reddy Chatterji method registering images[1:] to image[0].
+
+    This differs from papers and published scikit implimentations by
+    computing the fixed base image[0] pipeline once then reusing.
+
+    This is a util function to help loop over `classes`.
+
+    :param images: Image data (m_img, L, L)
+    :param class_k: Image indices (m_img,)
+    :param reflection_k: Image reflections (m_img,)
+    :returns: (rotations_k, correlations_k, shifts_k) corresponding to `images`
+    """
+
+    # Result arrays
+    M = len(images)
+    rotations_k = np.zeros(M, dtype=dtype)
+    correlations_k = np.full(M, -np.inf, dtype=dtype)
+    shifts_k = np.zeros((M, 2), dtype=int)
+
+    # De-Mean, note images is mutated and should be a `copy`.
+    images -= images.mean(axis=(-1, -2))[:, np.newaxis, np.newaxis]
+
+    # Precompute fixed_img data used repeatedly in the loop below.
+    fixed_img = images[0]
+    # Difference of Gaussians (Band Filter)
+    fixed_img_dog = difference_of_gaussians(fixed_img, 1, 4)
+    # Window Images (Fix spectral boundary)
+    wfixed_img = fixed_img_dog * window("hann", fixed_img.shape)
+    # Transform image to Fourier space
+    fixed_img_fs = np.abs(fft.fftshift(fft.fft2(wfixed_img))) ** 2
+    # Compute Log Polar Transform
+    radius = fixed_img_fs.shape[0] // 8  # Low Pass
+    warped_fixed_img_fs = warp_polar(
+        fixed_img_fs,
+        radius=radius,
+        output_shape=fixed_img_fs.shape,
+        scaling="log",
+    )
+    # Only use half of FFT, because it's symmetrical
+    warped_fixed_img_fs = warped_fixed_img_fs[: fixed_img_fs.shape[0] // 2, :]
+
+    # Now prepare for rotating original images,
+    #   and searching for translations.
+    # We start back at the raw fixed_img.
+    twfixed_img = fixed_img * window("hann", fixed_img.shape)
+
+    # Register image `m` against image[0]
+    for m in range(1, len(images)):
+        # Get the image to register
+        regis_img = images[m]
+
+        # Reflect images when necessary
+        if reflection_k[m]:
+            regis_img = np.flipud(regis_img)
+
+        # Difference of Gaussians (Band Filter)
+        regis_img_dog = difference_of_gaussians(regis_img, 1, 4)
+
+        # Window Images (Fix spectral boundary)
+        wregis_img = regis_img_dog * window("hann", regis_img.shape)
+
+        # self._input_images_diagnostic(
+        #     class_k[0], wfixed_img, class_k[m], wregis_img
+        # )
+
+        # Transform image to Fourier space
+        regis_img_fs = np.abs(fft.fftshift(fft.fft2(wregis_img))) ** 2
+
+        # self._windowed_psd_diagnostic(
+        #     class_k[0], fixed_img_fs, class_k[m], regis_img_fs
+        # )
+
+        # Compute Log Polar Transform
+        warped_regis_img_fs = warp_polar(
+            regis_img_fs,
+            radius=radius,  # Low Pass
+            output_shape=fixed_img_fs.shape,
+            scaling="log",
+        )
+
+        # self._log_polar_diagnostic(
+        #     class_k[0], warped_fixed_img_fs, class_k[m], warped_regis_img_fs
+        # )
+
+        # Only use half of FFT, because it's symmetrical
+        warped_regis_img_fs = warped_regis_img_fs[: fixed_img_fs.shape[0] // 2, :]
+
+        # Compute the Cross_Correlation to estimate rotation
+        # Note that _phase_cross_correlation uses the mangnitudes (abs()),
+        #  ie it is using both freq and phase information.
+        cross_correlation, _ = _phase_cross_correlation(
+            warped_fixed_img_fs, warped_regis_img_fs
+        )
+
+        # Rotating Cartesian space translates the angular log polar component.
+        # Scaling Cartesian space translates the radial log polar component.
+        # In common image resgistration problems, both components are used
+        #   to simultaneously estimate scaling and rotation.
+        # Since we are not currently concerned with scaling transformation,
+        #   disregard the second axis of the `cross_correlation` returned by
+        #   `_phase_cross_correlation`.
+        cross_correlation_score = cross_correlation[:, 0].ravel()
+
+        # self._rotation_cross_corr_diagnostic(
+        #     cross_correlation, cross_correlation_score
+        # )
+
+        # Recover the angle from index representing maximal cross_correlation
+        recovered_angle_degrees = (360 / regis_img_fs.shape[0]) * np.argmax(
+            cross_correlation_score
+        )
+
+        if recovered_angle_degrees > 90:
+            r = 180 - recovered_angle_degrees
+        else:
+            r = -recovered_angle_degrees
+
+        # For now, try the hack below, attempting two cases ...
+        # Some papers mention running entire algos /twice/,
+        #   when admitting reflections, so this hack is not
+        #   the worst you could do :).
+        # Hack
+        regis_img_estimated = rotate(regis_img, r)
+        regis_img_rotated_p180 = rotate(regis_img, r + 180)
+        da = np.dot(fixed_img[mask], regis_img_estimated[mask])
+        db = np.dot(fixed_img[mask], regis_img_rotated_p180[mask])
+        if db > da:
+            regis_img_estimated = regis_img_rotated_p180
+            r += 180
+
+        # self._rotated_diagnostic(
+        #     class_k[0],
+        #     fixed_img,
+        #     class_k[m],
+        #     regis_img_estimated,
+        #     reflection_k[m],
+        #     r,
+        # )
+
+        # Assign estimated rotations results
+        rotations_k[m] = -r * np.pi / 180  # Reverse rot and convert to radians
+
+        if do_cross_corr_translations:
+            # Prepare for searching over translations using cross-correlation with the rotated image.
+            twregis_img = regis_img_estimated * window("hann", regis_img.shape)
+            cross_correlation, shift = _phase_cross_correlation(
+                twfixed_img, twregis_img
+            )
+
+            # self._translation_cross_corr_diagnostic(cross_correlation)
+
+            # Compute the shifts as integer number of pixels,
+            shift_x, shift_y = int(shift[1]), int(shift[0])
+            # then apply the shifts
+            regis_img_estimated = np.roll(regis_img_estimated, shift_y, axis=0)
+            regis_img_estimated = np.roll(regis_img_estimated, shift_x, axis=1)
+            # Assign estimated shift to results
+            shifts_k[m] = shift[::-1].astype(int)
+
+            # self._averaged_diagnostic(
+            #     class_k[0],
+            #     fixed_img,
+            #     class_k[m],
+            #     regis_img_estimated,
+            #     reflection_k[m],
+            #     r,
+            # )
+        else:
+            shift = None  # For logger line
+
+        # Estimated `corr` metric
+        corr = np.dot(fixed_img[mask], regis_img_estimated[mask])
+        correlations_k[m] = corr
+
+        # logger.debug(
+        #     f"ref {class_k[0]}, Neighbor {m} Index {class_k[m]}"
+        #     f" Estimates: {r}*, Shift: {shift},"
+        #     f" Corr: {corr}, Refl?: {reflection_k[m]}"
+        # )
+
+    # Cleanup some cached stuff for this class
+    __cache.pop(id(warped_fixed_img_fs), None)
+    __cache.pop(id(twfixed_img), None)
+
+    return rotations_k, shifts_k, correlations_k
 
 class Averager2D(ABC):
     """
@@ -460,7 +684,6 @@ class ReddyChatterjiAverager2D(AligningAverager2D):
         :param dtype: Numpy dtype to be used during alignment.
         """
 
-        self.__cache = dict()
         self.diagnostics = diagnostics
         self.do_cross_corr_translations = True
         self.alignment_src = alignment_src or src
@@ -476,39 +699,6 @@ class ReddyChatterjiAverager2D(AligningAverager2D):
 
         super().__init__(composite_basis, src, composite_basis, dtype=dtype)
 
-    def _phase_cross_correlation(self, img0, img1):
-        """
-        # Adapted from skimage.registration.phase_cross_correlation
-
-        :param img0: Fixed image.
-        :param img1: Translated image.
-        :returns: (cross-correlation magnitudes (2D array), shifts)
-        """
-
-        # Cache img0 transform, this saves n_classes*(n_nbor-1) transforms
-        # Note we use the `id` because ndarray are unhashable
-        key = id(img0)
-        if key not in self.__cache:
-            self.__cache[key] = fft.fft2(img0)
-        src_f = self.__cache[key]
-
-        target_f = fft.fft2(img1)
-
-        # Whole-pixel shifts - Compute cross-correlation by an IFFT
-        shape = src_f.shape
-        image_product = src_f * target_f.conj()
-        cross_correlation = fft.ifft2(image_product)
-
-        # Locate maximum
-        maxima = np.unravel_index(
-            np.argmax(np.abs(cross_correlation)), cross_correlation.shape
-        )
-        midpoints = np.array([np.fix(axis_size / 2) for axis_size in shape])
-
-        shifts = np.array(maxima, dtype=np.float64)
-        shifts[shifts > midpoints] -= np.array(shape)[shifts > midpoints]
-
-        return np.abs(cross_correlation), shifts
 
     def align(self, classes, reflections, basis_coefficients):
         """
@@ -527,217 +717,37 @@ class ReddyChatterjiAverager2D(AligningAverager2D):
         correlations = np.zeros(classes.shape, dtype=self.dtype)
         shifts = np.zeros((*classes.shape, 2), dtype=int)
 
-        # def _innerloop(k, rotations, shifts, correlations):
-        def _innerloop(k):
-            logger.info(
-                f"Processing alignment for class: {k}",
-            )
-            # # Get the array of images for this class, using the `alignment_src`.
-            images = self._cls_images(classes[k], src=self.alignment_src)
-
-            rotations[k], shifts[k], correlations[k] = self._reddychatterji(
-                images, classes[k], reflections[k]
-            )
-
         if self.num_procs < 1:
             for k in trange(n_classes):
-                _innerloop(k)
+                logger.info(
+                    f"Processing alignment for class: {k}",
+                )
+                # # Get the array of images for this class, using the `alignment_src`.
+                images = self._cls_images(classes[k], src=self.alignment_src)
+
+                rotations[k], shifts[k], correlations[k] = _reddychatterji(images, classes[k], reflections[k], self.mask, self.do_cross_corr_translations, self.dtype)
+
         else:
+            xxx_all_images = [self._cls_images(classes[k], src=self.alignment_src) for k in range(n_classes)]
             logger.info(f"Starting Pool({self.num_procs})")
-            exe = ThreadPoolExecutor(max_workers=self.num_procs)
-            exe.map(_innerloop, range(n_classes))
-            exe.shutdown()
+            with get_context("spawn").Pool(self.num_procs) as p:
+                
+                #res = p.starmap(self._innerloop, zip(range(n_classes), repeat(classes), repeat(reflections)))
+                res = p.starmap(
+                    _reddychatterji,
+                    zip(xxx_all_images, classes, reflections, repeat(self.mask), repeat(self.do_cross_corr_translations), repeat(self.dtype)
+                    )
+                )
+                p.close()
+                p.join()
+
             logger.info(f"Terminated Pool({self.num_procs})")
+            
+            # Unpack multiprocessing join
+            for k, v in enumerate(res):
+                rotations[k], shifts[k], correlations[k] = v
 
         return rotations, shifts, correlations
-
-    def _reddychatterji(self, images, class_k, reflection_k):
-        """
-        Compute the Reddy Chatterji method registering images[1:] to image[0].
-
-        This differs from papers and published scikit implimentations by
-        computing the fixed base image[0] pipeline once then reusing.
-
-        This is a util function to help loop over `classes`.
-
-        :param images: Image data (m_img, L, L)
-        :param class_k: Image indices (m_img,)
-        :param reflection_k: Image reflections (m_img,)
-        :returns: (rotations_k, correlations_k, shifts_k) corresponding to `images`
-        """
-
-        # Result arrays
-        M = len(images)
-        rotations_k = np.zeros(M, dtype=self.dtype)
-        correlations_k = np.full(M, -np.inf, dtype=self.dtype)
-        shifts_k = np.zeros((M, 2), dtype=int)
-
-        # De-Mean, note images is mutated and should be a `copy`.
-        images -= images.mean(axis=(-1, -2))[:, np.newaxis, np.newaxis]
-
-        # Precompute fixed_img data used repeatedly in the loop below.
-        fixed_img = images[0]
-        # Difference of Gaussians (Band Filter)
-        fixed_img_dog = difference_of_gaussians(fixed_img, 1, 4)
-        # Window Images (Fix spectral boundary)
-        wfixed_img = fixed_img_dog * window("hann", fixed_img.shape)
-        # Transform image to Fourier space
-        fixed_img_fs = np.abs(fft.fftshift(fft.fft2(wfixed_img))) ** 2
-        # Compute Log Polar Transform
-        radius = fixed_img_fs.shape[0] // 8  # Low Pass
-        warped_fixed_img_fs = warp_polar(
-            fixed_img_fs,
-            radius=radius,
-            output_shape=fixed_img_fs.shape,
-            scaling="log",
-        )
-        # Only use half of FFT, because it's symmetrical
-        warped_fixed_img_fs = warped_fixed_img_fs[: fixed_img_fs.shape[0] // 2, :]
-
-        # Now prepare for rotating original images,
-        #   and searching for translations.
-        # We start back at the raw fixed_img.
-        twfixed_img = fixed_img * window("hann", fixed_img.shape)
-
-        # Register image `m` against image[0]
-        for m in range(1, len(images)):
-            # Get the image to register
-            regis_img = images[m]
-
-            # Reflect images when necessary
-            if reflection_k[m]:
-                regis_img = np.flipud(regis_img)
-
-            # Difference of Gaussians (Band Filter)
-            regis_img_dog = difference_of_gaussians(regis_img, 1, 4)
-
-            # Window Images (Fix spectral boundary)
-            wregis_img = regis_img_dog * window("hann", regis_img.shape)
-
-            self._input_images_diagnostic(
-                class_k[0], wfixed_img, class_k[m], wregis_img
-            )
-
-            # Transform image to Fourier space
-            regis_img_fs = np.abs(fft.fftshift(fft.fft2(wregis_img))) ** 2
-
-            self._windowed_psd_diagnostic(
-                class_k[0], fixed_img_fs, class_k[m], regis_img_fs
-            )
-
-            # Compute Log Polar Transform
-            warped_regis_img_fs = warp_polar(
-                regis_img_fs,
-                radius=radius,  # Low Pass
-                output_shape=fixed_img_fs.shape,
-                scaling="log",
-            )
-
-            self._log_polar_diagnostic(
-                class_k[0], warped_fixed_img_fs, class_k[m], warped_regis_img_fs
-            )
-
-            # Only use half of FFT, because it's symmetrical
-            warped_regis_img_fs = warped_regis_img_fs[: fixed_img_fs.shape[0] // 2, :]
-
-            # Compute the Cross_Correlation to estimate rotation
-            # Note that _phase_cross_correlation uses the mangnitudes (abs()),
-            #  ie it is using both freq and phase information.
-            cross_correlation, _ = self._phase_cross_correlation(
-                warped_fixed_img_fs, warped_regis_img_fs
-            )
-
-            # Rotating Cartesian space translates the angular log polar component.
-            # Scaling Cartesian space translates the radial log polar component.
-            # In common image resgistration problems, both components are used
-            #   to simultaneously estimate scaling and rotation.
-            # Since we are not currently concerned with scaling transformation,
-            #   disregard the second axis of the `cross_correlation` returned by
-            #   `_phase_cross_correlation`.
-            cross_correlation_score = cross_correlation[:, 0].ravel()
-
-            self._rotation_cross_corr_diagnostic(
-                cross_correlation, cross_correlation_score
-            )
-
-            # Recover the angle from index representing maximal cross_correlation
-            recovered_angle_degrees = (360 / regis_img_fs.shape[0]) * np.argmax(
-                cross_correlation_score
-            )
-
-            if recovered_angle_degrees > 90:
-                r = 180 - recovered_angle_degrees
-            else:
-                r = -recovered_angle_degrees
-
-            # For now, try the hack below, attempting two cases ...
-            # Some papers mention running entire algos /twice/,
-            #   when admitting reflections, so this hack is not
-            #   the worst you could do :).
-            # Hack
-            regis_img_estimated = rotate(regis_img, r)
-            regis_img_rotated_p180 = rotate(regis_img, r + 180)
-            da = np.dot(fixed_img[self.mask], regis_img_estimated[self.mask])
-            db = np.dot(fixed_img[self.mask], regis_img_rotated_p180[self.mask])
-            if db > da:
-                regis_img_estimated = regis_img_rotated_p180
-                r += 180
-
-            self._rotated_diagnostic(
-                class_k[0],
-                fixed_img,
-                class_k[m],
-                regis_img_estimated,
-                reflection_k[m],
-                r,
-            )
-
-            # Assign estimated rotations results
-            rotations_k[m] = -r * np.pi / 180  # Reverse rot and convert to radians
-
-            if self.do_cross_corr_translations:
-                # Prepare for searching over translations using cross-correlation with the rotated image.
-                twregis_img = regis_img_estimated * window("hann", regis_img.shape)
-                cross_correlation, shift = self._phase_cross_correlation(
-                    twfixed_img, twregis_img
-                )
-
-                self._translation_cross_corr_diagnostic(cross_correlation)
-
-                # Compute the shifts as integer number of pixels,
-                shift_x, shift_y = int(shift[1]), int(shift[0])
-                # then apply the shifts
-                regis_img_estimated = np.roll(regis_img_estimated, shift_y, axis=0)
-                regis_img_estimated = np.roll(regis_img_estimated, shift_x, axis=1)
-                # Assign estimated shift to results
-                shifts_k[m] = shift[::-1].astype(int)
-
-                self._averaged_diagnostic(
-                    class_k[0],
-                    fixed_img,
-                    class_k[m],
-                    regis_img_estimated,
-                    reflection_k[m],
-                    r,
-                )
-            else:
-                shift = None  # For logger line
-
-            # Estimated `corr` metric
-            corr = np.dot(fixed_img[self.mask], regis_img_estimated[self.mask])
-            correlations_k[m] = corr
-
-            logger.debug(
-                f"ref {class_k[0]}, Neighbor {m} Index {class_k[m]}"
-                f" Estimates: {r}*, Shift: {shift},"
-                f" Corr: {corr}, Refl?: {reflection_k[m]}"
-            )
-
-        # Cleanup some cached stuff for this class
-        self.__cache.pop(id(warped_fixed_img_fs), None)
-        self.__cache.pop(id(twfixed_img), None)
-
-        return rotations_k, shifts_k, correlations_k
 
     def average(
         self,
@@ -1013,9 +1023,10 @@ class BFSReddyChatterjiAverager2D(ReddyChatterjiAverager2D):
                 # Don't shift the base image
                 images[1:] = Image(unshifted_images[1:]).shift(s).asnumpy()
 
-                _rotations, _, _correlations = self._reddychatterji(
-                    images, classes[k], reflections[k]
-                )
+                # _rotations, _, _correlations = self._reddychatterji(
+                #     images, classes[k], reflections[k]
+                # )
+                _rotations, _, _correlations  = _reddychatterji(images, classes[k], reflections[k], self.mask, self.do_cross_corr_translations, self.dtype)
 
                 # Where corr has improved
                 #  update our rolling best results with this loop.
@@ -1024,16 +1035,21 @@ class BFSReddyChatterjiAverager2D(ReddyChatterjiAverager2D):
                 rotations[k] = np.where(improved, _rotations, rotations[k])
                 shifts[k] = np.where(improved[..., np.newaxis], s, shifts[k])
                 logger.debug(f"Shift {s} has improved {np.sum(improved)} results")
+            return rotations, shifts, correlations
+
 
         if self.num_procs < 1:
             for k in trange(n_classes):
-                _innerloop(k)
+                rotations[k], shifts[k], correlations[k] = _innerloop(k)
         else:
             logger.info(f"Starting Pool({self.num_procs})")
-            exe = ThreadPoolExecutor(max_workers=self.num_procs)
-            exe.map(_innerloop, range(n_classes))
-            exe.shutdown()
+            with get_context("fork").Pool(self.num_procs) as p:
+                res = p.map(_innerloop, range(n_classes))
             logger.info(f"Terminated Pool({self.num_procs})")
+            
+            # Unpack multiprocessing join
+            for k, v in enumerate(res):
+                rotations[k], shifts[k], correlations[k] = v
 
         return rotations, shifts, correlations
 

--- a/src/aspire/classification/averager2d.py
+++ b/src/aspire/classification/averager2d.py
@@ -1065,10 +1065,10 @@ class BFSReddyChatterjiAverager2D(ReddyChatterjiAverager2D):
 
                 # Where corr has improved
                 #  update our rolling best results with this loop.
-                improved = _correlations > correlations[k]
-                __correlations = np.where(improved, _correlations, correlations[k])
-                __rotations = np.where(improved, _rotations, rotations[k])
-                __shifts = np.where(improved[..., np.newaxis], s, shifts[k])
+                improved = _correlations > __correlations
+                __correlations = np.where(improved, _correlations, __correlations)
+                __rotations = np.where(improved, _rotations, __rotations)
+                __shifts = np.where(improved[..., np.newaxis], s, __shifts)
                 logger.debug(f"Shift {s} has improved {np.sum(improved)} results")
             return __rotations, __shifts, __correlations
 

--- a/src/aspire/classification/averager2d.py
+++ b/src/aspire/classification/averager2d.py
@@ -3,9 +3,11 @@ from abc import ABC, abstractmethod
 from itertools import product
 
 import numpy as np
+import ray
 from ray.util.multiprocessing import Pool
 from tqdm import tqdm, trange
 
+from aspire import config
 from aspire.classification.reddy_chatterji import reddy_chatterji_register
 from aspire.image import Image
 from aspire.source import ArrayImageSource
@@ -222,8 +224,10 @@ class AligningAverager2D(Averager2D):
                 b_avgs[i] = _innerloop(i)
         else:
             logger.info(f"Starting Pool({self.num_procs})")
+            ray.init(_temp_dir=config.ray.temp_dir)
             with Pool(self.num_procs) as p:
                 results = p.map(_innerloop, range(n_classes))
+            ray.shutdown()
 
             logger.info(f"Terminated Pool({self.num_procs}), unpacking results.")
             for i, result in enumerate(results):
@@ -542,8 +546,10 @@ class ReddyChatterjiAverager2D(AligningAverager2D):
 
         else:
             logger.info(f"Starting Pool({self.num_procs})")
+            ray.init(_temp_dir=config.ray.temp_dir)
             with Pool(self.num_procs) as p:
                 results = p.map(_innerloop, range(n_classes))
+            ray.shutdown()
 
             logger.info(f"Terminated Pool({self.num_procs}), unpacking results.")
             for k, result in enumerate(results):
@@ -600,8 +606,10 @@ class ReddyChatterjiAverager2D(AligningAverager2D):
             b_avgs[i] = _innerloop(i)
         else:
             logger.info(f"Starting Pool({self.num_procs})")
+            ray.init(_temp_dir=config.ray.temp_dir)
             with Pool(self.num_procs) as p:
                 results = p.map(_innerloop, range(n_classes))
+            ray.shutdown()
 
             logger.info(f"Terminated Pool({self.num_procs}), unpacking results.")
             for i, result in enumerate(results):
@@ -729,8 +737,10 @@ class BFSReddyChatterjiAverager2D(ReddyChatterjiAverager2D):
                 rotations[k], shifts[k], correlations[k] = _innerloop(k)
         else:
             logger.info(f"Starting Pool({self.num_procs})")
+            ray.init(_temp_dir=config.ray.temp_dir)
             with Pool(self.num_procs) as p:
                 results = p.map(_innerloop, range(n_classes))
+            ray.shutdown()
 
             logger.info(f"Terminated Pool({self.num_procs}), unpacking results.")
             for k, result in enumerate(results):

--- a/src/aspire/classification/averager2d.py
+++ b/src/aspire/classification/averager2d.py
@@ -1035,7 +1035,6 @@ class BFSReddyChatterjiAverager2D(ReddyChatterjiAverager2D):
             __correlations = np.ones(classes.shape[1:], dtype=self.dtype) * -np.inf
             __shifts = np.zeros((*classes.shape[1:], 2), dtype=int)
 
-
             for xs, ys in zip(X, Y):
                 s = np.array([xs, ys])
                 # Get the array of images for this class
@@ -1074,7 +1073,7 @@ class BFSReddyChatterjiAverager2D(ReddyChatterjiAverager2D):
             with Pool(self.num_procs) as p:
                 results = p.map(_innerloop, range(n_classes))
 
-            for k, res in  enumerate(results):
+            for k, res in enumerate(results):
                 rotations[k], shifts[k], correlations[k] = res
 
         return rotations, shifts, correlations

--- a/src/aspire/classification/averager2d.py
+++ b/src/aspire/classification/averager2d.py
@@ -1,6 +1,6 @@
 import logging
 from abc import ABC, abstractmethod
-from itertools import product, repeat
+from itertools import product
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -251,7 +251,7 @@ class Averager2D(ABC):
     Base class for 2D Image Averaging methods.
     """
 
-    def __init__(self, composite_basis, src, num_procs=1, dtype=None):
+    def __init__(self, composite_basis, src, num_procs="auto", dtype=None):
         """
         :param composite_basis:  Basis to be used during class average composition (eg FFB2D)
         :param src: Source of original images.
@@ -726,50 +726,50 @@ class ReddyChatterjiAverager2D(AligningAverager2D):
         correlations = np.zeros(classes.shape, dtype=self.dtype)
         shifts = np.zeros((*classes.shape, 2), dtype=int)
 
-        if self.num_procs <= 1:
-            for k in trange(n_classes):
-                logger.info(
-                    f"Processing alignment for class: {k}",
-                )
-                # # Get the array of images for this class, using the `alignment_src`.
-                images = self._cls_images(classes[k], src=self.alignment_src)
+        # if self.num_procs <= 1:
+        for k in trange(n_classes):
+            logger.info(
+                f"Processing alignment for class: {k}",
+            )
+            # # Get the array of images for this class, using the `alignment_src`.
+            images = self._cls_images(classes[k], src=self.alignment_src)
 
-                rotations[k], shifts[k], correlations[k] = _reddychatterji(
-                    images,
-                    classes[k],
-                    reflections[k],
-                    self.mask,
-                    self.do_cross_corr_translations,
-                    self.dtype,
-                )
+            rotations[k], shifts[k], correlations[k] = _reddychatterji(
+                images,
+                classes[k],
+                reflections[k],
+                self.mask,
+                self.do_cross_corr_translations,
+                self.dtype,
+            )
 
-        else:
-            # Todo, replace this with a generator or function or something to pack in the zip below.
-            xxx_all_images = [
-                self._cls_images(classes[k], src=self.alignment_src)
-                for k in range(n_classes)
-            ]
+        # else:
+        #     # Todo, replace this with a generator or function or something to pack in the zip below.
+        #     xxx_all_images = [
+        #         self._cls_images(classes[k], src=self.alignment_src)
+        #         for k in range(n_classes)
+        #     ]
 
-            logger.info(f"Starting Pool({self.num_procs})")
-            with Pool(self.num_procs) as p:
+        #     logger.info(f"Starting Pool({self.num_procs})")
+        #     with Pool(self.num_procs) as p:
 
-                res = p.starmap(
-                    _reddychatterji,
-                    zip(
-                        xxx_all_images,
-                        classes,
-                        reflections,
-                        repeat(self.mask),
-                        repeat(self.do_cross_corr_translations),
-                        repeat(self.dtype),
-                    ),
-                )
+        #         res = p.starmap(
+        #             _reddychatterji,
+        #             zip(
+        #                 xxx_all_images,
+        #                 classes,
+        #                 reflections,
+        #                 repeat(self.mask),
+        #                 repeat(self.do_cross_corr_translations),
+        #                 repeat(self.dtype),
+        #             ),
+        #         )
 
-            logger.info(f"Terminated Pool({self.num_procs})")
+        #     logger.info(f"Terminated Pool({self.num_procs})")
 
-            # Unpack multiprocessing join
-            for k, v in enumerate(res):
-                rotations[k], shifts[k], correlations[k] = v
+        #     # Unpack multiprocessing join
+        #     for k, v in enumerate(res):
+        #         rotations[k], shifts[k], correlations[k] = v
 
         return rotations, shifts, correlations
 

--- a/src/aspire/classification/averager2d.py
+++ b/src/aspire/classification/averager2d.py
@@ -255,6 +255,8 @@ class Averager2D(ABC):
         """
         :param composite_basis:  Basis to be used during class average composition (eg FFB2D)
         :param src: Source of original images.
+        :param num_procs: Number of processes to use. Defaults "auto".
+        Note some underlying code may already use threading.
         :param dtype: Numpy dtype to be used during alignment.
         """
 
@@ -270,7 +272,11 @@ class Averager2D(ABC):
         else:
             self.dtype = np.dtype(dtype)
 
-        self.num_procs = get_num_multi_procs(num_procs)
+        if num_procs == "auto":
+            num_procs = get_num_multi_procs()
+        elif not (isinstance(num_procs, int) and num_procs > 0):
+            raise ValueError(f"num_procs should be an integer, passed {num_procs}.")
+        self.num_procs = num_procs
 
         if self.src and self.dtype != self.src.dtype:
             logger.warning(

--- a/src/aspire/classification/averager2d.py
+++ b/src/aspire/classification/averager2d.py
@@ -251,7 +251,7 @@ class Averager2D(ABC):
     Base class for 2D Image Averaging methods.
     """
 
-    def __init__(self, composite_basis, src, num_procs="auto", dtype=None):
+    def __init__(self, composite_basis, src, num_procs=1, dtype=None):
         """
         :param composite_basis:  Basis to be used during class average composition (eg FFB2D)
         :param src: Source of original images.
@@ -726,7 +726,7 @@ class ReddyChatterjiAverager2D(AligningAverager2D):
         correlations = np.zeros(classes.shape, dtype=self.dtype)
         shifts = np.zeros((*classes.shape, 2), dtype=int)
 
-        if self.num_procs < 1:
+        if self.num_procs <= 1:
             for k in trange(n_classes):
                 logger.info(
                     f"Processing alignment for class: {k}",
@@ -1072,7 +1072,7 @@ class BFSReddyChatterjiAverager2D(ReddyChatterjiAverager2D):
                 logger.debug(f"Shift {s} has improved {np.sum(improved)} results")
             return __rotations, __shifts, __correlations
 
-        if self.num_procs < 1:
+        if self.num_procs <= 1:
             for k in trange(n_classes):
                 rotations[k], shifts[k], correlations[k] = _innerloop(k)
         else:

--- a/src/aspire/classification/reddy_chatterji.py
+++ b/src/aspire/classification/reddy_chatterji.py
@@ -51,12 +51,10 @@ def reddy_chatterji_register(
     images_k, reflection_k, mask=None, do_cross_corr_translations=True, dtype=None
 ):
     """
-    Compute the Reddy Chatterji method registering images_k[1:] to image[0].
+    Compute the Reddy Chatterji method registering images_k[1:] to images_k[0].
 
     This differs from papers and published scikit implimentations by
-    computing the fixed base image[0] pipeline once then reusing.
-
-    This is a util function to help loop over `classes`.
+    computing the fixed base image_k[0] pipeline once then reusing.
 
     :param images_k: Image data (m_img, L, L)
     :param reflection_k: Image reflections (m_img,)

--- a/src/aspire/classification/reddy_chatterji.py
+++ b/src/aspire/classification/reddy_chatterji.py
@@ -5,6 +5,7 @@ from skimage.filters import difference_of_gaussians, window
 from skimage.transform import rotate, warp_polar
 
 from aspire.numeric import fft
+from aspire.utils.coor_trans import grid_2d
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +48,7 @@ def _phase_cross_correlation(img0, img1):
 
 
 def reddy_chatterji_register(
-    images_k, reflection_k, mask, do_cross_corr_translations, dtype
+    images_k, reflection_k, mask=None, do_cross_corr_translations=True, dtype=None
 ):
     """
     Compute the Reddy Chatterji method registering images_k[1:] to image[0].
@@ -59,8 +60,17 @@ def reddy_chatterji_register(
 
     :param images_k: Image data (m_img, L, L)
     :param reflection_k: Image reflections (m_img,)
+    :param mask: Support of image. Defaults to disk with radius images_k.shape[-1]//2.
+    :param do_cross_corr_translations: Solve trnaslations by using cross correlation (log polar) method.
+    :param dtype: Specify dtype.  Defaults to infer from images_k.dtype
     :returns: (rotations_k, shifts_k, correlations_k) corresponding to `images_k`
     """
+
+    if mask is None:
+        L = images_k.shape[-1]
+        mask = grid_2d(L, normalized=False)["r"] < L // 2
+    if dtype is None:
+        dtype = images_k.dtype
 
     # Result arrays
     M = len(images_k)

--- a/src/aspire/classification/reddy_chatterji.py
+++ b/src/aspire/classification/reddy_chatterji.py
@@ -1,0 +1,195 @@
+import logging
+
+import numpy as np
+from skimage.filters import difference_of_gaussians, window
+from skimage.transform import rotate, warp_polar
+
+from aspire.numeric import fft
+
+logger = logging.getLogger(__name__)
+
+__cache = dict()
+
+
+def _phase_cross_correlation(img0, img1):
+    """
+    # Adapted from skimage.registration.phase_cross_correlation
+
+    :param img0: Fixed image.
+    :param img1: Translated image.
+    :returns: (cross-correlation magnitudes (2D array), shifts)
+    """
+
+    # Cache img0 transform, this saves n_classes*(n_nbor-1) transforms
+    # Note we use the `id` because ndarray are unhashable
+    key = id(img0)
+    if key not in __cache:
+        __cache[key] = fft.fft2(img0)
+    src_f = __cache[key]
+
+    target_f = fft.fft2(img1)
+
+    # Whole-pixel shifts - Compute cross-correlation by an IFFT
+    shape = src_f.shape
+    image_product = src_f * target_f.conj()
+    cross_correlation = fft.ifft2(image_product)
+
+    # Locate maximum
+    maxima = np.unravel_index(
+        np.argmax(np.abs(cross_correlation)), cross_correlation.shape
+    )
+    midpoints = np.array([np.fix(axis_size / 2) for axis_size in shape])
+
+    shifts = np.array(maxima, dtype=np.float64)
+    shifts[shifts > midpoints] -= np.array(shape)[shifts > midpoints]
+
+    return np.abs(cross_correlation), shifts
+
+
+def reddy_chatterji_register(
+    images_k, reflection_k, mask, do_cross_corr_translations, dtype
+):
+    """
+    Compute the Reddy Chatterji method registering images_k[1:] to image[0].
+
+    This differs from papers and published scikit implimentations by
+    computing the fixed base image[0] pipeline once then reusing.
+
+    This is a util function to help loop over `classes`.
+
+    :param images_k: Image data (m_img, L, L)
+    :param reflection_k: Image reflections (m_img,)
+    :returns: (rotations_k, shifts_k, correlations_k) corresponding to `images_k`
+    """
+
+    # Result arrays
+    M = len(images_k)
+    rotations_k = np.zeros(M, dtype=dtype)
+    correlations_k = np.full(M, -np.inf, dtype=dtype)
+    shifts_k = np.zeros((M, 2), dtype=int)
+
+    # De-Mean
+    images_k = images_k - images_k.mean(axis=(-1, -2))[:, np.newaxis, np.newaxis]
+
+    # Precompute fixed_img data used repeatedly in the loop below.
+    fixed_img = images_k[0]
+    # Difference of Gaussians (Band Filter)
+    fixed_img_dog = difference_of_gaussians(fixed_img, 1, 4)
+    # Window Images (Fix spectral boundary)
+    wfixed_img = fixed_img_dog * window("hann", fixed_img.shape)
+    # Transform image to Fourier space
+    fixed_img_fs = np.abs(fft.fftshift(fft.fft2(wfixed_img))) ** 2
+    # Compute Log Polar Transform
+    radius = fixed_img_fs.shape[0] // 8  # Low Pass
+    warped_fixed_img_fs = warp_polar(
+        fixed_img_fs,
+        radius=radius,
+        output_shape=fixed_img_fs.shape,
+        scaling="log",
+    )
+    # Only use half of FFT, because it's symmetrical
+    warped_fixed_img_fs = warped_fixed_img_fs[: fixed_img_fs.shape[0] // 2, :]
+
+    # Now prepare for rotating original images,
+    #   and searching for translations.
+    # We start back at the raw fixed_img.
+    twfixed_img = fixed_img * window("hann", fixed_img.shape)
+
+    # Register image `m` against images_k[0]
+    for m in range(1, len(images_k)):
+        # Get the image to register
+        regis_img = images_k[m]
+
+        # Reflect images when necessary
+        if reflection_k[m]:
+            regis_img = np.flipud(regis_img)
+
+        # Difference of Gaussians (Band Filter)
+        regis_img_dog = difference_of_gaussians(regis_img, 1, 4)
+
+        # Window Images (Fix spectral boundary)
+        wregis_img = regis_img_dog * window("hann", regis_img.shape)
+
+        # Transform image to Fourier space
+        regis_img_fs = np.abs(fft.fftshift(fft.fft2(wregis_img))) ** 2
+
+        # Compute Log Polar Transform
+        warped_regis_img_fs = warp_polar(
+            regis_img_fs,
+            radius=radius,  # Low Pass
+            output_shape=fixed_img_fs.shape,
+            scaling="log",
+        )
+
+        # Only use half of FFT, because it's symmetrical
+        warped_regis_img_fs = warped_regis_img_fs[: fixed_img_fs.shape[0] // 2, :]
+
+        # Compute the Cross_Correlation to estimate rotation
+        # Note that _phase_cross_correlation uses the mangnitudes (abs()),
+        #  ie it is using both freq and phase information.
+        cross_correlation, _ = _phase_cross_correlation(
+            warped_fixed_img_fs, warped_regis_img_fs
+        )
+
+        # Rotating Cartesian space translates the angular log polar component.
+        # Scaling Cartesian space translates the radial log polar component.
+        # In common image resgistration problems, both components are used
+        #   to simultaneously estimate scaling and rotation.
+        # Since we are not currently concerned with scaling transformation,
+        #   disregard the second axis of the `cross_correlation` returned by
+        #   `_phase_cross_correlation`.
+        cross_correlation_score = cross_correlation[:, 0].ravel()
+
+        # Recover the angle from index representing maximal cross_correlation
+        recovered_angle_degrees = (360 / regis_img_fs.shape[0]) * np.argmax(
+            cross_correlation_score
+        )
+
+        if recovered_angle_degrees > 90:
+            r = 180 - recovered_angle_degrees
+        else:
+            r = -recovered_angle_degrees
+
+        # For now, try the hack below, attempting two cases ...
+        # Some papers mention running entire algos /twice/,
+        #   when admitting reflections, so this hack is not
+        #   the worst you could do :).
+        # Hack
+        regis_img_estimated = rotate(regis_img, r)
+        regis_img_rotated_p180 = rotate(regis_img, r + 180)
+        da = np.dot(fixed_img[mask], regis_img_estimated[mask])
+        db = np.dot(fixed_img[mask], regis_img_rotated_p180[mask])
+        if db > da:
+            regis_img_estimated = regis_img_rotated_p180
+            r += 180
+
+        # Assign estimated rotations results
+        rotations_k[m] = -r * np.pi / 180  # Reverse rot and convert to radians
+
+        if do_cross_corr_translations:
+            # Prepare for searching over translations using cross-correlation with the rotated image.
+            twregis_img = regis_img_estimated * window("hann", regis_img.shape)
+            cross_correlation, shift = _phase_cross_correlation(
+                twfixed_img, twregis_img
+            )
+
+            # Compute the shifts as integer number of pixels,
+            shift_x, shift_y = int(shift[1]), int(shift[0])
+            # then apply the shifts
+            regis_img_estimated = np.roll(regis_img_estimated, shift_y, axis=0)
+            regis_img_estimated = np.roll(regis_img_estimated, shift_x, axis=1)
+            # Assign estimated shift to results
+            shifts_k[m] = shift[::-1].astype(int)
+
+        else:
+            shift = None  # For logger line
+
+        # Estimated `corr` metric
+        corr = np.dot(fixed_img[mask], regis_img_estimated[mask])
+        correlations_k[m] = corr
+
+    # Cleanup some cached stuff for this class
+    __cache.pop(id(warped_fixed_img_fs), None)
+    __cache.pop(id(twfixed_img), None)
+
+    return rotations_k, shifts_k, correlations_k

--- a/src/aspire/classification/rir_class2d.py
+++ b/src/aspire/classification/rir_class2d.py
@@ -6,8 +6,11 @@ from sklearn.neighbors import NearestNeighbors
 from tqdm import tqdm
 
 from aspire.basis import FSPCABasis
-from aspire.classification import BFSReddyChatterjiAverager2D, Class2D
-from aspire.classification import ReddyChatterjiAverager2D, Class2D
+from aspire.classification import (
+    BFSReddyChatterjiAverager2D,
+    Class2D,
+    ReddyChatterjiAverager2D,
+)
 from aspire.classification.legacy_implementations import bispec_2drot_large, pca_y
 from aspire.numeric import ComplexPCA
 from aspire.utils.random import rand
@@ -173,7 +176,7 @@ class RIRClass2D(Class2D):
         # When not provided by a user, the averager is instantiated after
         #  we are certain our pca_basis has been constructed.
         if self.averager is None:
-            #self.averager = BFSReddyChatterjiAverager2D(
+            # self.averager = BFSReddyChatterjiAverager2D(
             self.averager = ReddyChatterjiAverager2D(
                 self.fb_basis, self.src, dtype=self.dtype
             )

--- a/src/aspire/classification/rir_class2d.py
+++ b/src/aspire/classification/rir_class2d.py
@@ -7,6 +7,7 @@ from tqdm import tqdm
 
 from aspire.basis import FSPCABasis
 from aspire.classification import BFSReddyChatterjiAverager2D, Class2D
+from aspire.classification import ReddyChatterjiAverager2D, Class2D
 from aspire.classification.legacy_implementations import bispec_2drot_large, pca_y
 from aspire.numeric import ComplexPCA
 from aspire.utils.random import rand
@@ -172,7 +173,8 @@ class RIRClass2D(Class2D):
         # When not provided by a user, the averager is instantiated after
         #  we are certain our pca_basis has been constructed.
         if self.averager is None:
-            self.averager = BFSReddyChatterjiAverager2D(
+            #self.averager = BFSReddyChatterjiAverager2D(
+            self.averager = ReddyChatterjiAverager2D(
                 self.fb_basis, self.src, dtype=self.dtype
             )
 

--- a/src/aspire/classification/rir_class2d.py
+++ b/src/aspire/classification/rir_class2d.py
@@ -6,11 +6,7 @@ from sklearn.neighbors import NearestNeighbors
 from tqdm import tqdm
 
 from aspire.basis import FSPCABasis
-from aspire.classification import (
-    BFSReddyChatterjiAverager2D,
-    Class2D,
-    ReddyChatterjiAverager2D,
-)
+from aspire.classification import BFSReddyChatterjiAverager2D, Class2D
 from aspire.classification.legacy_implementations import bispec_2drot_large, pca_y
 from aspire.numeric import ComplexPCA
 from aspire.utils.random import rand

--- a/src/aspire/classification/rir_class2d.py
+++ b/src/aspire/classification/rir_class2d.py
@@ -176,8 +176,8 @@ class RIRClass2D(Class2D):
         # When not provided by a user, the averager is instantiated after
         #  we are certain our pca_basis has been constructed.
         if self.averager is None:
-            # self.averager = BFSReddyChatterjiAverager2D(
-            self.averager = ReddyChatterjiAverager2D(
+            # self.averager = ReddyChatterjiAverager2D(
+            self.averager = BFSReddyChatterjiAverager2D(
                 self.fb_basis, self.src, dtype=self.dtype
             )
 

--- a/src/aspire/classification/rir_class2d.py
+++ b/src/aspire/classification/rir_class2d.py
@@ -29,7 +29,7 @@ class RIRClass2D(Class2D):
         large_pca_implementation="legacy",
         nn_implementation="legacy",
         bispectrum_implementation="legacy",
-        num_procs="auto",
+        num_procs=None,
         averager=None,
         dtype=None,
         seed=None,
@@ -61,7 +61,8 @@ class RIRClass2D(Class2D):
         :param nn_implementation: See `nn_classification`.
         :param bispectrum_implementation: See `bispectrum`.
         :param averager: An Averager2D subclass. Defaults to BFSReddyChatterjiAverager2D.
-        :param num_procs: Number of processes to use. Defaults "auto".
+        :param num_procs: Number of processes to use.
+        `None` will attempt computing a suggestion based on machine resources.
         :param dtype: Optional dtype, otherwise taken from src.
         :param seed: Optional RNG seed to be passed to random methods, (example Random NN).
         :return: RIRClass2D instance to be used to compute bispectrum-like rotationally invariant 2D classification.

--- a/src/aspire/classification/rir_class2d.py
+++ b/src/aspire/classification/rir_class2d.py
@@ -29,6 +29,7 @@ class RIRClass2D(Class2D):
         large_pca_implementation="legacy",
         nn_implementation="legacy",
         bispectrum_implementation="legacy",
+        num_procs="auto",
         averager=None,
         dtype=None,
         seed=None,
@@ -60,6 +61,7 @@ class RIRClass2D(Class2D):
         :param nn_implementation: See `nn_classification`.
         :param bispectrum_implementation: See `bispectrum`.
         :param averager: An Averager2D subclass. Defaults to BFSReddyChatterjiAverager2D.
+        :param num_procs: Number of processes to use. Defaults "auto".
         :param dtype: Optional dtype, otherwise taken from src.
         :param seed: Optional RNG seed to be passed to random methods, (example Random NN).
         :return: RIRClass2D instance to be used to compute bispectrum-like rotationally invariant 2D classification.
@@ -72,6 +74,7 @@ class RIRClass2D(Class2D):
             seed=seed,
             dtype=dtype,
         )
+        self.num_procs = num_procs
 
         # For now, only run with FSPCA basis
         if pca_basis and not isinstance(pca_basis, FSPCABasis):
@@ -172,9 +175,8 @@ class RIRClass2D(Class2D):
         # When not provided by a user, the averager is instantiated after
         #  we are certain our pca_basis has been constructed.
         if self.averager is None:
-            # self.averager = ReddyChatterjiAverager2D(
             self.averager = BFSReddyChatterjiAverager2D(
-                self.fb_basis, self.src, dtype=self.dtype
+                self.fb_basis, self.src, num_procs=self.num_procs, dtype=self.dtype
             )
 
         # Get the expanded coefs in the compressed FSPCA space.

--- a/src/aspire/config.ini
+++ b/src/aspire/config.ini
@@ -25,3 +25,11 @@ regularizer = 0.
 
 [nfft]
 backends = finufft, cufinufft, pynfft
+
+[ray]
+# Ray will default to a OS specific tmp dir.
+#   By default on linux this is `/tmp/ray`.
+# If you find your machine has a very small /tmp,
+#   try setting `temp_dir` to `/dev/shm`
+#   or some other fast scratch dir.
+temp_dir = /tmp/ray

--- a/src/aspire/utils/__init__.py
+++ b/src/aspire/utils/__init__.py
@@ -45,8 +45,8 @@ from .matrix import (
     volmat_to_vecmat,
 )
 from .multiprocessing import (
-    get_num_multi_procs,
     mem_based_cpu_suggestion,
+    num_procs_suggestion,
     physical_core_cpu_suggestion,
     virtual_core_cpu_suggestion,
 )

--- a/src/aspire/utils/__init__.py
+++ b/src/aspire/utils/__init__.py
@@ -44,6 +44,6 @@ from .matrix import (
     vol_to_vec,
     volmat_to_vecmat,
 )
-from .multiprocessing import apply_async
+from .multiprocessing import apply_async, get_num_multi_procs
 from .rotation import Rotation
 from .types import complex_type, real_type, utest_tolerance

--- a/src/aspire/utils/__init__.py
+++ b/src/aspire/utils/__init__.py
@@ -44,5 +44,6 @@ from .matrix import (
     vol_to_vec,
     volmat_to_vecmat,
 )
+from .multiprocessing import apply_async
 from .rotation import Rotation
 from .types import complex_type, real_type, utest_tolerance

--- a/src/aspire/utils/__init__.py
+++ b/src/aspire/utils/__init__.py
@@ -44,6 +44,10 @@ from .matrix import (
     vol_to_vec,
     volmat_to_vecmat,
 )
-from .multiprocessing import apply_async, get_num_multi_procs
+from .multiprocessing import (
+    get_num_multi_procs,
+    mem_based_cpu_suggestion,
+    physical_core_cpu_suggestion,
+)
 from .rotation import Rotation
 from .types import complex_type, real_type, utest_tolerance

--- a/src/aspire/utils/__init__.py
+++ b/src/aspire/utils/__init__.py
@@ -48,6 +48,7 @@ from .multiprocessing import (
     get_num_multi_procs,
     mem_based_cpu_suggestion,
     physical_core_cpu_suggestion,
+    virtual_core_cpu_suggestion,
 )
 from .rotation import Rotation
 from .types import complex_type, real_type, utest_tolerance

--- a/src/aspire/utils/multiprocessing.py
+++ b/src/aspire/utils/multiprocessing.py
@@ -1,4 +1,74 @@
+import logging
+import os
+
 import dill
+import psutil
+
+logger = logging.getLogger(__name__)
+
+
+def mem_based_cpu_suggestion():
+    pid = os.getpid()
+    process = psutil.Process(pid)
+    rss_mem_usage = process.memory_info().rss
+
+    free_mem = psutil.virtual_memory()[4]
+
+    n = free_mem // (rss_mem_usage * 1.1)
+
+    logger.info(
+        f"Current process usage {rss_mem_usage}"
+        f" and {free_mem} free memory, could fit {n} processes in RAM."
+    )
+
+    return n
+
+
+def physical_core_cpu_suggestion():
+    """
+    Return the physical cores.
+    """
+
+    n = psutil.cpu_count(logical=False)
+    logger.info(f"Found {n} physical cores")
+    return n
+
+
+def virtual_core_cpu_suggestion():
+    """
+    Return the virtual cores.
+    """
+
+    n = psutil.cpu_count(logical=True)
+    logger.info(f"Found {n} logical cores")
+    return n
+
+
+def get_num_multi_procs(n):
+    """
+    Resolve and return number of processors to use for multiprocessing.
+
+    If n is 'auto', query memory and cpu, then makes suggestion.
+    Developers should ensure n=0, n=None, n=False runs code serially without Pool.
+    Otherwise, n is expected to be an integer and will pass through.
+    """
+    if isinstance(n, int):
+        return n
+    elif n is None or n is False:
+        return 0
+    elif n.lower() == "auto":
+        suggestions = {
+            "mememory": mem_based_cpu_suggestion(),
+            "physical cores": physical_core_cpu_suggestion(),
+        }
+        k = sorted(suggestions, key=suggestions.get)[0]
+        n = suggestions[k]
+
+        logger.info(f"Suggesting {n} multi processor based on {k}.")
+
+        return n
+    else:
+        raise ValueError(f"Unable to parse {n}, try an integer or 'auto'")
 
 
 def __run_encoded(payload):

--- a/src/aspire/utils/multiprocessing.py
+++ b/src/aspire/utils/multiprocessing.py
@@ -43,28 +43,18 @@ def virtual_core_cpu_suggestion():
     return n
 
 
-def get_num_multi_procs(n):
+def get_num_multi_procs():
     """
     Resolve and return number of processors to use for multiprocessing.
 
-    If n is 'auto', query memory and cpu, then makes suggestion.
-    Developers should ensure n=0, n=None, n=False runs code serially without Pool.
-    Otherwise, n is expected to be an integer and will pass through.
+    Query memory and cpu, then makes suggestion.
     """
-    if isinstance(n, int):
-        return n
-    elif n is None or n is False:
-        return 0
-    elif n.lower() == "auto":
-        suggestions = {
-            "mememory": mem_based_cpu_suggestion(),
-            "physical cores": physical_core_cpu_suggestion(),
-        }
-        k = sorted(suggestions, key=suggestions.get)[0]
-        n = suggestions[k]
+    suggestions = {
+        "mememory": mem_based_cpu_suggestion(),
+        "physical cores": physical_core_cpu_suggestion(),
+    }
+    k = sorted(suggestions, key=suggestions.get)[0]
+    n = suggestions[k]
 
-        logger.info(f"Suggesting {n} multi processor based on {k}.")
-
-        return n
-    else:
-        raise ValueError(f"Unable to parse {n}, try an integer or 'auto'")
+    logger.info(f"Suggesting {n} multi processor based on {k}.")
+    return n

--- a/src/aspire/utils/multiprocessing.py
+++ b/src/aspire/utils/multiprocessing.py
@@ -1,0 +1,31 @@
+import dill
+
+
+def __run_encoded(payload):
+    """
+    Private method to decode and execute payload
+    """
+
+    # decode payload
+    f, x = dill.loads(payload)
+    # exec
+    return f(*x)
+
+
+def apply_async(mp_pool, function, args):
+    """
+    This method packs most arbitrary functions and their arguments
+    into a payload that can be unpacked and run asynchronously
+    in a multiprocessing pool.
+
+    :param mp_pool: Multiprocessing Pool
+    (see: https://docs.python.org/3/library/multiprocessing.html)
+    :param function: Function to run async in the `pool`
+    :param args: Arguments passed to `function`
+    """
+
+    # encode payload
+    payload = dill.dumps((function, args))
+
+    # (async)
+    return mp_pool.apply_async(__run_encoded, (payload,))

--- a/src/aspire/utils/multiprocessing.py
+++ b/src/aspire/utils/multiprocessing.py
@@ -13,7 +13,7 @@ def mem_based_cpu_suggestion():
 
     free_mem = psutil.virtual_memory()[4]
 
-    n = free_mem // (rss_mem_usage * 1.1)
+    n = int(free_mem // (rss_mem_usage * 1.1))
 
     logger.info(
         f"Current process usage {rss_mem_usage}"

--- a/src/aspire/utils/multiprocessing.py
+++ b/src/aspire/utils/multiprocessing.py
@@ -21,7 +21,7 @@ def mem_based_cpu_suggestion():
     free_mem = psutil.virtual_memory()[4]
 
     # Calculate how many processes would fit using a 10% safety margin.
-    n = int(free_mem // (rss_mem_usage * 1.1))
+    n = int(free_mem // (rss_mem_usage * 1.1)) + 1  # Count current process
 
     logger.info(
         f"Current process usage {rss_mem_usage}"
@@ -51,18 +51,18 @@ def virtual_core_cpu_suggestion():
     return n
 
 
-def get_num_multi_procs():
+def num_procs_suggestion():
     """
     Resolve and return number of processors to use for multiprocessing.
 
     Query memory and cpu, then makes suggestion.
     """
     suggestions = {
-        "mememory": mem_based_cpu_suggestion(),
+        "memory": mem_based_cpu_suggestion(),
         "physical cores": physical_core_cpu_suggestion(),
     }
     k = sorted(suggestions, key=suggestions.get)[0]
     n = suggestions[k]
 
-    logger.info(f"Suggesting {n} multi processor based on {k}.")
+    logger.info(f"Suggesting {n} processors based on {k}.")
     return n

--- a/src/aspire/utils/multiprocessing.py
+++ b/src/aspire/utils/multiprocessing.py
@@ -7,12 +7,20 @@ logger = logging.getLogger(__name__)
 
 
 def mem_based_cpu_suggestion():
+    """
+    Return an estimate of the number of clone processes
+    that would fit in the currently available memory.
+    """
+
+    # Get the resident size of current process
     pid = os.getpid()
     process = psutil.Process(pid)
     rss_mem_usage = process.memory_info().rss
 
+    # Get the free memory
     free_mem = psutil.virtual_memory()[4]
 
+    # Calculate how many processes would fit using a 10% safety margin.
     n = int(free_mem // (rss_mem_usage * 1.1))
 
     logger.info(

--- a/src/aspire/utils/multiprocessing.py
+++ b/src/aspire/utils/multiprocessing.py
@@ -1,7 +1,6 @@
 import logging
 import os
 
-import dill
 import psutil
 
 logger = logging.getLogger(__name__)
@@ -69,33 +68,3 @@ def get_num_multi_procs(n):
         return n
     else:
         raise ValueError(f"Unable to parse {n}, try an integer or 'auto'")
-
-
-def __run_encoded(payload):
-    """
-    Private method to decode and execute payload
-    """
-
-    # decode payload
-    f, x = dill.loads(payload)
-    # exec
-    return f(*x)
-
-
-def apply_async(mp_pool, function, args):
-    """
-    This method packs most arbitrary functions and their arguments
-    into a payload that can be unpacked and run asynchronously
-    in a multiprocessing pool.
-
-    :param mp_pool: Multiprocessing Pool
-    (see: https://docs.python.org/3/library/multiprocessing.html)
-    :param function: Function to run async in the `pool`
-    :param args: Arguments passed to `function`
-    """
-
-    # encode payload
-    payload = dill.dumps((function, args))
-
-    # (async)
-    return mp_pool.apply_async(__run_encoded, (payload,))

--- a/tests/test_averager2d.py
+++ b/tests/test_averager2d.py
@@ -18,7 +18,7 @@ from aspire.classification import (
     ReddyChatterjiAverager2D,
 )
 from aspire.source import Simulation
-from aspire.utils import Rotation, get_num_multi_procs
+from aspire.utils import Rotation, num_procs_suggestion
 from aspire.volume import Volume
 
 logger = logging.getLogger(__name__)
@@ -38,7 +38,7 @@ def xfail_ray_dev():
             importlib.util.find_spec("ray"),  # 'ray' installed
             parse_version(get_distribution("numpy").version)
             >= parse_version("1.22.0"),  # with unsupported numpy combo
-            get_num_multi_procs() > 1,  # and code would attempt to use multiprocessing
+            num_procs_suggestion() > 1,  # and code would attempt to use multiprocessing
         ]
     )
 
@@ -315,7 +315,7 @@ class BFSRAverager2DTestCase(BFRAverager2DTestCase):
 class ReddyChatterjiAverager2DTestCase(BFSRAverager2DTestCase):
 
     averager = ReddyChatterjiAverager2D
-    num_procs = 1 if xfail_ray_dev() else "auto"
+    num_procs = 1 if xfail_ray_dev() else None
 
     def testAverager(self):
         """

--- a/tests/test_averager2d.py
+++ b/tests/test_averager2d.py
@@ -152,6 +152,7 @@ class AligningAverager2DBase(Averager2DBase):
     """
 
     averager = AligningAverager2D
+    num_procs = 1  # paralleized subclasses may override
 
     def setUp(self):
 
@@ -168,7 +169,7 @@ class AligningAverager2DBase(Averager2DBase):
 
     def _call_averager(self):
         # Construct the Averager
-        avgr = self.averager(self.basis, self._getSrc())
+        avgr = self.averager(self.basis, self._getSrc(), num_procs=self.num_procs)
         # Call the `align` method
         _ = avgr.align(self.classes, self.reflections, self.coefs)
         _ = avgr.average(self.classes, self.reflections, self.coefs)
@@ -314,6 +315,7 @@ class BFSRAverager2DTestCase(BFRAverager2DTestCase):
 class ReddyChatterjiAverager2DTestCase(BFSRAverager2DTestCase):
 
     averager = ReddyChatterjiAverager2D
+    num_procs = 1 if xfail_ray_dev() else "auto"
 
     def testAverager(self):
         """
@@ -326,7 +328,7 @@ class ReddyChatterjiAverager2DTestCase(BFSRAverager2DTestCase):
         avgr = self.averager(
             composite_basis=self.basis,
             src=self._getSrc(),
-            num_procs=1 if xfail_ray_dev() else "auto",
+            num_procs=self.num_procs,
             dtype=self.dtype,
         )
         _rotations, _shifts, _ = avgr.align(self.classes, self.reflections, self.coefs)

--- a/tests/test_class2D.py
+++ b/tests/test_class2D.py
@@ -14,6 +14,8 @@ from aspire.source import Simulation
 from aspire.utils import utest_tolerance
 from aspire.volume import Volume
 
+from .test_averager2d import xfail_ray_dev
+
 logger = logging.getLogger(__name__)
 
 
@@ -182,6 +184,7 @@ class RIRClass2DTestCase(TestCase):
             large_pca_implementation="legacy",
             nn_implementation="legacy",
             bispectrum_implementation="legacy",
+            num_procs=1 if xfail_ray_dev() else "auto",
         )
 
         classification_results = rir.classify()
@@ -198,6 +201,7 @@ class RIRClass2DTestCase(TestCase):
             large_pca_implementation="legacy",
             nn_implementation="legacy",
             bispectrum_implementation="devel",
+            num_procs=1 if xfail_ray_dev() else "auto",
         )
 
         classification_results = rir.classify()

--- a/tests/test_class2D.py
+++ b/tests/test_class2D.py
@@ -184,7 +184,7 @@ class RIRClass2DTestCase(TestCase):
             large_pca_implementation="legacy",
             nn_implementation="legacy",
             bispectrum_implementation="legacy",
-            num_procs=1 if xfail_ray_dev() else "auto",
+            num_procs=1 if xfail_ray_dev() else None,
         )
 
         classification_results = rir.classify()
@@ -201,7 +201,7 @@ class RIRClass2DTestCase(TestCase):
             large_pca_implementation="legacy",
             nn_implementation="legacy",
             bispectrum_implementation="devel",
-            num_procs=1 if xfail_ray_dev() else "auto",
+            num_procs=1 if xfail_ray_dev() else None,
         )
 
         classification_results = rir.classify()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,8 +7,8 @@ from pytest import raises
 from aspire import __version__
 from aspire.utils import (
     get_full_version,
-    get_num_multi_procs,
     mem_based_cpu_suggestion,
+    num_procs_suggestion,
     physical_core_cpu_suggestion,
     powerset,
     utest_tolerance,
@@ -137,4 +137,4 @@ class MultiProcessingUtilsTestCase(TestCase):
         self.assertTrue(isinstance(virtual_core_cpu_suggestion(), int))
 
     def testGetNumMultiProcs(self):
-        self.assertTrue(isinstance(get_num_multi_procs(), int))
+        self.assertTrue(isinstance(num_procs_suggestion(), int))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,15 @@ import numpy as np
 from pytest import raises
 
 from aspire import __version__
-from aspire.utils import get_full_version, powerset, utest_tolerance
+from aspire.utils import (
+    get_full_version,
+    get_num_multi_procs,
+    mem_based_cpu_suggestion,
+    physical_core_cpu_suggestion,
+    powerset,
+    utest_tolerance,
+    virtual_core_cpu_suggestion,
+)
 from aspire.utils.misc import gaussian_1d, gaussian_2d, gaussian_3d
 
 
@@ -112,3 +120,21 @@ class UtilsTestCase(TestCase):
 
         self.assertTrue(np.allclose(g_2d, g_2d_scalar))
         self.assertTrue(np.allclose(g_3d, g_3d_scalar))
+
+
+class MultiProcessingUtilsTestCase(TestCase):
+    """
+    Smoke tests.
+    """
+
+    def testMemSuggestion(self):
+        self.assertTrue(isinstance(mem_based_cpu_suggestion(), int))
+
+    def testPhySuggestion(self):
+        self.assertTrue(isinstance(physical_core_cpu_suggestion(), int))
+
+    def testVrtSuggestion(self):
+        self.assertTrue(isinstance(virtual_core_cpu_suggestion(), int))
+
+    def testGetNumMultiProcs(self):
+        self.assertTrue(isinstance(get_num_multi_procs(), int))


### PR DESCRIPTION
Implements a `ray` based multiprocessing pool for the ReddyChatterji class average alignment methods for some tasty speedups.

Has some logic that disables mp runs for development environments that are xfail, runs serially. This is actually nice since it will cover bought areas of code.

Adds some utils for suggesting number of cores based on mem usage/avail, phys cpu, and virtual cpu.

Moves Reddy Chatterji registration algo into it's own file.

Still WIP.  Will quash commits when closer to undrafting.