### PR TITLE
Enforcing `_evaluate_t` and `_evaluate` signatures

### DIFF
--- a/src/aspire/basis/basis.py
+++ b/src/aspire/basis/basis.py
@@ -38,9 +38,9 @@ class Basis:
         self.ell_max = ell_max
         self.ndim = ndim
         if self.ndim == 2:
-            self.cls = Image
+            self._cls = Image
         elif self.ndim == 3:
-            self.cls = Volume
+            self._cls = Volume
         else:
             raise RuntimeError("Basis ndim must be 2 or 3")
         self.dtype = np.dtype(dtype)
@@ -92,7 +92,7 @@ class Basis:
                 f" Inconsistent dtypes v: {v.dtype} self: {self.dtype}"
             )
 
-        return self.cls(self._evaluate(v))
+        return self._cls(self._evaluate(v))
 
     def _evaluate(self, v):
         raise NotImplementedError("subclasses must implement this")
@@ -113,10 +113,10 @@ class Basis:
                 f" Inconsistent dtypes v: {v.dtype} self: {self.dtype}"
             )
 
-        if not isinstance(v, self.cls):
+        if not isinstance(v, self._cls):
             logger.warning(
                 f"{self.__class__.__name__}::evaluate_t"
-                f" passed numpy array instead of {self.cls}."
+                f" passed numpy array instead of {self._cls}."
             )
         else:
             v = v.asnumpy()
@@ -196,7 +196,7 @@ class Basis:
         v = np.zeros((n_data, self.count), dtype=x.dtype)
 
         for isample in range(0, n_data):
-            b = self.evaluate_t(self.cls(x[isample])).T
+            b = self.evaluate_t(self._cls(x[isample])).T
             # TODO: need check the initial condition x0 can improve the results or not.
             v[isample], info = cg(operator, b, tol=tol, atol=0)
             if info != 0:

--- a/src/aspire/basis/basis.py
+++ b/src/aspire/basis/basis.py
@@ -118,7 +118,8 @@ class Basis:
                 f"{self.__class__.__name__}::evaluate_t"
                 f" passed numpy array instead of {self.cls}."
             )
-            v = self.cls(v)
+        else:
+            v = v.asnumpy()
         return self._evaluate_t(v)
 
     def _evaluate_t(self, v):

--- a/src/aspire/basis/fb_2d.py
+++ b/src/aspire/basis/fb_2d.py
@@ -245,8 +245,7 @@ class FBBasis2D(SteerableBasis2D, FBBasisMixin):
             `self.count` and whose first dimensions correspond to
             first dimensions of `v`.
         """
-        v = v.asnumpy().T  # RCOPT
-
+        v = v.T
         x, sz_roll = unroll_dim(v, self.ndim + 1)
         x = m_reshape(
             x, new_shape=tuple([np.prod(self.sz)] + list(x.shape[self.ndim :]))

--- a/src/aspire/basis/fb_3d.py
+++ b/src/aspire/basis/fb_3d.py
@@ -6,7 +6,6 @@ from aspire.basis import Basis, FBBasisMixin
 from aspire.basis.basis_utils import real_sph_harmonic, sph_bessel, unique_coords_nd
 from aspire.utils import roll_dim, unroll_dim
 from aspire.utils.matlab_compat import m_flatten, m_reshape
-from aspire.volume import Volume
 
 logger = logging.getLogger(__name__)
 
@@ -199,10 +198,6 @@ class FBBasis3D(Basis, FBBasisMixin):
             equals `self.count` and whose remaining dimensions correspond
             to higher dimensions of `v`.
         """
