### PR TITLE
use the dtype from volume in simulated pipeline

### DIFF
--- a/gallery/experiments/simulated_abinitio_pipeline.py
+++ b/gallery/experiments/simulated_abinitio_pipeline.py
@@ -106,6 +106,7 @@ src = Simulation(
     vols=v,
     noise_filter=custom_noise_filter,
     unique_filters=ctf_filters,
+    dtype=v.dtype,
 )
 # Peek
 if interactive:


### PR DESCRIPTION
Doing some debugging for something else I noticed this wasn't inheriting from simulation.

Pushing up before I forget about it.

I think we can skip Joakim on this one if looks okay to you Josh.