### PR TITLE
commonline orient est dtype passthrough check

### DIFF
--- a/tests/test_orient_sync.py
+++ b/tests/test_orient_sync.py
@@ -68,6 +68,9 @@ class OrientSyncTestCase(TestCase):
     def testEstRotations(self):
         self.orient_est.estimate_rotations()
         results = np.load(os.path.join(DATA_DIR, "orient_est_rots.npy"))
+        # Check the dtype passthrough is preserved
+        self.assertTrue(self.orient_est.rotations.dtype == self.dtype)
+        # Check the values match reference rotation
         self.assertTrue(
             np.allclose(
                 results,


### PR DESCRIPTION
Note this is xfail until 713, but should cover this case in unit test instead of just the gallery.