### PR TITLE
Unified `transpose` and `flip` API for Volume and Image

### DIFF
--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -174,7 +174,16 @@ class Image:
     def sqrt(self):
         return Image(np.sqrt(self.data))
 
-    def flip_axes(self):
+    @property
+    def T(self):
+        """
+        Abbreviation for transpose.
+
+        :return: Image instance.
+        """
+        return self.transpose()
+
+    def transpose(self):
         return Image(np.transpose(self.data, (0, 2, 1)))
 
     def __repr__(self):

--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -186,7 +186,7 @@ class Image:
 
     def transpose(self):
         """
-        Returns a new Image instance with image data axis transposed.
+        Returns a new Image instance with image data axes transposed.
 
         :return: Image instance.
         """

--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Iterable
 
 import matplotlib.pyplot as plt
 import mrcfile
@@ -185,6 +186,20 @@ class Image:
 
     def transpose(self):
         return Image(np.transpose(self.data, (0, 2, 1)))
+
+    def flip(self, axis=1):
+        """
+        Flip image stack data along axis using numpy.flip().
+
+        :param axis: Optionally specify axis as integer or tuple.
+            Defaults to axis=1.
+
+        :return: Image instance.
+        """
+        if axis == 0 or (isinstance(axis, Iterable) and 0 in axis):
+            raise ValueError("Cannot flip axis 0: stack axis.")
+
+        return Image(np.flip(self.data, axis))
 
     def __repr__(self):
         return f"{self.n_images} images of size {self.res}x{self.res}"

--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -185,6 +185,11 @@ class Image:
         return self.transpose()
 
     def transpose(self):
+        """
+        Returns a new Image instance with image data axis transposed.
+
+        :return: Image instance.
+        """
         return Image(np.transpose(self.data, (0, 2, 1)))
 
     def flip(self, axis=1):

--- a/src/aspire/volume/__init__.py
+++ b/src/aspire/volume/__init__.py
@@ -215,7 +215,7 @@ class Volume:
 
     def transpose(self):
         """
-        Returns a new Volume instance with volume data axis tranposed
+        Returns a new Volume instance with volume data axes tranposed.
 
         :return: Volume instance.
         """

