### PR TITLE
Pin pytest to 7.1.3 to see if resolves Azure hangs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
             "pyflakes",
             "pydocstyle",
             "parameterized",
-            "pytest",
+            "pytest==7.1.3",
             "pytest-cov",
             "pytest-random-order",
             "pytest-xdist",


### PR DESCRIPTION
@j-c-c mentioned that pytest pushed a new release around the time we started seeing hangs on Azure.

Today for the first time I saw a hang in pytest on a local machine running `develop` using new env having pytest 7.2.0. Looked like it might have been a thread wait/lock inside of pytest; the ^C traceback did not include any frames from our code.

If it does not resolve the hangs we can revert.