### PR TITLE
Bump Function Division by Zero Warning

### DIFF
--- a/src/aspire/utils/misc.py
+++ b/src/aspire/utils/misc.py
@@ -212,12 +212,11 @@ def bump_3d(size, spread=1, dtype=np.float64):
     :return: Numpy array (3D)
     """
     g = grid_3d(size, dtype=dtype)
-    selection = g["r"] < 1
 
     p = g["x"] ** 2 + g["y"] ** 2 + g["z"] ** 2
 
     bump = np.zeros((size,) * 3, dtype=dtype)
-    bump[selection] = np.exp(-1 / (spread - spread * p[selection]))
+    bump[p < 1] = np.exp(-1 / (spread - spread * p[p < 1]))
     bump /= np.exp(-1 / spread)
 
     return bump


### PR DESCRIPTION
It turns out the `g["r"] < 1` is not always the same as `(g["x"]**2 + g["y"]**2 + g["z"]**2) < 1` for `grid_3d`.

In `bump_3d` we were masking `p =  (g["x"]**2 + g["y"]**2 + g["z"]**2)` with `p[g["r"] < 1]`, which for some grid sizes contained a few entries `== 1`. 

This PR refactors the mask to `p[p < 1]`. This resolves one of the warnings in #798.