--- a/src/aspire/volume/__init__.py
+++ b/src/aspire/volume/__init__.py
@@ -219,12 +219,7 @@ class Volume:
 
         :return: Volume instance.
         """
-
-        vol_t = np.empty_like(self._data)
-        for n, v in enumerate(self._data):
-            vol_t[n] = v.T
-
-        return Volume(vol_t)
+        return Volume(np.transpose(self._data, (0, 3, 2, 1)))
 
     @property
     def T(self):

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,7 +1,6 @@
 import os.path
-from unittest import TestCase
-
 from itertools import combinations
+from unittest import TestCase
 
 import numpy as np
 from scipy import misc

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -55,15 +55,19 @@ class ImageTestCase(TestCase):
 
     def testImageTranspose(self):
         # test method and abbreviation
-        self.assertTrue(np.allclose(self.im.T.asnumpy(), self.im.transpose().asnumpy()))
         self.assertTrue(
             np.allclose(self.im.T.asnumpy(), np.transpose(self.im_np, (0, 2, 1)))
+        )
+        self.assertTrue(
+            np.allclose(
+                self.im.transpose().asnumpy(), np.transpose(self.im_np, (0, 2, 1))
+            )
         )
 
         # Check individual imgs in a stack
         for i in range(self.ims_np.shape[0]):
-            self.assertTrue(np.allclose(self.ims.T[i], self.ims.transpose()[i]))
             self.assertTrue(np.allclose(self.ims.T[i], self.ims_np[i].T))
+            self.assertTrue(np.allclose(self.ims.transpose()[i], self.ims_np[i].T))
 
     def testImageFlip(self):
         for axis in powerset(range(1, 3)):

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -55,19 +55,15 @@ class ImageTestCase(TestCase):
 
     def testImageTranspose(self):
         # test method and abbreviation
+        self.assertTrue(np.allclose(self.im.T.asnumpy(), self.im.transpose().asnumpy()))
         self.assertTrue(
-            np.allclose(
-                self.im.T.asnumpy(),
-                self.im.transpose().asnumpy(),
-                np.transpose(self.im_np, (0, 2, 1)),
-            )
+            np.allclose(self.im.T.asnumpy(), np.transpose(self.im_np, (0, 2, 1)))
         )
 
         # Check individual imgs in a stack
         for i in range(self.ims_np.shape[0]):
-            self.assertTrue(
-                np.allclose(self.ims.T[i], self.ims.transpose()[i], self.ims_np[i].T)
-            )
+            self.assertTrue(np.allclose(self.ims.T[i], self.ims.transpose()[i]))
+            self.assertTrue(np.allclose(self.ims.T[i], self.ims_np[i].T))
 
     def testImageFlip(self):
         axes = list(combinations([1, 2], 2))

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -53,20 +53,15 @@ class ImageTestCase(TestCase):
         self.assertTrue(np.allclose(self.ims.sqrt().asnumpy(), np.sqrt(self.ims_np)))
 
     def testImageTranspose(self):
+        # test method and abbreviation
         self.assertTrue(
             np.allclose(
-                self.im.flip_axes().asnumpy(), np.transpose(self.im_np, (0, 2, 1))
+                self.im.T.asnumpy(),
+                self.im.transpose().asnumpy(),
+                np.transpose(self.im_np, (0, 2, 1)),
             )
         )
 
-        # This is equivalent to checking np.tranpose(..., (0, 2, 1))
+        # Check individual imgs in stack
         for i in range(self.ims_np.shape[0]):
-
-            self.assertTrue(np.allclose(self.ims.flip_axes()[i], self.ims_np[i].T))
-
-            # Check against the contruction.
-            self.assertTrue(
-                np.allclose(
-                    self.ims.flip_axes()[i], self.im_np[0].T * (i + 1) / float(self.n)
-                )
-            )
+            self.assertTrue(np.allclose(self.ims.transpose()[i], self.ims_np[i].T))

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -80,12 +80,12 @@ class ImageTestCase(TestCase):
                 result_single = self.im.flip(axis).asnumpy()
                 result_stack = self.ims.flip(axis).asnumpy()
             # single image
-            self.assertTrue(np.allclose(np.flip(self.im_np, axis), result_single))
+            self.assertTrue(np.allclose(result_single, np.flip(self.im_np, axis)))
             # stack
             self.assertTrue(
                 np.allclose(
-                    np.flip(self.ims_np, axis),
                     result_stack,
+                    np.flip(self.ims_np, axis),
                 )
             )
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,11 +1,11 @@
 import os.path
-from itertools import combinations
 from unittest import TestCase
 
 import numpy as np
 from scipy import misc
 
 from aspire.image import Image, _im_translate2
+from aspire.utils import powerset
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "saved_test_data")
 
@@ -66,19 +66,22 @@ class ImageTestCase(TestCase):
             self.assertTrue(np.allclose(self.ims.T[i], self.ims_np[i].T))
 
     def testImageFlip(self):
-        axes = list(combinations([1, 2], 2))
-        for axis in axes:
-            if isinstance(axis, tuple):
-                axis = axis[0]
+        for axis in powerset(range(1, 3)):
+            if not axis:
+                # test default
+                result_single = self.im.flip().asnumpy()
+                result_stack = self.ims.flip().asnumpy()
+                axis = 1
+            else:
+                result_single = self.im.flip(axis).asnumpy()
+                result_stack = self.ims.flip(axis).asnumpy()
             # single image
-            self.assertTrue(
-                np.allclose(np.flip(self.im_np, axis), self.im.flip(axis).asnumpy())
-            )
+            self.assertTrue(np.allclose(np.flip(self.im_np, axis), result_single))
             # stack
             self.assertTrue(
                 np.allclose(
                     np.flip(self.ims_np, axis),
-                    self.ims.flip(axis).asnumpy(),
+                    result_stack,
                 )
             )
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -65,7 +65,9 @@ class ImageTestCase(TestCase):
 
         # Check individual imgs in a stack
         for i in range(self.ims_np.shape[0]):
-            self.assertTrue(np.allclose(self.ims.transpose()[i], self.ims_np[i].T))
+            self.assertTrue(
+                np.allclose(self.ims.T[i], self.ims.transpose()[i], self.ims_np[i].T)
+            )
 
     def testImageFlip(self):
         axes = list(combinations([1, 2], 2))
@@ -74,9 +76,7 @@ class ImageTestCase(TestCase):
                 axis = axis[0]
             # single image
             self.assertTrue(
-                np.allclose(
-                    np.flip(self.im.asnumpy(), axis), self.im.flip(axis).asnumpy()
-                )
+                np.allclose(np.flip(self.im_np, axis), self.im.flip(axis).asnumpy())
             )
             # stack
             self.assertTrue(


### PR DESCRIPTION
See #644 

Currently `Image.flip_axes` does what `.T` should do, and `Image` does not have a `flip()`.

This PR fixes `Volume.transpose()` and introduces the same API for `Image`

That is, `transpose()` and `T` transpose each volume/image along the stack axis, while `flip(axes)` reverses the order of the data along a given axis (with the stack axis being forbidden)