### PR TITLE
Daily docs build

### DIFF
--- a/.github/workflows/daily_workflow.yml
+++ b/.github/workflows/daily_workflow.yml
@@ -25,3 +25,9 @@ jobs:
           sphinx-apidoc -f -o ./source ../src -H Modules
           make html
         working-directory: ./docs
+      - name: Archive Sphinx docs
+        uses: actions/upload-artifact@v3
+        with:
+          name: sphinx-docs
+          path: docs
+          retention-days: 7

--- a/.github/workflows/daily_workflow.yml
+++ b/.github/workflows/daily_workflow.yml
@@ -1,9 +1,8 @@
 name: ASPIRE Python Daily Build CI
 
 on:
-  push:
-    branches:
-      - daily_doc_build
+  schedule:
+    -cron: '0 0 * * *'
 
 jobs:
   dev_docs:

--- a/.github/workflows/daily_workflow.yml
+++ b/.github/workflows/daily_workflow.yml
@@ -21,10 +21,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
       - name: Build Sphinx docs
-        defaults:
-          run:
-            working-directory: ./docs
         run: |
           make clean
           sphinx-apidoc -f -o ./source ../src -H Modules
           make html
+        working-directory: ./docs

--- a/.github/workflows/daily_workflow.yml
+++ b/.github/workflows/daily_workflow.yml
@@ -21,6 +21,7 @@ jobs:
           pip install -e ".[dev]"
       - name: Build Sphinx docs
         run: |
+	  cd docs
 	  make clean
 	  sphinx-apidoc -f -o ./source ../src -H Modules
 	  make html

--- a/.github/workflows/daily_workflow.yml
+++ b/.github/workflows/daily_workflow.yml
@@ -20,8 +20,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
       - name: Build Sphinx docs
+        working-directory: ./docs
         run: |
-	  cd docs
 	  make clean
 	  sphinx-apidoc -f -o ./source ../src -H Modules
 	  make html

--- a/.github/workflows/daily_workflow.yml
+++ b/.github/workflows/daily_workflow.yml
@@ -21,7 +21,7 @@ jobs:
           pip install -e ".[dev]"
       - name: Build Sphinx docs
         run: |
-          make clean
+	  make clean
 	  sphinx-apidoc -f -o ./source ../src -H Modules
 	  make html
 	  

--- a/.github/workflows/daily_workflow.yml
+++ b/.github/workflows/daily_workflow.yml
@@ -20,8 +20,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
       - name: Build Sphinx docs
-        working-directory: ./docs
-        run: |
+        defaults:
+	  run:
+	    working-directory: ./docs
+	run: |
 	  make clean
 	  sphinx-apidoc -f -o ./source ../src -H Modules
 	  make html

--- a/.github/workflows/daily_workflow.yml
+++ b/.github/workflows/daily_workflow.yml
@@ -1,8 +1,9 @@
 name: ASPIRE Python Daily Build CI
 
 on:
-  schedule:
-    - cron: '0 14 * * *'
+  push:
+    branches:
+      - daily_doc_build
 
 jobs:
   dev_docs:

--- a/.github/workflows/daily_workflow.yml
+++ b/.github/workflows/daily_workflow.yml
@@ -1,0 +1,27 @@
+name: ASPIRE Python Daily Build CI
+
+on:
+  schedule:
+    - cron: '0 5 * * *'
+
+jobs:
+  dev_docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: develop
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.7'
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Build Sphinx docs
+        run: |
+          make clean
+	  sphinx-apidoc -f -o ./source ../src -H Modules
+	  make html
+	  

--- a/.github/workflows/daily_workflow.yml
+++ b/.github/workflows/daily_workflow.yml
@@ -2,7 +2,7 @@ name: ASPIRE Python Daily Build CI
 
 on:
   schedule:
-    - cron: '0 5 * * *'
+    - cron: '0 14 * * *'
 
 jobs:
   dev_docs:
@@ -21,10 +21,9 @@ jobs:
           pip install -e ".[dev]"
       - name: Build Sphinx docs
         defaults:
-	  run:
-	    working-directory: ./docs
-	run: |
-	  make clean
-	  sphinx-apidoc -f -o ./source ../src -H Modules
-	  make html
-	  
+          run:
+            working-directory: ./docs
+        run: |
+          make clean
+          sphinx-apidoc -f -o ./source ../src -H Modules
+          make html


### PR DESCRIPTION
Adds a github actions workflow that checks out `develop` and builds the docs including the gallery. This runs on a daily schedule at 12am UTC (7pm EST). 

Scheduled workflows will only run from the default (`master`) branch, so to test scheduling I forked the repo and merged the `daily_workflow.yml` into `master` in the fork to confirm that the scheduler does trigger the workflow. I also confirmed that the workflow does indeed build the docs by triggering the workflow on  a `push` here inside this branch. Everything appears to be functioning properly.

This closes #707  