### PR TITLE
Rectangular micrograph `estimate_ctf` patch

### DIFF
--- a/src/aspire/ctf/ctf_estimator.py
+++ b/src/aspire/ctf/ctf_estimator.py
@@ -153,7 +153,7 @@ class CtfEstimator:
 
         block_list = [
             micrograph[
-                i * step_size : (i + 2) * step_size, j * step_size : (j + 2) * step_size
+                j * step_size : (j + 2) * step_size, i * step_size : (i + 2) * step_size
             ]
             for j in range(range_y)
             for i in range(range_x)

--- a/tests/test_CtfEstimate.py
+++ b/tests/test_CtfEstimate.py
@@ -85,7 +85,7 @@ class CtfEstimatorTestCase(TestCase):
     # we are chopping the micrograph into a vertical and a horizontal rectangle
     # as small as possible to save testing duration
     @parameterized.expand(
-        [[(slice(0, 200), slice(0, 100))], [(slice(0, 100), slice(0, 200))]]
+        [[(slice(0, 128), slice(0, 64))], [(slice(0, 64), slice(0, 128))]]
     )
     def testRectangularMicrograph(self, slice_range):
         with tempfile.TemporaryDirectory() as tmp_input_dir:
@@ -101,4 +101,4 @@ class CtfEstimatorTestCase(TestCase):
                 data = mrc_in.data[slice_range]
                 mrc_in.set_data(data)
             # make sure we can estimate with no errors
-            _ = estimate_ctf(data_folder=tmp_input_dir, psd_size=100)
+            _ = estimate_ctf(data_folder=tmp_input_dir, psd_size=64)

--- a/tests/test_CtfEstimate.py
+++ b/tests/test_CtfEstimate.py
@@ -28,18 +28,6 @@ class CtfEstimatorTestCase(TestCase):
             "amplitude_contrast": 0.07,
         }
 
-        self.ctf_args = {
-            "pixel_size": 1,
-            "cs": 2.0,
-            "amplitude_contrast": 0.07,
-            "voltage": 300.0,
-            "num_tapers": 2,
-            "psd_size": 512,
-            "g_min": 30.0,
-            "g_max": 5.0,
-            "dtype": np.float64,
-        }
-
     def tearDown(self):
         pass
 
@@ -55,10 +43,18 @@ class CtfEstimatorTestCase(TestCase):
                 # Returns results in output_dir
                 results = estimate_ctf(
                     data_folder=tmp_input_dir,
+                    pixel_size=1,
+                    cs=2.0,
+                    amplitude_contrast=0.07,
+                    voltage=300.0,
+                    num_tapers=2,
+                    psd_size=512,
+                    g_min=30.0,
+                    g_max=5.0,
                     output_dir=tmp_output_dir,
+                    dtype=np.float64,
                     save_ctf_images=True,
                     save_noise_images=True,
-                    **self.ctf_args,
                 )
 
                 logger.debug(f"results: {results}")

--- a/tests/test_CtfEstimate.py
+++ b/tests/test_CtfEstimate.py
@@ -91,16 +91,16 @@ class CtfEstimatorTestCase(TestCase):
     @parameterized.expand(
         [[(slice(0, 200), slice(0, 100))], [(slice(0, 100), slice(0, 200))]]
     )
-    def testRectangularMicrograph_vert(self, slice_range):
+    def testRectangularMicrograph(self, slice_range):
         with tempfile.TemporaryDirectory() as tmp_input_dir:
             # copy input file
             copyfile(
                 os.path.join(DATA_DIR, self.test_input_fn),
-                os.path.join(tmp_input_dir, "vert_" + self.test_input_fn),
+                os.path.join(tmp_input_dir, "rect_" + self.test_input_fn),
             )
             # trim the file into a rectangle
             with mrcfile.open(
-                os.path.join(tmp_input_dir, "vert_" + self.test_input_fn), "r+"
+                os.path.join(tmp_input_dir, "rect_" + self.test_input_fn), "r+"
             ) as mrc_in:
                 data = mrc_in.data[slice_range]
                 mrc_in.set_data(data)


### PR DESCRIPTION
Quick fix for #651 

Simple x/y mixup. `mrcfile` stores the Y coordinate at index 0 and the X at index 1.