### PR TITLE
Use CnSymmetricVolume in Common-lines test

### DIFF
--- a/tests/test_orient_symmetric.py
+++ b/tests/test_orient_symmetric.py
@@ -52,7 +52,10 @@ class OrientSymmTestCase(TestCase):
             )
 
             self.cl_orient_ests[order] = CLSymmetryC3C4(
-                self.srcs[order], symmetry=f"C{order}", n_theta=self.n_theta
+                self.srcs[order],
+                symmetry=f"C{order}",
+                n_theta=self.n_theta,
+                max_shift=1 / self.L,
             )
 
     def tearDown(self):

--- a/tests/test_orient_symmetric.py
+++ b/tests/test_orient_symmetric.py
@@ -13,9 +13,9 @@ from aspire.utils.coor_trans import (
     get_rots_mse,
     register_rotations,
 )
-from aspire.utils.misc import J_conjugate, all_pairs, cyclic_rotations, gaussian_3d
+from aspire.utils.misc import J_conjugate, all_pairs, cyclic_rotations
 from aspire.utils.random import randn
-from aspire.volume import CnSymmetricVolume, Volume
+from aspire.volume import CnSymmetricVolume
 
 
 class OrientSymmTestCase(TestCase):
@@ -227,7 +227,6 @@ class OrientSymmTestCase(TestCase):
         # ie. check that the svd is close to [1, 0, 0].
         error_ij = np.linalg.norm(np.array([1, 0, 0], dtype=self.dtype) - sij, axis=1)
         error_ii = np.linalg.norm(np.array([1, 0, 0], dtype=self.dtype) - sii, axis=1)
-
         self.assertTrue(np.max(error_ij) < 0.2)
         self.assertTrue(np.max(error_ii) < 1e-5)
         self.assertTrue(np.mean(error_ij) < 0.002)

--- a/tests/test_orient_symmetric.py
+++ b/tests/test_orient_symmetric.py
@@ -402,6 +402,15 @@ def testCompleteThirdRow(dtype):
     assert np.allclose(det(R), 1)
 
 
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def testDtypePassThrough(dtype):
+    L = 16
+    n_img = 20
+    order = 3  # test does not depend on order
+    src, cl_symm = source_orientation_objs(L, n_img, order, dtype)
+    assert src.dtype == cl_symm.dtype
+
+
 def buildSelfCommonLinesMatrix(n_theta, rots, order):
     # Construct rotatation matrices associated with cyclic order.
     rots_symm = cyclic_rotations(order, rots.dtype).matrices

--- a/tests/test_orient_symmetric.py
+++ b/tests/test_orient_symmetric.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 from numpy import pi, random
 from numpy.linalg import det, norm
-from parameterized import param, parameterized, parameterized_class
+from parameterized import parameterized_class
 
 from aspire.abinitio import CLSymmetryC3C4
 from aspire.source import Simulation
@@ -419,7 +419,7 @@ class OrderFreeTestCase(TestCase):
 
         self.orient_est = CLSymmetryC3C4(
             self.src,
-            symmetry=f"C3",
+            symmetry="C3",
             n_theta=self.n_theta,
             max_shift=1 / self.L,
         )

--- a/tests/test_orient_symmetric.py
+++ b/tests/test_orient_symmetric.py
@@ -1,10 +1,7 @@
-from unittest import TestCase
-
 import numpy as np
 import pytest
 from numpy import pi, random
 from numpy.linalg import det, norm
-from parameterized import parameterized_class
 
 from aspire.abinitio import CLSymmetryC3C4
 from aspire.source import Simulation
@@ -18,488 +15,439 @@ from aspire.utils.misc import J_conjugate, all_pairs, cyclic_rotations
 from aspire.utils.random import randn
 from aspire.volume import CnSymmetricVolume
 
