### PR TITLE
Build Gallery without Running

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -25,3 +25,9 @@ distclean:
 	@echo "Removing auto gallery sources."
 	@rm -rf $(wildcard $(SOURCEDIR)/auto_*)
 	$(MAKE) clean
+
+# Build Sphinx Gallery without running any examples.
+html-noplot:
+	$(SPHINXBUILD) -D plot_gallery=False -b html $(ALLSPHINXOPTS) $(SOURCEDIR) $(BUILDDIR)/html
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -28,6 +28,6 @@ distclean:
 
 # Build Sphinx Gallery without running any examples.
 html-noplot:
-	$(SPHINXBUILD) -D plot_gallery=False -b html $(ALLSPHINXOPTS) $(SOURCEDIR) $(BUILDDIR)/html
+	$(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) $(SOURCEDIR) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,6 +48,7 @@ sphinx_gallery_conf = {
      'examples_dirs': ['../../gallery/tutorials', '../../gallery/experiments'],   # path to your example scripts
      'gallery_dirs': ['auto_tutorials', 'auto_experiments'],  # path to where to save gallery generated output
      'download_all_examples': False,
+     'plot_gallery': 'True',
      'within_subsection_order': ExampleTitleSortKey,
      'filename_pattern': r'/tutorials/.*\.py',  # Parse all gallery python files, but only execute tutorials.
 }


### PR DESCRIPTION
This closes #720.

This PR adds `html-noplot` to the Makefile to build the docs without running the gallery:

```
html-noplot:
        $(SPHINXBUILD) -D plot_gallery=False -b html $(ALLSPHINXOPTS) $(SOURCEDIR) $(BUILDDIR)/html
        @echo
        @echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
```

To build docs with modules but without running gallery use commands while in the `docs` directory:

```
sphinx-apidoc -f -o ./source ../src -H Modules
make html-noplot
```