### PR TITLE
Deprecate Azure OSX 10.15 CI in favor of OSX11

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -86,9 +86,9 @@ jobs:
     displayName: pytest
 
 - job:
-  displayName: macOS-10.15
+  displayName: macOS-11
   pool:
-    vmImage: 'macOS-10.15'
+    vmImage: 'macOS-11'
   strategy:
     matrix:
       Python37:


### PR DESCRIPTION
Remove OSX 10.15 in favor of new OSX 11.

OSX 12 was released July 20th and I want to check the logs of this CI run to verify whether we are using that for `-latest`.
