### PR TITLE
`evaluate_t()` NumPy warnings

### DIFF
--- a/src/aspire/basis/basis.py
+++ b/src/aspire/basis/basis.py
@@ -119,6 +119,7 @@ class Basis:
                 f"{self.__class__.__name__}::evaluate_t"
                 f" passed numpy array instead of {_class}."
             )
+
             v = _class(v)
         return self._evaluate_t(v)
 
@@ -168,7 +169,6 @@ class Basis:
             those first dimensions of `x`.
 
         """
-
         if isinstance(x, Image) or isinstance(x, Volume):
             x = x.asnumpy()
 
@@ -181,6 +181,11 @@ class Basis:
         sz_roll = x.shape[: -self.ndim]
         # convert to standardized shape e.g. (L,L) to (1,L,L)
         x = x.reshape((-1, *self.sz))
+
+        if x.ndim == 3:
+            _class = Image
+        else:
+            _class = Volume
 
         operator = LinearOperator(
             shape=(self.count, self.count),
@@ -197,7 +202,7 @@ class Basis:
         v = np.zeros((n_data, self.count), dtype=x.dtype)
 
         for isample in range(0, n_data):
-            b = self.evaluate_t(x[isample]).T
+            b = self.evaluate_t(_class(x[isample])).T
             # TODO: need check the initial condition x0 can improve the results or not.
             v[isample], info = cg(operator, b, tol=tol, atol=0)
             if info != 0:

--- a/src/aspire/basis/basis.py
+++ b/src/aspire/basis/basis.py
@@ -119,7 +119,6 @@ class Basis:
                 f"{self.__class__.__name__}::evaluate_t"
                 f" passed numpy array instead of {_class}."
             )
-
             v = _class(v)
         return self._evaluate_t(v)
 

--- a/src/aspire/covariance/covar2d.py
+++ b/src/aspire/covariance/covar2d.py
@@ -530,7 +530,7 @@ class BatchedRotCov2D(RotCov2D):
             batch = np.arange(start, min(start + self.batch_size, src.n))
 
             im = src.images(batch[0], len(batch))
-            coeff = basis.evaluate_t(im.data)
+            coeff = basis.evaluate_t(im)
 
             for k in np.unique(ctf_idx[batch]):
                 coeff_k = coeff[ctf_idx[batch] == k]

--- a/src/aspire/denoising/denoiser_cov2d.py
+++ b/src/aspire/denoising/denoiser_cov2d.py
@@ -180,7 +180,7 @@ class DenoiserCov2D(Denoiser):
         img_start = istart
         img_end = min(istart + batch_size, src.n)
         imgs_noise = src.images(img_start, batch_size)
-        coeffs_noise = self.basis.evaluate_t(imgs_noise.data)
+        coeffs_noise = self.basis.evaluate_t(imgs_noise)
         logger.info(
             f"Estimating Cov2D coefficients for images from {img_start} to {img_end-1}"
         )

--- a/src/aspire/reconstruction/estimator.py
+++ b/src/aspire/reconstruction/estimator.py
@@ -148,7 +148,7 @@ class Estimator:
         vol = self.basis.evaluate(vol_coeff)
         # convolve_volume expects a 3-dimensional array
         # so we remove the first dimension of the volume, which is 1
-        vol = Volume(kernel.convolve_volume(np.squeeze(vol.asnumpy(), axis=0)))
+        vol = kernel.convolve_volume(vol[0])
         vol = self.basis.evaluate_t(vol)
 
         return vol

--- a/src/aspire/reconstruction/estimator.py
+++ b/src/aspire/reconstruction/estimator.py
@@ -83,14 +83,15 @@ class Estimator:
         :return: The adjoint mapping applied to the images, averaged over the whole dataset and expressed
             as coefficients of `basis`.
         """
-        mean_b = np.zeros((self.src.L, self.src.L, self.src.L), dtype=self.dtype)
+        mean_b = Volume(
+            np.zeros((self.src.L, self.src.L, self.src.L), dtype=self.dtype)
+        )
 
         for i in range(0, self.src.n, self.batch_size):
             im = self.src.images(i, self.batch_size)
             batch_mean_b = self.src.im_backward(im, i) / self.src.n
             mean_b += batch_mean_b.astype(self.dtype)
 
