### PR TITLE
Fspca components lower bound

### DIFF
--- a/src/aspire/basis/fspca.py
+++ b/src/aspire/basis/fspca.py
@@ -38,11 +38,12 @@ class FSPCABasis(SteerableBasis2D):
 
         :param src: Source instance
         :param basis: Optional Fourier Bessel Basis (usually FFBBasis2D)
-        :param components: Number of components (compression).
-        Defaults None implies basis.count, therefor no compression.
-        :param noise_var: None estimates noise (default).
-        0 forces "clean" treatment (no weighting).
-        Other values assigned to noise_var.
+        :param components: Optionally assign number of principle components
+        to use for the FSPCA basis.
+        Default value of `None` will use `self.basis.count`.
+        :param noise_var: Optionally assign noise variance.
+        Default value of `None` will estimate noise with WhiteNoiseEstimator.
+        Use 0 when using clean images so cov2d skips applying noisy covar coeffs..
         :param batch_size: Batch size for computing basis coefficients.
         """
 

--- a/src/aspire/basis/fspca.py
+++ b/src/aspire/basis/fspca.py
@@ -38,7 +38,7 @@ class FSPCABasis(SteerableBasis2D):
 
         :param src: Source instance
         :param basis: Optional Fourier Bessel Basis (usually FFBBasis2D)
-        :param components: Optionally assign number of principle components
+        :param components: Optionally assign number of principal components
         to use for the FSPCA basis.
         Default value of `None` will use `self.basis.count`.
         :param noise_var: Optionally assign noise variance.

--- a/src/aspire/classification/rir_class2d.py
+++ b/src/aspire/classification/rir_class2d.py
@@ -19,7 +19,7 @@ class RIRClass2D(Class2D):
         self,
         src,
         pca_basis=None,
-        fspca_components=400,
+        fspca_components=None,
         alpha=1 / 3,
         sample_n=4000,
         bispectrum_components=300,
@@ -50,7 +50,8 @@ class RIRClass2D(Class2D):
         :param src: Source instance.  Note it is possible to use one `source` for classification (ie CWF),
         and a different `source` for stacking in the `averager`.
         :param pca_basis: Optional FSPCA Basis instance
-        :param fspca_components: Components (top eigvals) to keep from full FSCPA, default truncates to  400.
+        :param fspca_components: Optinally set number of components (top eigvals) to keep from full FSCPA.
+        Default value of None will infer from `pca_basis` when provided, otherwise defaults to 400.
         :param alpha: Amplitude Power Scale, default 1/3 (eq 20 from  RIIR paper).
         :param sample_n: Threshold for random sampling of bispectrum coefs. Default 4000,
         high values such as 50000 reduce random sampling.
@@ -124,19 +125,15 @@ class RIRClass2D(Class2D):
             )
         self.pca_basis = pca_basis
 
-        # When a user provides a basis, the fspca_components arg is either
-        # redundant (same) or conflicting (different).
-        # So when a user provides fspca_components, we need to check it matches the basis' components.
-        _provided_fspca_components = (
-            fspca_components is not self.__init__.__defaults__[1]
-        )
-        if pca_basis and _provided_fspca_components:
-            # Check the provided components match.
+        # When a user provides a `pca_basis` and `fspca_components`
+        #  the arg is either redundant (same) or conflicting with `pca_basis`.
+        if pca_basis and fspca_components is not None:
+            # Check the provided components match. On match we can use this value.
             if pca_basis.components != fspca_components:
                 raise RuntimeError(
                     f"`pca_basis` components {pca_basis.components} != {fspca_components} `fspca_components` provided by user."
                 )
-        elif pca_basis:  # fspca_components not specfied (default to taking from basis)
+        elif pca_basis:  # infer `fspca_components` from pca_basis components
             fspca_components = pca_basis.components
 
             # For small problems, such as unit tests, we also need to guard against
@@ -144,6 +141,9 @@ class RIRClass2D(Class2D):
             # In the case RIRClass2d instantiates the pca_basis,
             #   this will be checked then, in FSPCABasis.
             pca_basis._check_components()
+        elif fspca_components is None:
+            # Default of 400 components was taken from legacy reearch and code.
+            fspca_components = 400
 
         self.fspca_components = fspca_components
         self.bispectrum_components = bispectrum_components
@@ -178,7 +178,6 @@ class RIRClass2D(Class2D):
         # # Stage 1: Compute coef and reduce dimensionality.
         # Memioze/batch this later when result is working
         # Initial round of component truncation is before bispectrum.
-        #  default of 400 components was taken from legacy code.
         # Instantiate a new compressed (truncated) basis.
         if self.pca_basis is None:
             self.pca_basis = FSPCABasis(self.src, components=self.fspca_components)

--- a/src/aspire/classification/rir_class2d.py
+++ b/src/aspire/classification/rir_class2d.py
@@ -125,8 +125,8 @@ class RIRClass2D(Class2D):
         self.pca_basis = pca_basis
 
         # When a user provides a basis, the fspca_components arg is either
-        # redudant (same) or conflicting (different).
-        # So when a user provides fspca_components, we need to check it matches the basis' compoenents.
+        # redundant (same) or conflicting (different).
+        # So when a user provides fspca_components, we need to check it matches the basis' components.
         _provided_fspca_components = (
             fspca_components is not self.__init__.__defaults__[1]
         )

--- a/tests/test_class2D.py
+++ b/tests/test_class2D.py
@@ -210,7 +210,6 @@ class RIRClass2DTestCase(TestCase):
         )
 
         classification_results = rir.classify()
-        _ = rir.averages(*classification_results)
 
     def testRIRsk(self):
         """