-
-class OrientSymmTestCase:
-    def setUp(self):
-        self.n_img = 24
-        self.n_theta = 360
-
-        # Generate CnSymmetricVolume, associated Simulation object, and orientation estimation object.
-        # For the Simulation object we use clean, non-shifted projection images.
-        self.vol = CnSymmetricVolume(
-            L=self.L,
-            C=1,
-            order=self.order,
-            seed=0,
-            dtype=self.dtype,
-        ).generate()
-
-        self.src = Simulation(
-            L=self.L,
-            n=self.n_img,
-            offsets=np.zeros((self.n_img, 2)),
-            dtype=self.dtype,
-            vols=self.vol,
-            C=1,
-            seed=123,
-        )
-
-        self.cl_orient_est = CLSymmetryC3C4(
-            self.src,
-            symmetry=f"C{self.order}",
-            n_theta=self.n_theta,
-            max_shift=1 / self.L,
-        )
-
-    def tearDown(self):
-        pass
-
-    def testEstimateRotations(self):
-        src = self.src
-        cl_symm = self.cl_orient_est
-
-        # Estimate rotations.
-        cl_symm.estimate_rotations()
-        rots_est = cl_symm.rotations
-
-        # g-synchronize ground truth rotations.
-        rots_gt = src.rotations
-        rots_gt_sync = cl_symm.g_sync(rots_est, self.order, rots_gt)
-
-        # Register estimates to ground truth rotations and compute MSE.
-        Q_mat, flag = register_rotations(rots_est, rots_gt_sync)
-        regrot = get_aligned_rotations(rots_est, Q_mat, flag)
-        mse_reg = get_rots_mse(regrot, rots_gt_sync)
-
-        # Assert mse is small.
-        self.assertTrue(mse_reg < 0.005)
-
-    def testRelativeRotations(self):
-        n_img = self.n_img
-
-        # Simulation source and common lines estimation instance
-        # corresponding to volume with C3 or C4 symmetry.
-        src = self.src
-        cl_symm = self.cl_orient_est
-
-        # Estimate relative viewing directions.
-        cl_symm.build_clmatrix()
-        cl = cl_symm.clmatrix
-        Rijs = cl_symm._estimate_all_Rijs_c3_c4(cl)
-
-        # Each Rij belongs to the set {Ri.Tg_n^sRj, JRi.Tg_n^sRjJ},
-        # s = 1, 2, ..., order. We find the mean squared error over
-        # the minimum error between Rij and the above set.
-        gs = cyclic_rotations(self.order, self.dtype).matrices
-        rots_gt = src.rotations
-
-        # Find the angular distance between each Rij and the ground truth.
-        pairs = all_pairs(n_img)
-        angular_distance = np.zeros(len(pairs))
-        for idx, (i, j) in enumerate(pairs):
-            Rij = Rijs[idx]
-            Rij_J = J_conjugate(Rij)
-            Ri_gt = rots_gt[i]
-            Rj_gt = rots_gt[j]
-            dist = np.zeros(self.order)
-            for s in range(self.order):
-                Rij_s_gt = Ri_gt.T @ gs[s] @ Rj_gt
-                dist[s] = np.minimum(
-                    Rotation.angle_dist(Rij, Rij_s_gt),
-                    Rotation.angle_dist(Rij_J, Rij_s_gt),
-                )
-            angular_distance[idx] = np.min(dist)
-        mean_angular_distance = np.mean(angular_distance)
-
-        # Assert that the mean_angular_distance is less than 5 degrees.
-        self.assertTrue(mean_angular_distance < 5)
-
-    def testSelfRelativeRotations(self):
-        n_img = self.n_img
-
-        # Simulation source and common lines Class corresponding to
-        # volume with C3 or C4 symmetry.
-        src = self.src
-        cl_symm = self.cl_orient_est
-
-        # Estimate self-relative viewing directions, Riis.
-        scl = cl_symm._self_clmatrix_c3_c4()
-        Riis = cl_symm._estimate_all_Riis_c3_c4(scl)
-
-        # Each estimated Rii belongs to the set
-        # {Ri.Tg_nRi, Ri.Tg_n^{n-1}Ri, JRi.Tg_nRiJ, JRi.Tg_n^{n-1}RiJ}.
-        # We find the minimum angular distance between the estimate Rii
-        # and the 4 possible ground truths.
-        rots_symm = cyclic_rotations(self.order, self.dtype).matrices
-        g = rots_symm[1]
-        rots_gt = src.rotations
-
-        # Find angular distance between estimate and ground truth.
-        dist = np.zeros(4)
-        angular_distance = np.zeros(n_img)
-        for i, rot_gt in enumerate(rots_gt):
-            Rii_gt = rot_gt.T @ g @ rot_gt
-            Rii = Riis[i]
-            cases = np.array([Rii, Rii.T, J_conjugate(Rii), J_conjugate(Rii.T)])
-            for i, estimate in enumerate(cases):
-                dist[i] = Rotation.angle_dist(estimate, Rii_gt)
-            angular_distance[i] = dist[np.argmin(dist)]
-        mean_angular_distance = np.mean(angular_distance)
-
-        # Check that mean_angular_distance is less than 5 degrees.
-        self.assertTrue(mean_angular_distance < 5)
-
-    def testRelativeViewingDirections(self):
-        n_img = self.n_img
-
-        # Simulation source and common lines Class corresponding to
-        # volume with C3 or C4 symmetry.
-        src = self.src
-        cl_symm = self.cl_orient_est
-
-        # Calculate ground truth relative viewing directions, viis and vijs.
-        rots_gt = src.rotations
-
-        viis_gt = np.zeros((n_img, 3, 3))
-        for i in range(n_img):
-            vi = rots_gt[i, 2]
-            viis_gt[i] = np.outer(vi, vi)
-
-        pairs = all_pairs(n_img)
-        n_pairs = len(pairs)
-        vijs_gt = np.zeros((n_pairs, 3, 3))
-        for idx, (i, j) in enumerate(pairs):
-            vi = rots_gt[i, 2]
-            vj = rots_gt[j, 2]
-            vijs_gt[idx] = np.outer(vi, vj)
-
-        # Estimate relative viewing directions.
-        vijs, viis = cl_symm._estimate_relative_viewing_directions_c3_c4()
-
-        # Since ground truth vijs and viis are rank 1 matrices they span a 1D subspace.
-        # We use SVD to find this subspace for our estimates and the ground truth relative viewing directions.
-        # We then calculate the angular distance between these subspaces (and take the mean).
-        # SVD's:
-        uij_gt, _, _ = np.linalg.svd(vijs_gt)
-        uii_gt, _, _ = np.linalg.svd(viis_gt)
-        uij_est, sij, _ = np.linalg.svd(vijs)
-        uii_est, sii, _ = np.linalg.svd(viis)
-        uij_J_est, _, _ = np.linalg.svd(J_conjugate(vijs))
-        uii_J_est, _, _ = np.linalg.svd(J_conjugate(viis))
-
-        # Ground truth 1D supbspaces.
-        uij_gt = uij_gt[:, :, 0]
-        uii_gt = uii_gt[:, :, 0]
-
-        # 1D subspace of estimates.
-        uij_est = uij_est[:, :, 0]
-        uii_est = uii_est[:, :, 0]
-        uij_J_est = uij_J_est[:, :, 0]
-        uii_J_est = uii_J_est[:, :, 0]
-
-        # Calculate angular distance between subspaces.
-        theta_vij = np.arccos(np.sum(uij_gt * uij_est, axis=1))
-        theta_vij_J = np.arccos(np.sum(uij_gt * uij_J_est, axis=1))
-        theta_vii = np.arccos(np.sum(uii_gt * uii_est, axis=1))
-        theta_vii_J = np.arccos(np.sum(uii_gt * uii_J_est, axis=1))
-
-        # Minimum angle between subspaces.
-        min_theta_vij = np.min(
-            (theta_vij, theta_vij_J, np.pi - theta_vij, np.pi - theta_vij_J), axis=0
-        )
-        min_theta_vii = np.min(
-            (theta_vii, theta_vii_J, np.pi - theta_vii, np.pi - theta_vii_J), axis=0
-        )
-
-        # Calculate the mean minimum angular distance.
-        angular_dist_vijs = np.mean(min_theta_vij)
-        angular_dist_viis = np.mean(min_theta_vii)
-
-        # Check that estimates are indeed approximately rank 1.
-        # ie. check that the svd is close to [1, 0, 0].
-        error_ij = np.linalg.norm(np.array([1, 0, 0], dtype=self.dtype) - sij, axis=1)
-        error_ii = np.linalg.norm(np.array([1, 0, 0], dtype=self.dtype) - sii, axis=1)
-        self.assertTrue(np.max(error_ij) < 0.2)
-        self.assertTrue(np.max(error_ii) < 1e-5)
-        self.assertTrue(np.mean(error_ij) < 0.002)
-        self.assertTrue(np.mean(error_ii) < 1e-5)
-
-        # Check that the mean angular difference is within 2 degrees.
-        angle_tol = 2 * np.pi / 180
-        self.assertTrue(angular_dist_vijs < angle_tol)
-        self.assertTrue(angular_dist_viis < angle_tol)
-
-    def testSelfCommonLines(self):
-        n_theta = self.n_theta
-        src = self.src
-        L = src.L
-        cl_symm = self.cl_orient_est
-
-        # Initialize common-lines orientation estimation object and compute self-common-lines matrix.
-        scl = cl_symm._self_clmatrix_c3_c4()
-
-        # Compute ground truth self-common-lines matrix.
-        rots = src.rotations
-        scl_gt = self.buildSelfCommonLinesMatrix(rots, self.order)
-
-        # Since we search for self common lines whose angle differences fall
-        # outside of 180 degrees by a tolerance of 2 * (360 // L), we must exclude
-        # indices whose ground truth self common lines fall within that tolerance.
-        gt_diffs = abs(scl_gt[:, 0] - scl_gt[:, 1])
-        res = 2 * (360 // L)
-        good_indices = (gt_diffs < (180 - res)) | (gt_diffs > (180 + res))
-        scl = scl[good_indices]
-        scl_gt = scl_gt[good_indices]
-
-        # Get angle difference between scl_gt and scl.
-        scl_diff1 = scl_gt - scl
-        scl_diff2 = scl_gt - np.flip(scl, 1)  # Order of indices might be switched.
-        scl_diff1_angle = scl_diff1 * 2 * pi / n_theta
-        scl_diff2_angle = scl_diff2 * 2 * pi / n_theta
-
-        # cosine is invariant to 2pi, and abs is invariant to +-pi due to J-conjugation.
-        # We take the mean deviation wrt to the two lines in each image.
-        scl_diff1_angle_mean = np.mean(np.arccos(abs(np.cos(scl_diff1_angle))), axis=1)
-        scl_diff2_angle_mean = np.mean(np.arccos(abs(np.cos(scl_diff2_angle))), axis=1)
-
-        scl_diff_angle_mean = np.vstack((scl_diff1_angle_mean, scl_diff2_angle_mean))
-        scl_idx = np.argmin(scl_diff_angle_mean, axis=0)
-        min_mean_angle_diff = scl_idx.choose(scl_diff_angle_mean)
-
-        # Assert scl detection rate is 100% for 5 degree angle tolerance
-        angle_tol_err = 5 * pi / 180
-        detection_rate = np.count_nonzero(min_mean_angle_diff < angle_tol_err) / len(
-            scl
-        )
-        self.assertTrue(np.allclose(detection_rate, 1.0))
-
-    def testCommonLines(self):
-        n_img = self.n_img
-        src = self.src
-        cl_symm = self.cl_orient_est
-        n_theta = self.n_theta
-
-        # Build common-lines matrix.
-        cl_symm.build_clmatrix()
-        cl = cl_symm.clmatrix
-
-        # Compare common-line indices with ground truth angles.
-        rots = src.rotations  # ground truth rotations
-        rots_symm = cyclic_rotations(self.order, self.dtype).matrices
-        pairs = all_pairs(n_img)
-        within_1_degree = 0
-        within_5_degrees = 0
-        for (i, j) in pairs:
-            a_ij_s = np.zeros(self.order)
-            a_ji_s = np.zeros(self.order)
-            # Convert common-line indices to angles. Use angle of common line in [0, 180).
-            cl_ij = (cl[i, j] * 360 / n_theta) % 180
-            cl_ji = (cl[j, i] * 360 / n_theta) % 180
-
-            # The common-line estimates cl_ij, cl_ji should match the
-            # true common-line angles a_ij_s, a_ji_s for some value s,
-            # where s is the number of common-lines induced by the symmetric self.order.
-            for s in range(self.order):
-                rel_rot = rots[i].T @ rots_symm[s] @ rots[j]
-                a_ij_s[s] = np.rad2deg(np.arctan(-rel_rot[0, 2] / rel_rot[1, 2])) % 180
-                a_ji_s[s] = np.rad2deg(np.arctan(-rel_rot[2, 0] / rel_rot[2, 1])) % 180
-            best_s = np.argmin(abs(cl_ij - a_ij_s) + abs(cl_ji - a_ji_s))
-            diff_ij = abs(cl_ij - a_ij_s[best_s])
-            diff_ji = abs(cl_ji - a_ji_s[best_s])
-
-            # Count the number of good estimates.
-            if diff_ij < 1:
-                within_1_degree += 1
-                within_5_degrees += 1
-            elif diff_ij < 5:
-                within_5_degrees += 1
-
-            if diff_ji < 1:
-                within_1_degree += 1
-                within_5_degrees += 1
-            elif diff_ji < 5:
-                within_5_degrees += 1
-
-        # Assert that at least 98% of estimates are within 5 degrees and
-        # at least 90% of estimates are within 1 degree.
-        n_estimates = 2 * len(pairs)
-        within_5 = within_5_degrees / n_estimates
-        within_1 = within_1_degree / n_estimates
-        self.assertTrue(within_5 > 0.98)
-        self.assertTrue(within_1 > 0.90)
-
-    def buildSelfCommonLinesMatrix(self, rots, order):
-        # Construct rotatation matrices associated with cyclic order.
-        rots_symm = cyclic_rotations(order, self.dtype).matrices
-
-        # Build ground truth self-common-lines matrix.
-        scl_gt = np.zeros((self.n_img, 2), dtype=self.dtype)
-        n_theta = self.n_theta
-        g = rots_symm[1]
-        g_n = rots_symm[-1]
-        for i in range(self.n_img):
-            Ri = rots[i]
-
-            U1 = Ri.T @ g @ Ri
-            U2 = Ri.T @ g_n @ Ri
-
-            c1 = np.array([-U1[1, 2], U1[0, 2]])
-            c2 = np.array([-U2[1, 2], U2[0, 2]])
-
-            theta_g = np.arctan2(c1[1], c1[0]) % (2 * np.pi)
-            theta_gn = np.arctan2(c2[1], c2[0]) % (2 * np.pi)
-
-            scl_gt[i, 0] = np.round(theta_g * n_theta / (2 * np.pi)) % n_theta
-            scl_gt[i, 1] = np.round(theta_gn * n_theta / (2 * np.pi)) % n_theta
-
-        return scl_gt
-
-
-@parameterized_class(("L", "order", "dtype"), [(44, 4, np.float32)])
-class OrientSymmSmallSuite(OrientSymmTestCase, TestCase):
-    """Small test suite for OrientSymmTestCase."""
-
-    L = 44
-    order = 3
-    dtype = np.float32
-
-
-@pytest.mark.expensive
-@parameterized_class(
-    ("L", "order", "dtype"),
-    [
-        (44, 4, np.float64),
-        (45, 3, np.float32),
-        (45, 4, np.float32),
-        (45, 3, np.float64),
-        (45, 4, np.float64),
-    ],
-)
-class OrientSymmLargeSuite(OrientSymmTestCase, TestCase):
-    """Large test suite for OrientSymmTestCase."""
-
-    L = 44
-    order = 3
-    dtype = np.float64
-
-
-@parameterized_class(
-    ("L", "dtype"),
-    [
-        (16, np.float32),
-        (16, np.float64),
-        (17, np.float32),
-        (17, np.float64),
-    ],
-)
-class OrderFreeTestCase(TestCase):
-    """Tests for methods that do not depend on cyclic order."""
-
-    def setUp(self):
-        self.n_img = 16
-        self.n_theta = 360
-
-        self.vols = CnSymmetricVolume(
-            L=self.L,
-            C=1,
-            order=3,
-            seed=0,
-            dtype=self.dtype,
-        ).generate()
-
-        self.src = Simulation(
-            L=self.L,
-            n=self.n_img,
-            offsets=np.zeros((self.n_img, 2)),
-            dtype=self.dtype,
-            vols=self.vols,
-            C=1,
-            seed=123,
-        )
-
-        self.orient_est = CLSymmetryC3C4(
-            self.src,
-            symmetry="C3",
-            n_theta=self.n_theta,
-            max_shift=1 / self.L,
-        )
-
-    def testGlobalJSync(self):
-        n_img = self.n_img
-        # Build a set of outer products of random third rows.
-        vijs, viis, _ = self.buildOuterProducts(n_img)
-
-        # J-conjugate some of these outer products (every other element).
-        vijs_conj, viis_conj = vijs.copy(), viis.copy()
-        vijs_conj[::2] = J_conjugate(vijs_conj[::2])
-        viis_conj[::2] = J_conjugate(viis_conj[::2])
-
-        # Synchronize vijs_conj and viis_conj.
-        # Note: `_global_J_sync()` does not depend on cyclic order, so we can use
-        # either cl_orient_ests[3] or cl_orient_ests[4] to access the method.
-        vijs_sync, viis_sync = self.orient_est._global_J_sync(vijs_conj, viis_conj)
-
-        # Check that synchronized outer products equal original
-        # up to J-conjugation of the entire set.
-        if (vijs[0] == vijs_sync[0]).all():
-            self.assertTrue(np.allclose(vijs, vijs_sync))
-            self.assertTrue(np.allclose(viis, viis_sync))
-        else:
-            self.assertTrue(np.allclose(vijs, J_conjugate(vijs_sync)))
-            self.assertTrue(np.allclose(viis, J_conjugate(viis_sync)))
-
-    def testEstimateThirdRows(self):
-        n_img = self.n_img
-
-        # Build outer products vijs, viis, and get ground truth third rows.
-        vijs, viis, gt_vis = self.buildOuterProducts(n_img)
-
-        # Estimate third rows from outer products.
-        # Due to factorization of V, these might be negated third rows.
-        vis = self.orient_est._estimate_third_rows(vijs, viis)
-
-        # Check if all-close up to difference of sign
-        ground_truth = np.sign(gt_vis[0, 0]) * gt_vis
-        estimate = np.sign(vis[0, 0]) * vis
-        self.assertTrue(np.allclose(ground_truth, estimate))
-
-    def testCompleteThirdRow(self):
-        # Complete third row that coincides with z-axis
-        z = np.array([0, 0, 1])
-        Rz = CLSymmetryC3C4._complete_third_row_to_rot(z)
-
-        # Complete random third row.
-        r3 = randn(3, seed=123)
-        r3 /= norm(r3)
-        R = CLSymmetryC3C4._complete_third_row_to_rot(r3)
-
-        # Assert that Rz is the identity matrix.
-        self.assertTrue(np.allclose(Rz, np.eye(3)))
-
-        # Assert that R is orthogonal with determinant 1.
-        self.assertTrue(np.allclose(R @ R.T, np.eye(3)))
-        self.assertTrue(np.allclose(det(R), 1))
-
-    def buildOuterProducts(self, n_img):
-        # Build random third rows, ground truth vis (unit vectors)
-        gt_vis = np.zeros((n_img, 3), dtype=np.float32)
-        for i in range(n_img):
-            random.seed(i)
-            v = random.randn(3)
-            gt_vis[i] = v / norm(v)
-
-        # Find outer products viis and vijs for i<j
-        nchoose2 = int(n_img * (n_img - 1) / 2)
-        vijs = np.zeros((nchoose2, 3, 3))
-        viis = np.zeros((n_img, 3, 3))
-
-        # All pairs (i,j) where i<j
-        pairs = all_pairs(n_img)
-
-        for k, (i, j) in enumerate(pairs):
-            vijs[k] = np.outer(gt_vis[i], gt_vis[j])
-
-        for i in range(n_img):
-            viis[i] = np.outer(gt_vis[i], gt_vis[i])
-
-        return vijs, viis, gt_vis
+# A set of these parameters are marked expensive to reduce testing time.
+param_list = [
+    (44, 3, np.float32),
+    (45, 4, np.float64),
+    pytest.param(44, 4, np.float32, marks=pytest.mark.expensive),
+    pytest.param(44, 3, np.float64, marks=pytest.mark.expensive),
+    pytest.param(44, 4, np.float64, marks=pytest.mark.expensive),
+    pytest.param(45, 3, np.float32, marks=pytest.mark.expensive),
+    pytest.param(45, 4, np.float32, marks=pytest.mark.expensive),
+    pytest.param(45, 3, np.float64, marks=pytest.mark.expensive),
+]
+
+
+# Method to instantiate a Simulation source and orientation estimation object.
+def source_orientation_objs(L, n_img, order, dtype):
+    vol = CnSymmetricVolume(
+        L=L,
+        C=1,
+        order=order,
+        seed=0,
+        dtype=dtype,
+    ).generate()
+
+    src = Simulation(
+        L=L,
+        n=n_img,
+        offsets=np.zeros((n_img, 2)),
+        dtype=dtype,
+        vols=vol,
+        C=1,
+        seed=123,
+    )
+
+    orient_est = CLSymmetryC3C4(
+        src,
+        symmetry=f"C{order}",
+        n_theta=360,
+        max_shift=1 / L,  # set to 1 pixel
+    )
+    return src, orient_est
+
+
+@pytest.mark.parametrize("L, order, dtype", param_list)
+def testEstimateRotations(L, order, dtype):
+    n_img = 24
+    src, cl_symm = source_orientation_objs(L, n_img, order, dtype)
+
+    # Estimate rotations.
+    cl_symm.estimate_rotations()
+    rots_est = cl_symm.rotations
+
+    # g-synchronize ground truth rotations.
+    rots_gt = src.rotations
+    rots_gt_sync = cl_symm.g_sync(rots_est, order, rots_gt)
+
+    # Register estimates to ground truth rotations and compute MSE.
+    Q_mat, flag = register_rotations(rots_est, rots_gt_sync)
+    regrot = get_aligned_rotations(rots_est, Q_mat, flag)
+    mse_reg = get_rots_mse(regrot, rots_gt_sync)
+
+    # Assert mse is small.
+    assert mse_reg < 0.005
+
+
+@pytest.mark.parametrize("L, order, dtype", param_list)
+def testRelativeRotations(L, order, dtype):
+    # Simulation source and common lines estimation instance
+    # corresponding to volume with C3 or C4 symmetry.
+    n_img = 24
+    src, cl_symm = source_orientation_objs(L, n_img, order, dtype)
+
+    # Estimate relative viewing directions.
+    cl_symm.build_clmatrix()
+    cl = cl_symm.clmatrix
+    Rijs = cl_symm._estimate_all_Rijs_c3_c4(cl)
+
+    # Each Rij belongs to the set {Ri.Tg_n^sRj, JRi.Tg_n^sRjJ},
+    # s = 1, 2, ..., order. We find the mean squared error over
+    # the minimum error between Rij and the above set.
+    gs = cyclic_rotations(order, dtype).matrices
+    rots_gt = src.rotations
+
+    # Find the angular distance between each Rij and the ground truth.
+    pairs = all_pairs(n_img)
+    angular_distance = np.zeros(len(pairs))
+    for idx, (i, j) in enumerate(pairs):
+        Rij = Rijs[idx]
+        Rij_J = J_conjugate(Rij)
+        Ri_gt = rots_gt[i]
+        Rj_gt = rots_gt[j]
+        dist = np.zeros(order)
+        for s in range(order):
+            Rij_s_gt = Ri_gt.T @ gs[s] @ Rj_gt
+            dist[s] = np.minimum(
+                Rotation.angle_dist(Rij, Rij_s_gt),
+                Rotation.angle_dist(Rij_J, Rij_s_gt),
+            )
+        angular_distance[idx] = np.min(dist)
+    mean_angular_distance = np.mean(angular_distance)
+
+    # Assert that the mean_angular_distance is less than 5 degrees.
+    assert mean_angular_distance < 5
+
+
+@pytest.mark.parametrize("L, order, dtype", param_list)
+def testSelfRelativeRotations(L, order, dtype):
+    # Simulation source and common lines Class corresponding to
+    # volume with C3 or C4 symmetry.
+    n_img = 24
+    src, cl_symm = source_orientation_objs(L, n_img, order, dtype)
+
+    # Estimate self-relative viewing directions, Riis.
+    scl = cl_symm._self_clmatrix_c3_c4()
+    Riis = cl_symm._estimate_all_Riis_c3_c4(scl)
+
+    # Each estimated Rii belongs to the set
+    # {Ri.Tg_nRi, Ri.Tg_n^{n-1}Ri, JRi.Tg_nRiJ, JRi.Tg_n^{n-1}RiJ}.
+    # We find the minimum angular distance between the estimate Rii
+    # and the 4 possible ground truths.
+    rots_symm = cyclic_rotations(order, dtype).matrices
+    g = rots_symm[1]
+    rots_gt = src.rotations
+
+    # Find angular distance between estimate and ground truth.
+    dist = np.zeros(4)
+    angular_distance = np.zeros(n_img)
+    for i, rot_gt in enumerate(rots_gt):
+        Rii_gt = rot_gt.T @ g @ rot_gt
+        Rii = Riis[i]
+        cases = np.array([Rii, Rii.T, J_conjugate(Rii), J_conjugate(Rii.T)])
+        for i, estimate in enumerate(cases):
+            dist[i] = Rotation.angle_dist(estimate, Rii_gt)
+        angular_distance[i] = dist[np.argmin(dist)]
+    mean_angular_distance = np.mean(angular_distance)
+
+    # Check that mean_angular_distance is less than 5 degrees.
+    assert mean_angular_distance < 5
+
+
+@pytest.mark.parametrize("L, order, dtype", param_list)
+def testRelativeViewingDirections(L, order, dtype):
+    # Simulation source and common lines Class corresponding to
+    # volume with C3 or C4 symmetry.
+    n_img = 24
+    src, cl_symm = source_orientation_objs(L, n_img, order, dtype)
+
+    # Calculate ground truth relative viewing directions, viis and vijs.
+    rots_gt = src.rotations
+
+    viis_gt = np.zeros((n_img, 3, 3))
+    for i in range(n_img):
+        vi = rots_gt[i, 2]
+        viis_gt[i] = np.outer(vi, vi)
+
+    pairs = all_pairs(n_img)
+    n_pairs = len(pairs)
+    vijs_gt = np.zeros((n_pairs, 3, 3))
+    for idx, (i, j) in enumerate(pairs):
+        vi = rots_gt[i, 2]
+        vj = rots_gt[j, 2]
+        vijs_gt[idx] = np.outer(vi, vj)
+
+    # Estimate relative viewing directions.
+    vijs, viis = cl_symm._estimate_relative_viewing_directions_c3_c4()
+
+    # Since ground truth vijs and viis are rank 1 matrices they span a 1D subspace.
+    # We use SVD to find this subspace for our estimates and the ground truth relative viewing directions.
+    # We then calculate the angular distance between these subspaces (and take the mean).
+    # SVD's:
+    uij_gt, _, _ = np.linalg.svd(vijs_gt)
+    uii_gt, _, _ = np.linalg.svd(viis_gt)
+    uij_est, sij, _ = np.linalg.svd(vijs)
+    uii_est, sii, _ = np.linalg.svd(viis)
+    uij_J_est, _, _ = np.linalg.svd(J_conjugate(vijs))
+    uii_J_est, _, _ = np.linalg.svd(J_conjugate(viis))
+
+    # Ground truth 1D supbspaces.
+    uij_gt = uij_gt[:, :, 0]
+    uii_gt = uii_gt[:, :, 0]
+
+    # 1D subspace of estimates.
+    uij_est = uij_est[:, :, 0]
+    uii_est = uii_est[:, :, 0]
+    uij_J_est = uij_J_est[:, :, 0]
+    uii_J_est = uii_J_est[:, :, 0]
+
+    # Calculate angular distance between subspaces.
+    theta_vij = np.arccos(np.sum(uij_gt * uij_est, axis=1))
+    theta_vij_J = np.arccos(np.sum(uij_gt * uij_J_est, axis=1))
+    theta_vii = np.arccos(np.sum(uii_gt * uii_est, axis=1))
+    theta_vii_J = np.arccos(np.sum(uii_gt * uii_J_est, axis=1))
+
+    # Minimum angle between subspaces.
+    min_theta_vij = np.min(
+        (theta_vij, theta_vij_J, np.pi - theta_vij, np.pi - theta_vij_J), axis=0
+    )
+    min_theta_vii = np.min(
+        (theta_vii, theta_vii_J, np.pi - theta_vii, np.pi - theta_vii_J), axis=0
+    )
+
+    # Calculate the mean minimum angular distance.
+    angular_dist_vijs = np.mean(min_theta_vij)
+    angular_dist_viis = np.mean(min_theta_vii)
+
+    # Check that estimates are indeed approximately rank 1.
+    # ie. check that the svd is close to [1, 0, 0].
+    error_ij = np.linalg.norm(np.array([1, 0, 0], dtype=dtype) - sij, axis=1)
+    error_ii = np.linalg.norm(np.array([1, 0, 0], dtype=dtype) - sii, axis=1)
+    assert np.max(error_ij) < 0.2
+    assert np.max(error_ii) < 1e-5
+    assert np.mean(error_ij) < 0.002
+    assert np.mean(error_ii) < 1e-5
+
+    # Check that the mean angular difference is within 2 degrees.
+    angle_tol = 2 * np.pi / 180
+    assert angular_dist_vijs < angle_tol
+    assert angular_dist_viis < angle_tol
+
+
+@pytest.mark.parametrize("L, order, dtype", param_list)
+def testSelfCommonLines(L, order, dtype):
+    n_img = 24
+    src, cl_symm = source_orientation_objs(L, n_img, order, dtype)
+    n_theta = cl_symm.n_theta
+
+    # Initialize common-lines orientation estimation object and compute self-common-lines matrix.
+    scl = cl_symm._self_clmatrix_c3_c4()
+
+    # Compute ground truth self-common-lines matrix.
+    rots = src.rotations
+    scl_gt = buildSelfCommonLinesMatrix(n_theta, rots, order)
+
+    # Since we search for self common lines whose angle differences fall
+    # outside of 180 degrees by a tolerance of 2 * (360 // L), we must exclude
+    # indices whose ground truth self common lines fall within that tolerance.
+    gt_diffs = abs(scl_gt[:, 0] - scl_gt[:, 1])
+    res = 2 * (360 // L)
+    good_indices = (gt_diffs < (180 - res)) | (gt_diffs > (180 + res))
+    scl = scl[good_indices]
+    scl_gt = scl_gt[good_indices]
+
+    # Get angle difference between scl_gt and scl.
+    scl_diff1 = scl_gt - scl
+    scl_diff2 = scl_gt - np.flip(scl, 1)  # Order of indices might be switched.
+    scl_diff1_angle = scl_diff1 * 2 * pi / n_theta
+    scl_diff2_angle = scl_diff2 * 2 * pi / n_theta
+
+    # cosine is invariant to 2pi, and abs is invariant to +-pi due to J-conjugation.
+    # We take the mean deviation wrt to the two lines in each image.
+    scl_diff1_angle_mean = np.mean(np.arccos(abs(np.cos(scl_diff1_angle))), axis=1)
+    scl_diff2_angle_mean = np.mean(np.arccos(abs(np.cos(scl_diff2_angle))), axis=1)
+
+    scl_diff_angle_mean = np.vstack((scl_diff1_angle_mean, scl_diff2_angle_mean))
+    scl_idx = np.argmin(scl_diff_angle_mean, axis=0)
+    min_mean_angle_diff = scl_idx.choose(scl_diff_angle_mean)
+
+    # Assert scl detection rate is 100% for 5 degree angle tolerance
+    angle_tol_err = 5 * pi / 180
+    detection_rate = np.count_nonzero(min_mean_angle_diff < angle_tol_err) / len(scl)
+    assert np.allclose(detection_rate, 1.0)
+
+
+@pytest.mark.parametrize("L, order, dtype", param_list)
+def testCommonLines(L, order, dtype):
+    n_img = 24
+    src, cl_symm = source_orientation_objs(L, n_img, order, dtype)
+    n_theta = cl_symm.n_theta
+
+    # Build common-lines matrix.
+    cl_symm.build_clmatrix()
+    cl = cl_symm.clmatrix
+
+    # Compare common-line indices with ground truth angles.
+    rots = src.rotations  # ground truth rotations
+    rots_symm = cyclic_rotations(order, dtype).matrices
+    pairs = all_pairs(n_img)
+    within_1_degree = 0
+    within_5_degrees = 0
+    for (i, j) in pairs:
+        a_ij_s = np.zeros(order)
+        a_ji_s = np.zeros(order)
+        # Convert common-line indices to angles. Use angle of common line in [0, 180).
+        cl_ij = (cl[i, j] * 360 / n_theta) % 180
+        cl_ji = (cl[j, i] * 360 / n_theta) % 180
+
+        # The common-line estimates cl_ij, cl_ji should match the
+        # true common-line angles a_ij_s, a_ji_s for some value s,
+        # where s is the number of common-lines induced by the symmetric self.order.
+        for s in range(order):
+            rel_rot = rots[i].T @ rots_symm[s] @ rots[j]
+            a_ij_s[s] = np.rad2deg(np.arctan(-rel_rot[0, 2] / rel_rot[1, 2])) % 180
+            a_ji_s[s] = np.rad2deg(np.arctan(-rel_rot[2, 0] / rel_rot[2, 1])) % 180
+        best_s = np.argmin(abs(cl_ij - a_ij_s) + abs(cl_ji - a_ji_s))
+        diff_ij = abs(cl_ij - a_ij_s[best_s])
+        diff_ji = abs(cl_ji - a_ji_s[best_s])
+
+        # Count the number of good estimates.
+        if diff_ij < 1:
+            within_1_degree += 1
+            within_5_degrees += 1
+        elif diff_ij < 5:
+            within_5_degrees += 1
+
+        if diff_ji < 1:
+            within_1_degree += 1
+            within_5_degrees += 1
+        elif diff_ji < 5:
+            within_5_degrees += 1
+
+    # Assert that at least 98% of estimates are within 5 degrees and
+    # at least 90% of estimates are within 1 degree.
+    n_estimates = 2 * len(pairs)
+    within_5 = within_5_degrees / n_estimates
+    within_1 = within_1_degree / n_estimates
+    assert within_5 > 0.98
+    assert within_1 > 0.90
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def testGlobalJSync(dtype):
+    L = 16
+    n_img = 20
+    order = 3  # test not dependent on order
+    _, orient_est = source_orientation_objs(L, n_img, order, dtype)
+
+    # Build a set of outer products of random third rows.
+    vijs, viis, _ = buildOuterProducts(n_img, dtype)
+
+    # J-conjugate some of these outer products (every other element).
+    vijs_conj, viis_conj = vijs.copy(), viis.copy()
+    vijs_conj[::2] = J_conjugate(vijs_conj[::2])
+    viis_conj[::2] = J_conjugate(viis_conj[::2])
+
+    # Synchronize vijs_conj and viis_conj.
+    # Note: `_global_J_sync()` does not depend on cyclic order, so we can use
+    # either cl_orient_ests[3] or cl_orient_ests[4] to access the method.
+    vijs_sync, viis_sync = orient_est._global_J_sync(vijs_conj, viis_conj)
+
+    # Check that synchronized outer products equal original
+    # up to J-conjugation of the entire set.
+    if (vijs[0] == vijs_sync[0]).all():
+        assert np.allclose(vijs, vijs_sync)
+        assert np.allclose(viis, viis_sync)
+    else:
+        assert np.allclose(vijs, J_conjugate(vijs_sync))
+        assert np.allclose(viis, J_conjugate(viis_sync))
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def testEstimateThirdRows(dtype):
+    L = 16
+    n_img = 20
+    order = 3  # test not dependent on order
+    _, orient_est = source_orientation_objs(L, n_img, order, dtype)
+
+    # Build outer products vijs, viis, and get ground truth third rows.
+    vijs, viis, gt_vis = buildOuterProducts(n_img, dtype)
+
+    # Estimate third rows from outer products.
+    # Due to factorization of V, these might be negated third rows.
+    vis = orient_est._estimate_third_rows(vijs, viis)
+
+    # Check if all-close up to difference of sign
+    ground_truth = np.sign(gt_vis[0, 0]) * gt_vis
+    estimate = np.sign(vis[0, 0]) * vis
+    assert np.allclose(ground_truth, estimate)
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def testCompleteThirdRow(dtype):
+    # Complete third row that coincides with z-axis
+    z = np.array([0, 0, 1], dtype=dtype)
+    Rz = CLSymmetryC3C4._complete_third_row_to_rot(z)
+
+    # Complete random third row.
+    r3 = randn(3, seed=123).astype(dtype)
+    r3 /= norm(r3)
+    R = CLSymmetryC3C4._complete_third_row_to_rot(r3)
+
+    # Assert that Rz is the identity matrix.
+    assert np.allclose(Rz, np.eye(3, dtype=dtype))
+
+    # Assert that R is orthogonal with determinant 1.
+    assert np.allclose(R @ R.T, np.eye(3, dtype=dtype))
+    assert np.allclose(det(R), 1)
+
+
+def buildSelfCommonLinesMatrix(n_theta, rots, order):
+    # Construct rotatation matrices associated with cyclic order.
+    rots_symm = cyclic_rotations(order, rots.dtype).matrices
+
+    # Build ground truth self-common-lines matrix.
+    scl_gt = np.zeros((len(rots), 2), dtype=rots.dtype)
+    g = rots_symm[1]
+    g_n = rots_symm[-1]
+    for i, rot in enumerate(rots):
+        Ri = rot
+
+        U1 = Ri.T @ g @ Ri
+        U2 = Ri.T @ g_n @ Ri
+
+        c1 = np.array([-U1[1, 2], U1[0, 2]])
+        c2 = np.array([-U2[1, 2], U2[0, 2]])
+
+        theta_g = np.arctan2(c1[1], c1[0]) % (2 * np.pi)
+        theta_gn = np.arctan2(c2[1], c2[0]) % (2 * np.pi)
+
+        scl_gt[i, 0] = np.round(theta_g * n_theta / (2 * np.pi)) % n_theta
+        scl_gt[i, 1] = np.round(theta_gn * n_theta / (2 * np.pi)) % n_theta
+
+    return scl_gt
+
+
+def buildOuterProducts(n_img, dtype):
+    # Build random third rows, ground truth vis (unit vectors)
+    gt_vis = np.zeros((n_img, 3), dtype=dtype)
+    for i in range(n_img):
+        random.seed(i)
+        v = random.randn(3)
+        gt_vis[i] = v / norm(v)
+
+    # Find outer products viis and vijs for i<j
+    nchoose2 = int(n_img * (n_img - 1) / 2)
+    vijs = np.zeros((nchoose2, 3, 3), dtype=dtype)
+    viis = np.zeros((n_img, 3, 3), dtype=dtype)
+
+    # All pairs (i,j) where i<j
+    pairs = all_pairs(n_img)
+
+    for k, (i, j) in enumerate(pairs):
+        vijs[k] = np.outer(gt_vis[i], gt_vis[j])
+
+    for i in range(n_img):
+        viis[i] = np.outer(gt_vis[i], gt_vis[i])
+
+    return vijs, viis, gt_vis


### PR DESCRIPTION
This PR replaces the `simpleSymmetricVolume` used in `test_orient_symmetric` with a `CnSymmetricVolume`.

In addition, I reduced the `max_shift` parameter for the common-lines method to `1/L`. We can do this because we are exercising the algorithm on unshifted images. This reduced overall testing time from 85s to 37s.
 
One test had to be altered due to a tolerance being slightly broken when using the more realistic volume. The alteration now test the `mean` and `max` values and still validates that the algorithm is performing acceptably.