### PR TITLE
Numpy to Volume in `evaluate_t`

### DIFF
--- a/src/aspire/reconstruction/estimator.py
+++ b/src/aspire/reconstruction/estimator.py
@@ -148,7 +148,7 @@ class Estimator:
         vol = self.basis.evaluate(vol_coeff)
         # convolve_volume expects a 3-dimensional array
         # so we remove the first dimension of the volume, which is 1
-        vol = kernel.convolve_volume(vol[0])
+        vol = Volume(kernel.convolve_volume(vol[0]))
         vol = self.basis.evaluate_t(vol)
 
         return vol


### PR DESCRIPTION
Missed one occurrence of passing NumPy array to s`evaluate_t()` in #709. This will close #701. 