### PR TITLE
Azure timeout 746

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,7 +82,7 @@ jobs:
   - bash: |
       source activate myEnvironment
       pip install -e .[dev]
-      pytest --random-order
+      pytest -s
     displayName: pytest
 
 - job:
@@ -112,7 +112,7 @@ jobs:
   - bash: |
       source activate myEnvironment
       pip install -e .[dev]
-      pytest --random-order
+      pytest -s
     displayName: pytest
 
 - job:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,6 +94,8 @@ jobs:
       Python37:
         python.version: '3.7'
 
+# comment for testing
+
   steps:
   - bash: |
       echo "##vso[task.prependpath]$CONDA/bin"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,8 +94,6 @@ jobs:
       Python37:
         python.version: '3.7'
 
-# comment for testing
-
   steps:
   - bash: |
       echo "##vso[task.prependpath]$CONDA/bin"


### PR DESCRIPTION
This PR changes the azure CI to run pytest in order and with standard out (for macOS only) to troubleshoot recent timeouts. 