--- a/tests/test_class2D.py
+++ b/tests/test_class2D.py
@@ -182,7 +182,6 @@ class RIRClass2DTestCase(TestCase):
                 self.clean_src,
                 self.clean_fspca_basis,  # 400 components
                 fspca_components=100,
-                bispectrum_components=100,
                 large_pca_implementation="legacy",
                 nn_implementation="legacy",
                 bispectrum_implementation="legacy",

--- a/tests/test_class2D.py
+++ b/tests/test_class2D.py
@@ -102,6 +102,7 @@ class RIRClass2DTestCase(TestCase):
     def setUp(self):
         self.resolution = 16
         self.dtype = np.float64
+        self.n_img = 150
 
         # Create some projections
         v = Volume(
@@ -114,7 +115,7 @@ class RIRClass2DTestCase(TestCase):
         # Clean
         self.clean_src = Simulation(
             L=self.resolution,
-            n=321,
+            n=self.n_img,
             vols=v,
             dtype=self.dtype,
         )
@@ -124,7 +125,7 @@ class RIRClass2DTestCase(TestCase):
         noise_filter = ScalarFilter(dim=2, value=noise_var)
         self.noisy_src = Simulation(
             L=self.resolution,
-            n=123,
+            n=self.n_img,
             vols=v,
             dtype=self.dtype,
             noise_filter=noise_filter,
@@ -183,6 +184,7 @@ class RIRClass2DTestCase(TestCase):
         rir = RIRClass2D(
             self.clean_src,
             clean_fspca_basis,
+            n_classes=5,
             bispectrum_components=42,
             large_pca_implementation="legacy",
             nn_implementation="legacy",
@@ -209,7 +211,7 @@ class RIRClass2DTestCase(TestCase):
             num_procs=1 if xfail_ray_dev() else None,
         )
 
-        classification_results = rir.classify()
+        _ = rir.classify()
 
     def testRIRsk(self):
         """

--- a/tests/test_class2D.py
+++ b/tests/test_class2D.py
@@ -97,6 +97,18 @@ class FSPCATestCase(TestCase):
             rmse = np.sqrt(np.mean(np.square(np.flip(img) - rot_imgs[i])))
             self.assertTrue(rmse < 10 * utest_tolerance(self.dtype))
 
+    def testBasisTooSmall(self):
+        """
+        When number of components is more than basis functions raise with descriptive error.
+        """
+        fb_basis = FFBBasis2D((self.resolution, self.resolution), dtype=self.dtype)
+
+        with pytest.raises(ValueError, match=r".*Reduce components.*"):
+            # Configure an FSPCA basis
+            _ = FSPCABasis(
+                self.src, basis=fb_basis, components=fb_basis.count * 2, noise_var=0
+            )
+
 
 class RIRClass2DTestCase(TestCase):
     def setUp(self):
@@ -142,6 +154,21 @@ class RIRClass2DTestCase(TestCase):
 
         # Ceate another fspca_basis, use autogeneration FFB2D Basis
         self.noisy_fspca_basis = FSPCABasis(self.noisy_src)
+
+    def testSourceTooSmall(self):
+        """
+        When number of images in source is less than requested bispectrum components,
+        raise with descriptive error.
+        """
+
+        with pytest.raises(
+            RuntimeError, match=r".*Increase number of images or reduce components.*"
+        ):
+            _ = RIRClass2D(
+                self.clean_src,
+                fspca_components=self.clean_src.n * 4,
+                bispectrum_components=self.clean_src.n * 2,
+            )
 
     def testIncorrectComponents(self):
         """


### PR DESCRIPTION
Closes #588 

Also significantly speeds up Class2D unit tests by removing redundant tests and changing some configuration. (~20m to ~1m).

~Need to review coverage and potentially add some more sanity checks.~ (covered)