### PR TITLE
Add `crop_pad_3d` with tests

### DIFF
--- a/src/aspire/utils/__init__.py
+++ b/src/aspire/utils/__init__.py
@@ -1,6 +1,7 @@
 from .coor_trans import (  # isort:skip
     common_line_from_rots,
     crop_pad_2d,
+    crop_pad_3d,
     get_aligned_rotations,
     get_rots_mse,
     grid_1d,

--- a/src/aspire/utils/coor_trans.py
+++ b/src/aspire/utils/coor_trans.py
@@ -347,3 +347,15 @@ def crop_pad_3d(im, size, fill_value=0):
         return im[
             start_y : start_y + size, start_x : start_x + size, start_z : start_z + size
         ]
+    # padding
+    elif size >= max(im_y, im_x, im_x):
+        to_return = fill_value * np.ones((size, size, size), dtype=im.dtype)
+        to_return[
+            -start_y : im_y - start_y,
+            -start_x : im_x - start_x,
+            -start_z : im_z - start_z,
+        ] = im
+        return to_return
+    else:
+        # target size is between min and max of (im_y, im_x, im_z)
+        raise ValueError("Cannot crop and pad a volume at the same time.")

--- a/src/aspire/utils/coor_trans.py
+++ b/src/aspire/utils/coor_trans.py
@@ -333,3 +333,15 @@ def crop_pad_2d(im, size, fill_value=0):
     else:
         # target size is between mat_x and mat_y
         raise ValueError("Cannot crop and pad an image at the same time.")
+
+def crop_pad_3d(im, size, fill_value=0):
+    im_y, im_x, im_z = im.shape
+    # shift terms
+    start_x = math.floor(im_x / 2) - math.floor(size / 2)
+    start_y = math.floor(im_y / 2) - math.floor(size / 2)
+    start_z = math.floor(im_z / 2) - math.floor(size / 2)
+
+    # cropping
+    if size <= min(im_y, im_x, im_z):
+        return im[start_y:start_y + size, start_x:start_x + size, start_z: start_z + size]
+    

--- a/src/aspire/utils/coor_trans.py
+++ b/src/aspire/utils/coor_trans.py
@@ -334,6 +334,7 @@ def crop_pad_2d(im, size, fill_value=0):
         # target size is between mat_x and mat_y
         raise ValueError("Cannot crop and pad an image at the same time.")
 
+
 def crop_pad_3d(im, size, fill_value=0):
     im_y, im_x, im_z = im.shape
     # shift terms
@@ -343,5 +344,6 @@ def crop_pad_3d(im, size, fill_value=0):
 
     # cropping
     if size <= min(im_y, im_x, im_z):
-        return im[start_y:start_y + size, start_x:start_x + size, start_z: start_z + size]
-    
+        return im[
+            start_y : start_y + size, start_x : start_x + size, start_z : start_z + size
+        ]

--- a/src/aspire/utils/coor_trans.py
+++ b/src/aspire/utils/coor_trans.py
@@ -348,7 +348,7 @@ def crop_pad_3d(im, size, fill_value=0):
             start_y : start_y + size, start_x : start_x + size, start_z : start_z + size
         ]
     # padding
