### PR TITLE
Cast vols on mismatch Simulation dtype

### DIFF
--- a/src/aspire/source/simulation.py
+++ b/src/aspire/source/simulation.py
@@ -75,8 +75,9 @@ class Simulation(ImageSource):
             logger.warning(
                 f"{self.__class__.__name__}"
                 f" vols.dtype {self.vols.dtype} != self.dtype {self.dtype}."
-                " In the future this will raise an error."
+                " In the future this will raise an error. Casting..."
             )
+            self.vols = self.vols.astype(self.dtype)
 
         self.C = self.vols.n_vols
 


### PR DESCRIPTION
On a dtype mismatch it would cause too many spam warnings later on.

`Volume rot_matrices.dtype float32 != self.dtype float64. In the future this will raise an error.`

another alternative is to make this an error... Can discuss...