### PR TITLE
Add pytest-xdist to dev tools extras

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
             "pytest",
             "pytest-cov",
             "pytest-random-order",
+            "pytest-xdist",
             "requests",
             "sphinxcontrib-bibtex",
             "sphinx-gallery",


### PR DESCRIPTION
I find myself adding this package frequently.

It allows you to call pytest in parallel.

`pytest -n4` will use four cores.  On my Machine 4-6 cores reduces the pytest time significantly.

For the m1 machines, you will need to experiment.