-    elif size >= max(im_y, im_x, im_x):
+    elif size >= max(im_y, im_x, im_z):
         to_return = fill_value * np.ones((size, size, size), dtype=im.dtype)
         to_return[
             -start_y : im_y - start_y,

--- a/tests/test_coor_trans.py
+++ b/tests/test_coor_trans.py
@@ -296,8 +296,15 @@ class UtilsTestCase(TestCase):
     def testCropPad2DError(self):
         with self.assertRaises(ValueError) as e:
             _ = crop_pad_2d(np.zeros((6, 10)), 8)
-            self.assertTrue(
+            self.assertEqual(
                 "Cannot crop and pad an image at the same time.", str(e.exception)
+            )
+
+    def testCropPad3DError(self):
+        with self.assertRaises(ValueError) as e:
+            _ = crop_pad_3d(np.zeros((6, 8, 10)), 8)
+            self.assertEqual(
+                "Cannot crop and pad a volume at the same time.", str(e.exception)
             )
 
     def testCrop2DDtype(self):
@@ -308,6 +315,12 @@ class UtilsTestCase(TestCase):
             crop_pad_2d(np.eye(10).astype("complex"), 5).dtype, np.dtype("complex128")
         )
 
+    def testCrop3DDtype(self):
+        self.assertEqual(
+            crop_pad_3d(np.ones((8, 8, 8)).astype("complex"), 5).dtype,
+            np.dtype("complex128"),
+        )
+
     def testCrop2DFillValue(self):
         # make sure the fill value is as expected
         # we are padding from an odd to an even dimension
@@ -315,3 +328,10 @@ class UtilsTestCase(TestCase):
         a = np.ones((4, 3))
         b = crop_pad_2d(a, 4, fill_value=-1)
         self.assertTrue(np.array_equal(b[:, 0], np.array([-1, -1, -1, -1])))
+
+    def testCrop3DFillValue(self):
+        # make sure the fill value is expected. Since we are padding from even to odd
+        # the padded side is added to the 0-end of dimension 3
+        a = np.ones((4, 4, 3))
+        b = crop_pad_3d(a, 4, fill_value=-1)
+        self.assertTrue(np.array_equal(b[:, :, 0], -1 * np.ones((4, 4))))

--- a/tests/test_coor_trans.py
+++ b/tests/test_coor_trans.py
@@ -117,9 +117,34 @@ class UtilsTestCase(TestCase):
         self.assertTrue(np.array_equal(test_a, crop_pad_2d(a, 8)))
 
     def testSquareCrop3D(self):
-        a = np.zeros((10,10,10))
-        a[np.diag_indices(10, ndim=3)] = np.arange(0,10)
-        test_a = 
+        # even to even
+        a = np.zeros((8, 8, 8))
+        # pad it with the parts that will be cropped off from a 10x10x10
+        np.pad(a, ((1, 1), (1, 1), (1, 1)), "constant", constant_values=1)
+        # after cropping
+        test_a = np.zeros((8, 8, 8))
+        self.assertTrue(np.array_equal(crop_pad_3d(a, 8), test_a))
+
+        # even to odd
+        a = np.zeros((7, 7, 7))
+        # pad it with the parts that will be cropped off from a 10x10x10
+        np.pad(a, ((1, 2), (1, 2), (1, 2)), "constant", constant_values=1)
+        test_a = np.zeros((7, 7, 7))
+        self.assertTrue(np.array_equal(crop_pad_3d(a, 7), test_a))
+
+        # odd to odd
+        a = np.zeros((7, 7, 7))
+        # pad it with the parts that will be cropped off from a 9x9x9
+        np.pad(a, ((1, 1), (1, 1), (1, 1)), "constant", constant_values=1)
+        test_a = np.zeros((7, 7, 7))
+        self.assertTrue(np.array_equal(crop_pad_3d(a, 7), test_a))
+
+        # odd to even
+        a = np.zeros((8, 8, 8))
+        # pad it with the parts that will be cropped off from 11x11x11
+        np.pad(a, ((2, 1), (2, 1), (2, 1)), "constant", constant_values=1)
+        test_a = np.zeros((8, 8, 8))
+        self.assertTrue(np.array_equal(crop_pad_3d(a, 8), test_a))
 
     def testSquarePad2D(self):
         # Test even/odd cases based on the convention that the center of a sequence of length n
@@ -156,6 +181,36 @@ class UtilsTestCase(TestCase):
         a = np.diag(np.arange(1, 10))
         test_a = np.diag([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
         self.assertTrue(np.array_equal(test_a, crop_pad_2d(a, 10)))
+
+    def testSquarePad3D(self):
+        # even to even
+        a = np.zeros((8, 8, 8))
+        # pad it with the parts that will be cropped off from a 10x10x10
+        np.pad(a, ((1, 1), (1, 1), (1, 1)), "constant", constant_values=1)
+        # after cropping
+        test_a = np.zeros((8, 8, 8))
+        self.assertTrue(np.array_equal(crop_pad_3d(a, 8), test_a))
+
+        # even to odd
+        a = np.zeros((7, 7, 7))
+        # pad it with the parts that will be cropped off from a 10x10x10
+        np.pad(a, ((1, 2), (1, 2), (1, 2)), "constant", constant_values=1)
+        test_a = np.zeros((7, 7, 7))
+        self.assertTrue(np.array_equal(crop_pad_3d(a, 7), test_a))
+
+        # odd to odd
+        a = np.zeros((7, 7, 7))
+        # pad it with the parts that will be cropped off from a 9x9x9
+        np.pad(a, ((1, 1), (1, 1), (1, 1)), "constant", constant_values=1)
+        test_a = np.zeros((7, 7, 7))
+        self.assertTrue(np.array_equal(crop_pad_3d(a, 7), test_a))
+
+        # odd to even
+        a = np.zeros((8, 8, 8))
+        # pad it with the parts that will be cropped off from 11x11x11
+        np.pad(a, ((2, 1), (2, 1), (2, 1)), "constant", constant_values=1)
+        test_a = np.zeros((8, 8, 8))
+        self.assertTrue(np.array_equal(crop_pad_3d(a, 8), test_a))
 
     def testRectCrop2D(self):
         # Additional sanity checks for rectangular cropping case

--- a/tests/test_coor_trans.py
+++ b/tests/test_coor_trans.py
@@ -330,7 +330,7 @@ class UtilsTestCase(TestCase):
         self.assertTrue(np.array_equal(b[:, 0], np.array([-1, -1, -1, -1])))
 
     def testCrop3DFillValue(self):
-        # make sure the fill value is expected. Since we are padding from even to odd
+        # make sure the fill value is expected. Since we are padding from odd to even
         # the padded side is added to the 0-end of dimension 3
         a = np.ones((4, 4, 3))
         b = crop_pad_3d(a, 4, fill_value=-1)

--- a/tests/test_coor_trans.py
+++ b/tests/test_coor_trans.py
@@ -6,6 +6,7 @@ import numpy as np
 from aspire.utils import (
     Rotation,
     crop_pad_2d,
+    crop_pad_3d,
     get_aligned_rotations,
     grid_2d,
     grid_3d,
@@ -114,6 +115,11 @@ class UtilsTestCase(TestCase):
         a = np.diag(np.arange(9))
         test_a = np.diag(np.arange(8))
         self.assertTrue(np.array_equal(test_a, crop_pad_2d(a, 8)))
+
+    def testSquareCrop3D(self):
+        a = np.zeros((10,10,10))
+        a[np.diag_indices(10, ndim=3)] = np.arange(0,10)
+        test_a = 
 
     def testSquarePad2D(self):
         # Test even/odd cases based on the convention that the center of a sequence of length n

--- a/tests/test_coor_trans.py
+++ b/tests/test_coor_trans.py
@@ -120,7 +120,7 @@ class UtilsTestCase(TestCase):
         # even to even
         a = np.zeros((8, 8, 8))
         # pad it with the parts that will be cropped off from a 10x10x10
-        np.pad(a, ((1, 1), (1, 1), (1, 1)), "constant", constant_values=1)
+        a = np.pad(a, ((1, 1), (1, 1), (1, 1)), "constant", constant_values=1)
         # after cropping
         test_a = np.zeros((8, 8, 8))
         self.assertTrue(np.array_equal(crop_pad_3d(a, 8), test_a))
@@ -128,21 +128,21 @@ class UtilsTestCase(TestCase):
         # even to odd
         a = np.zeros((7, 7, 7))
         # pad it with the parts that will be cropped off from a 10x10x10
-        np.pad(a, ((1, 2), (1, 2), (1, 2)), "constant", constant_values=1)
+        a = np.pad(a, ((2, 1), (2, 1), (2, 1)), "constant", constant_values=1)
         test_a = np.zeros((7, 7, 7))
         self.assertTrue(np.array_equal(crop_pad_3d(a, 7), test_a))
 
         # odd to odd
         a = np.zeros((7, 7, 7))
         # pad it with the parts that will be cropped off from a 9x9x9
-        np.pad(a, ((1, 1), (1, 1), (1, 1)), "constant", constant_values=1)
+        a = np.pad(a, ((1, 1), (1, 1), (1, 1)), "constant", constant_values=1)
         test_a = np.zeros((7, 7, 7))
         self.assertTrue(np.array_equal(crop_pad_3d(a, 7), test_a))
 
         # odd to even
         a = np.zeros((8, 8, 8))
         # pad it with the parts that will be cropped off from 11x11x11
-        np.pad(a, ((2, 1), (2, 1), (2, 1)), "constant", constant_values=1)
+        a = np.pad(a, ((1, 2), (1, 2), (1, 2)), "constant", constant_values=1)
         test_a = np.zeros((8, 8, 8))
         self.assertTrue(np.array_equal(crop_pad_3d(a, 8), test_a))
 
@@ -185,11 +185,9 @@ class UtilsTestCase(TestCase):
     def testSquarePad3D(self):
         # even to even
         a = np.zeros((8, 8, 8))
-        # pad it with the parts that will be cropped off from a 10x10x10
-        np.pad(a, ((1, 1), (1, 1), (1, 1)), "constant", constant_values=1)
-        # after cropping
-        test_a = np.zeros((8, 8, 8))
-        self.assertTrue(np.array_equal(crop_pad_3d(a, 8), test_a))
+        # after padding
+        test_a = np.pad(a, ((1, 1), (1, 1), (1, 1)), "constant", constant_values=1)
+        self.assertTrue(np.array_equal(crop_pad_3d(a, 10), test_a))
 
         # even to odd
         a = np.zeros((7, 7, 7))

--- a/tests/test_coor_trans.py
+++ b/tests/test_coor_trans.py
@@ -185,30 +185,27 @@ class UtilsTestCase(TestCase):
     def testSquarePad3D(self):
         # even to even
         a = np.zeros((8, 8, 8))
-        # after padding
+        # after padding to 10x10x10
         test_a = np.pad(a, ((1, 1), (1, 1), (1, 1)), "constant", constant_values=1)
-        self.assertTrue(np.array_equal(crop_pad_3d(a, 10), test_a))
+        self.assertTrue(np.array_equal(crop_pad_3d(a, 10, fill_value=1), test_a))
 
         # even to odd
-        a = np.zeros((7, 7, 7))
-        # pad it with the parts that will be cropped off from a 10x10x10
-        np.pad(a, ((1, 2), (1, 2), (1, 2)), "constant", constant_values=1)
-        test_a = np.zeros((7, 7, 7))
-        self.assertTrue(np.array_equal(crop_pad_3d(a, 7), test_a))
+        a = np.zeros((8, 8, 8))
+        # after padding to 11x11x11
+        test_a = np.pad(a, ((1, 2), (1, 2), (1, 2)), "constant", constant_values=1)
+        self.assertTrue(np.array_equal(crop_pad_3d(a, 11, fill_value=1), test_a))
 
         # odd to odd
         a = np.zeros((7, 7, 7))
-        # pad it with the parts that will be cropped off from a 9x9x9
-        np.pad(a, ((1, 1), (1, 1), (1, 1)), "constant", constant_values=1)
-        test_a = np.zeros((7, 7, 7))
-        self.assertTrue(np.array_equal(crop_pad_3d(a, 7), test_a))
+        # after padding to 9x9x9
+        test_a = np.pad(a, ((1, 1), (1, 1), (1, 1)), "constant", constant_values=1)
+        self.assertTrue(np.array_equal(crop_pad_3d(a, 9, fill_value=1), test_a))
 
         # odd to even
-        a = np.zeros((8, 8, 8))
-        # pad it with the parts that will be cropped off from 11x11x11
-        np.pad(a, ((2, 1), (2, 1), (2, 1)), "constant", constant_values=1)
-        test_a = np.zeros((8, 8, 8))
-        self.assertTrue(np.array_equal(crop_pad_3d(a, 8), test_a))
+        a = np.zeros((7, 7, 7))
+        # after padding to 10x10x10
+        test_a = np.pad(a, ((2, 1), (2, 1), (2, 1)), "constant", constant_values=1)
+        self.assertTrue(np.array_equal(crop_pad_3d(a, 10, fill_value=1), test_a))
 
     def testRectCrop2D(self):
         # Additional sanity checks for rectangular cropping case


### PR DESCRIPTION
Initial PR for #617 

To implement Fourier-space cropping method for downsampling, first introduce `crop_pad_3d` with rigorous testing.

See the original method at

https://github.com/ComputationalCryoEM/ASPIRE-Python/blob/1bff8d3884183203bd77695a76bccb1efc909fd3/src/aspire/image/preprocess.py#L12

Details on centering and cropping convention with even/odd to follow.