-        mean_b = Volume(mean_b)
         res = self.basis.evaluate_t(mean_b)
         logger.info(f"Determined adjoint mappings. Shape = {res.shape}")
         return res

--- a/src/aspire/reconstruction/estimator.py
+++ b/src/aspire/reconstruction/estimator.py
@@ -8,6 +8,7 @@ from scipy.sparse.linalg import LinearOperator
 
 from aspire import config
 from aspire.reconstruction.kernel import FourierKernel
+from aspire.volume import Volume
 
 logger = logging.getLogger(__name__)
 
@@ -89,6 +90,7 @@ class Estimator:
             batch_mean_b = self.src.im_backward(im, i) / self.src.n
             mean_b += batch_mean_b.astype(self.dtype)
 
+        mean_b = Volume(mean_b)
         res = self.basis.evaluate_t(mean_b)
         logger.info(f"Determined adjoint mappings. Shape = {res.shape}")
         return res
@@ -145,7 +147,7 @@ class Estimator:
         vol = self.basis.evaluate(vol_coeff)
         # convolve_volume expects a 3-dimensional array
         # so we remove the first dimension of the volume, which is 1
-        vol = kernel.convolve_volume(np.squeeze(vol.asnumpy(), axis=0))
+        vol = Volume(kernel.convolve_volume(np.squeeze(vol.asnumpy(), axis=0)))
         vol = self.basis.evaluate_t(vol)
 
         return vol

--- a/tests/_basis_util.py
+++ b/tests/_basis_util.py
@@ -119,12 +119,11 @@ class Steerable2DMixin:
         if isinstance(Au, Image):
             Au = Au.asnumpy()
 
-        x = randn(*self.basis.sz, seed=self.seed)
-        x = x.astype(self.dtype)
+        x = Image(randn(*self.basis.sz, seed=self.seed), dtype=self.dtype)
 
         ATx = self.basis.evaluate_t(x)
 
-        Au_dot_x = np.sum(Au * x)
+        Au_dot_x = np.sum(Au * x.asnumpy())
         u_dot_ATx = np.sum(u * ATx)
 
         self.assertTrue(Au_dot_x.shape == u_dot_ATx.shape)

--- a/tests/test_FBbasis2D.py
+++ b/tests/test_FBbasis2D.py
@@ -7,6 +7,7 @@ from pytest import raises
 from scipy.special import jv
 
 from aspire.basis import FBBasis2D
+from aspire.image import Image
 from aspire.utils import complex_type, real_type
 from aspire.utils.coor_trans import grid_2d
 from aspire.utils.random import randn
@@ -82,10 +83,10 @@ class FBBasis2DTestCase(TestCase, Steerable2DMixin, UniversalBasisMixin):
             self._testElement(ell, k, sgn)
 
     def testComplexCoversion(self):
-        x = randn(*self.basis.sz, seed=self.seed)
+        x = Image(randn(*self.basis.sz, seed=self.seed), dtype=self.dtype)
 
         # Express in an FB basis
-        v1 = self.basis.expand(x.astype(self.dtype))
+        v1 = self.basis.expand(x)
 
         # Convert real FB coef to complex coef,
         cv = self.basis.to_complex(v1)

--- a/tests/test_FFBbasis3D.py
+++ b/tests/test_FFBbasis3D.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 import numpy as np
 
 from aspire.basis import FFBBasis3D
+from aspire.volume import Volume
 
 from ._basis_util import UniversalBasisMixin
 
@@ -480,7 +481,7 @@ class FFBBasis3DTestCase(TestCase, UniversalBasisMixin):
 
     def testFFBBasis3DEvaluate_t(self):
         x = np.load(os.path.join(DATA_DIR, "ffbbasis3d_xcoeff_in_8_8_8.npy")).T  # RCOPT
-        result = self.basis.evaluate_t(x)
+        result = self.basis.evaluate_t(Volume(x))
 
         ref = np.load(os.path.join(DATA_DIR, "ffbbasis3d_vcoeff_out_8_8_8.npy"))[..., 0]
 


### PR DESCRIPTION
This addresses issue #701. There were several instances of `evaluate_t()` being passed NumPy arrays. All have been converted to Image/Volume instances.