-        # v may be a Volume object or a 7D array passed from Basis.mat_evaluate_t
-        # making this check important
-        if isinstance(v, Volume):
-            v = v.asnumpy()
         v = v.T
         x, sz_roll = unroll_dim(v, self.ndim + 1)
         x = m_reshape(

--- a/src/aspire/basis/ffb_2d.py
+++ b/src/aspire/basis/ffb_2d.py
@@ -197,11 +197,10 @@ class FFBBasis2D(FBBasis2D):
         freqs = np.reshape(self._precomp["freqs"], (2, n_r * n_theta))
 
         # number of 2D image samples
-        n_images = x.n_images
-        x_data = x.data
+        n_images = x.shape[0]
 
         # resamping x in a polar Fourier gird using nonuniform discrete Fourier transform
-        pf = nufft(x_data, 2 * pi * freqs)
+        pf = nufft(x, 2 * pi * freqs)
         pf = np.reshape(pf, (n_images, n_r, n_theta))
 
         # Recover "negative" frequencies from "positive" half plane.

--- a/src/aspire/basis/ffb_2d.py
+++ b/src/aspire/basis/ffb_2d.py
@@ -187,9 +187,9 @@ class FFBBasis2D(FBBasis2D):
 
         :param x: The Image instance representing coefficient array in the
             standard 2D coordinate basis to be evaluated.
-        :return v: The evaluation of the coefficient array `v` in the FB basis.
+        :return: The evaluation of the coefficient array `x` in the FB basis.
             This is an array of vectors whose last dimension equals `self.count`
-            and whose first dimension correspond to `x.n_images`.
+            and whose first dimension correspond to `x.shape[0]`.
         """
         # get information on polar grids from precomputed data
         n_theta = np.size(self._precomp["freqs"], 2)

--- a/src/aspire/basis/ffb_3d.py
+++ b/src/aspire/basis/ffb_3d.py
@@ -289,8 +289,6 @@ class FFBBasis3D(FBBasis3D):
             `self.count` and whose remaining dimensions correspond to higher
             dimensions of `x`.
         """
-        x = x.asnumpy()
-
         # roll dimensions
         sz_roll = x.shape[:-3]
         x = x.reshape((-1, *self.sz))

--- a/src/aspire/basis/ffb_3d.py
+++ b/src/aspire/basis/ffb_3d.py
@@ -284,7 +284,7 @@ class FFBBasis3D(FBBasis3D):
 
         :param x: The coefficient array in the standard 3D coordinate basis
             to be evaluated. The last three dimensions must equal `self.sz`.
-        :return v: The evaluation of the coefficient array `v` in the FB basis.
+        :return: The evaluation of the coefficient array `x` in the FB basis.
             This is an array of vectors whose last dimension equals
             `self.count` and whose remaining dimensions correspond to higher
             dimensions of `x`.

--- a/src/aspire/basis/polar_2d.py
+++ b/src/aspire/basis/polar_2d.py
@@ -107,11 +107,11 @@ class PolarBasis2D(Basis):
             Fourier grid. This is an array of vectors whose first dimension
             corresponds to x.n_images, and last dimension equals `self.count`.
         """
-        nimgs = x.n_images
+        nimgs = x.shape[0]
 
         half_size = self.ntheta // 2
 
-        pf = nufft(x.asnumpy(), self.freqs)
+        pf = nufft(x, self.freqs)
 
         pf = pf.reshape((nimgs, self.nrad, half_size))
         v = np.concatenate((pf, pf.conj()), axis=1)

--- a/src/aspire/basis/polar_2d.py
+++ b/src/aspire/basis/polar_2d.py
@@ -103,9 +103,9 @@ class PolarBasis2D(Basis):
 
         :param x: The Image instance representing coefficient array in the
             standard 2D coordinate basis to be evaluated.
-        :return v: The evaluation of the coefficient array `v` in the polar
+        :return: The evaluation of the coefficient array `x` in the polar
             Fourier grid. This is an array of vectors whose first dimension
-            corresponds to x.n_images, and last dimension equals `self.count`.
+            corresponds to `x.shape[0]`, and last dimension equals `self.count`.
         """
         nimgs = x.shape[0]
 


### PR DESCRIPTION
#678 

`Basis` public methods `evaluate` and `evaluate_t` should accept a numpy array and return an `Image/Volume`, and vice versa. But the private methods should only deal with numpy arrays. This PR enforces that change and cleans up the `Basis` class.