### PR TITLE
`ImageSource` deep copy method

### DIFF
--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -212,13 +212,7 @@ class ImageSource(ABC):
         """
         Converts internal _rotations representation to expected matrix form.
         """
-        if self._rotations is not None:
-            return self._rotations.angles.astype(self.dtype)
-        else:
-            logger.warning(
-                f"{self.__class__.__name__} was not initialized with rotations. No Euler rotations to return."
-            )
-            return None
+        return self._rotations.angles.astype(self.dtype)
 
     @property
     def rotations(self):
@@ -236,13 +230,7 @@ class ImageSource(ABC):
 
         :return: Rotation matrices as a n x 3 x 3 array
         """
-        if self._rotations is not None:
-            return self._rotations.matrices.astype(self.dtype)
-        else:
-            logger.warning(
-                f"{self.__class__.__name__} was not initialized with rotations. No rotation matrices to return."
-            )
-            return None
+        return self._rotations.matrices.astype(self.dtype)
 
     @angles.setter
     def angles(self, values):
@@ -875,3 +863,33 @@ class ArrayImageSource(ImageSource):
         return self.generation_pipeline.forward(
             Image(self._cached_im[indices, :, :]), indices
         )
+
+    def _rots(self):
+        """
+        Private method, checks if `_rotations` has been set,
+        then returns inherited rotations, otherwise raise.
+        """
+
+        if self._rotations is not None:
+            return super()._rots()
+        else:
+            raise RuntimeError(
+                "Consumer of ArrayImageSource trying to access rotations,"
+                " but rotations were not defined for this source."
+                "  Try instantiating with angles."
+            )
+
+    def _angles(self):
+        """
+        Private method, checks if `_rotations` has been set,
+        then returns inherited angles, otherwise raise.
+        """
+
+        if self._rotations is not None:
+            return super()._angles()
+        else:
+            raise RuntimeError(
+                "Consumer of ArrayImageSource trying to access angles,"
+                " but angles were not defined for this source."
+                "  Try instantiating with angles."
+            )

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -568,6 +568,13 @@ class ImageSource(ABC):
         im *= self.amplitudes[all_idx, np.newaxis, np.newaxis]
         return im
 
+    @abstractmethod
+    def copy(self, starfile_filepath=None):
+        """
+        `ImageSource` subclasses must implement a `copy()` method that returns an identical
+             instance.
+        """
+
     def save(
         self,
         starfile_filepath,

--- a/tests/_copy_util.py
+++ b/tests/_copy_util.py
@@ -1,0 +1,52 @@
+from aspire.image.xform import (
+    FilterXform,
+    IndexedXform,
+    Multiply,
+    NoiseAdder,
+    Pipeline,
+    Shift,
+)
+
+
+def rotations_deepcopied(rots1, rots2):
+    # core NumPy rotation matrices should be deep copies
+    return rots1._matrices is not rots2._matrices
+
+
+def xforms_deepcopied(xf1, xf2):
+    # Xform attributes are heterogeneous, catch special cases
+    # that need to be checked
+
+    # FilterXform
+    if all(map(lambda x: isinstance(x, FilterXform), (xf1, xf2))):
+        return xf1.filter is not xf2.filter
+    # NoiseAdder
+    if all(map(lambda x: isinstance(x, NoiseAdder), (xf1, xf2))):
+        return xf1.noise_filter is not xf2.noise_filter
+    # Shift
+    if all(map(lambda x: isinstance(x, Shift), (xf1, xf2))):
+        return xf1.shifts is not xf2.shifts
+    # Multiply
+    if all(map(lambda x: isinstance(x, Multiply), (xf1, xf2))):
+        return xf1.multipliers is not xf2.multipliers
+    # Pipeline object
+    if all(map(lambda x: isinstance(x, Pipeline), (xf1, xf2))):
+        return all(
+            [
+                xforms_deepcopied(xf1.xforms[i], xf2.xforms[i])
+                for i in range(len(xf1.xforms))
+            ]
+        )
+    # IndexedXform object
+    if all(map(lambda x: isinstance(x, IndexedXform), (xf1, xf2))):
+        # 1d numpy array should be deep copied
+        indices_check = xf1.indices is not xf2.indices
+        return indices_check and all(
+            [
+                xforms_deepcopied(xf1.unique_xforms[i], xf2.unique_xforms[i])
+                for i in range(len(xf1.unique_xforms))
+            ]
+        )
+
+    # All other Xform objects we assume are deepcopied
+    return True

--- a/tests/_copy_util.py
+++ b/tests/_copy_util.py
@@ -53,7 +53,9 @@ def xforms_deepcopied(xf1, xf2):
 
 
 def img_accessors_deepcopied(i1, i2):
-    # functions should have different ids after deep copy
+    # the image-getting function associated with the ImageAccessor
+    # should have a different ID between different sources.
+    # NOTE: This works because fun is a *function* not a *method*
     return i1.fun is not i2.fun
 
 

--- a/tests/_copy_util.py
+++ b/tests/_copy_util.py
@@ -50,3 +50,30 @@ def xforms_deepcopied(xf1, xf2):
 
     # All other Xform objects we assume are deepcopied
     return True
+
+
+def img_accessors_deepcopied(i1, i2):
+    # functions should have different ids after deep copy
+    return i1.fun is not i2.fun
+
+
+# map ImageSource/subclass attributes to functions in this file that will
+# ensure they are deep copied
+_source_vars = {
+    "_image_accessor": img_accessors_deepcopied,
+    "_projections_accessor": img_accessors_deepcopied,
+    "_clean_image_accessor": img_accessors_deepcopied,
+    "_rotations": rotations_deepcopied,
+    "generation_pipeline": xforms_deepcopied,
+}
+
+# test files can import the list of source vars to test against
+source_vars = list(_source_vars.keys())
+
+
+def source_vars_deepcopied(v1, v2, name):
+    # if both are None, then no check necessary
+    if v1 is None and v2 is None:
+        return True
+    fun = _source_vars[name]
+    return fun(v1, v2)

--- a/tests/_copy_util.py
+++ b/tests/_copy_util.py
@@ -59,14 +59,26 @@ def img_accessors_deepcopied(i1, i2):
     return i1.fun is not i2.fun
 
 
+def ndarrays_deepcopied(ar1, ar2):
+    # Source attributes which are just numpy arrays
+    # should not have the same ID
+    return ar1 is not ar2
+
+
+def unique_filters_deepcopied(l1, l2):
+    return all([l1[i] is not l2[i] for i in range(len(l1))])
+
+
 # map ImageSource/subclass attributes to functions in this file that will
 # ensure they are deep copied
 _source_vars = {
-    "_image_accessor": img_accessors_deepcopied,
+    "_img_accessor": img_accessors_deepcopied,
     "_projections_accessor": img_accessors_deepcopied,
-    "_clean_image_accessor": img_accessors_deepcopied,
+    "_clean_images_accessor": img_accessors_deepcopied,
     "_rotations": rotations_deepcopied,
     "generation_pipeline": xforms_deepcopied,
+    "filter_indices": ndarrays_deepcopied,
+    "unique_filters": unique_filters_deepcopied,
 }
 
 # test files can import the list of source vars to test against

--- a/tests/test_array_image_source.py
+++ b/tests/test_array_image_source.py
@@ -203,12 +203,12 @@ class ImageTestCase(TestCase):
 
     def testArrayImageSourceCopy(self):
         # test deep copy of an ArrayImageSource
-        src1 = ArrayImageSource(self.im, angles=np.random.random((self.n, 3)))
-        src2 = src1.copy()
+        src = ArrayImageSource(self.im, angles=np.random.random((self.n, 3)))
+        src_copy = src.copy()
         for var in _copy_util.source_vars:
-            if hasattr(src1, var):
+            if hasattr(src, var):
                 self.assertTrue(
                     _copy_util.source_vars_deepcopied(
-                        getattr(src1, var), getattr(src2, var), var
+                        getattr(src, var), getattr(src_copy, var), var
                     )
                 )

--- a/tests/test_array_image_source.py
+++ b/tests/test_array_image_source.py
@@ -82,6 +82,44 @@ class ImageTestCase(TestCase):
         with raises(RuntimeError, match=r"Creating Image object from Numpy.*"):
             _ = ArrayImageSource(np.empty((3, 2, 1)))
 
+    def testArrayImageSourceAngGetterError(self):
+        """
+        Test that ArrayImageSource when instantiated without required
+        rotations/angles gives an appropriate error.
+        """
+
+        # Construct the source for testing.
+        #   Rotations (via angles) are required,
+        #   but we intentionally do not pass
+        #   to instantiater here.
+        src = ArrayImageSource(self.im)
+
+        # Test we raise with expected message
+        with raises(RuntimeError, match=r"Consumer of ArrayImageSource.*"):
+            _ = src.angles
+
+        # We also test that a source consumer generates same error,
+        #   by instantiating a volume estimator.
+        estimator = MeanEstimator(src, self.basis, preconditioner="none")
+
+        # Test we raise with expected message
+        with raises(RuntimeError, match=r"Consumer of ArrayImageSource.*"):
+            _ = estimator.estimate()
+
+    def testArrayImageSourceRotGetterError(self):
+        """
+        Test that ArrayImageSource when instantiated without required
+        rotations/angles gives an appropriate error.
+        Here we specifically test `rotations`.
+        """
+
+        # Construct the source for testing.
+        src = ArrayImageSource(self.im)
+
+        # Test we raise with expected message from getter.
+        with raises(RuntimeError, match=r"Consumer of ArrayImageSource.*"):
+            _ = src.rotations
+
     def testArrayImageSourceMeanVol(self):
         """
         Test that ArrayImageSource can be consumed by mean/volume codes.
@@ -162,44 +200,6 @@ class ImageTestCase(TestCase):
         wrong_dim = np.random.randn(self.n, 3, 3)
         with raises(ValueError, match=msg):
             _ = ArrayImageSource(self.im, angles=wrong_dim)
-
-    def testArrayImageSourceAngGetterError(self):
-        """
-        Test that ArrayImageSource when instantiated without required
-        rotations/angles gives an appropriate error.
-        """
-
-        # Construct the source for testing.
-        #   Rotations (via angles) are required,
-        #   but we intentionally do not pass
-        #   to instantiater here.
-        src = ArrayImageSource(self.im)
-
-        # Test we raise with expected message
-        with raises(RuntimeError, match=r"Consumer of ArrayImageSource.*"):
-            _ = src.angles
-
-        # We also test that a source consumer generates same error,
-        #   by instantiating a volume estimator.
-        estimator = MeanEstimator(src, self.basis, preconditioner="none")
-
-        # Test we raise with expected message
-        with raises(RuntimeError, match=r"Consumer of ArrayImageSource.*"):
-            _ = estimator.estimate()
-
-    def testArrayImageSourceRotGetterError(self):
-        """
-        Test that ArrayImageSource when instantiated without required
-        rotations/angles gives an appropriate error.
-        Here we specifically test `rotations`.
-        """
-
-        # Construct the source for testing.
-        src = ArrayImageSource(self.im)
-
-        # Test we raise with expected message from getter.
-        with raises(RuntimeError, match=r"Consumer of ArrayImageSource.*"):
-            _ = src.rotations
 
     def testArrayImageSourceCopy(self):
         # test deep copy of an ArrayImageSource

--- a/tests/test_array_image_source.py
+++ b/tests/test_array_image_source.py
@@ -205,6 +205,8 @@ class ImageTestCase(TestCase):
         # test deep copy of an ArrayImageSource
         src = ArrayImageSource(self.im, angles=np.random.random((self.n, 3)))
         src_copy = src.copy()
+        # sanity check that ASPIRE objects that are attributes of the source
+        # were deepcopied
         for var in _copy_util.source_vars:
             if hasattr(src, var):
                 self.assertTrue(
@@ -212,3 +214,15 @@ class ImageTestCase(TestCase):
                         getattr(src, var), getattr(src_copy, var), var
                     )
                 )
+        # make sure we can perform operations on both sources separately
+        src_copy.downsample(4)
+        img = src.images[:1]
+        img_copy = src_copy.images[:1]
+        self.assertEqual(img.resolution, self.resolution)
+        self.assertEqual(img_copy.resolution, 4)
+        # copy should have an updated xform pipeline
+        self.assertTrue(len(src.generation_pipeline.xforms) == 0)
+        self.assertTrue(len(src_copy.generation_pipeline.xforms) == 1)
+        # make sure metadata can be modified separately
+        src_copy.set_metadata("test_col", 0)
+        self.assertFalse(src.has_metadata("test_col"))

--- a/tests/test_array_image_source.py
+++ b/tests/test_array_image_source.py
@@ -12,6 +12,8 @@ from aspire.reconstruction import MeanEstimator
 from aspire.source import ArrayImageSource, Simulation
 from aspire.utils import Rotation, utest_tolerance
 
+from ._copy_util import *
+
 DATA_DIR = os.path.join(os.path.dirname(__file__), "saved_test_data")
 
 logger = logging.getLogger(__name__)
@@ -79,44 +81,6 @@ class ImageTestCase(TestCase):
         # Test we raise with expected message from getter.
         with raises(RuntimeError, match=r"Creating Image object from Numpy.*"):
             _ = ArrayImageSource(np.empty((3, 2, 1)))
-
-    def testArrayImageSourceAngGetterError(self):
-        """
-        Test that ArrayImageSource when instantiated without required
-        rotations/angles gives an appropriate error.
-        """
-
-        # Construct the source for testing.
-        #   Rotations (via angles) are required,
-        #   but we intentionally do not pass
-        #   to instantiater here.
-        src = ArrayImageSource(self.im)
-
-        # Test we raise with expected message
-        with raises(RuntimeError, match=r"Consumer of ArrayImageSource.*"):
-            _ = src.angles
-
-        # We also test that a source consumer generates same error,
-        #   by instantiating a volume estimator.
-        estimator = MeanEstimator(src, self.basis, preconditioner="none")
-
-        # Test we raise with expected message
-        with raises(RuntimeError, match=r"Consumer of ArrayImageSource.*"):
-            _ = estimator.estimate()
-
-    def testArrayImageSourceRotGetterError(self):
-        """
-        Test that ArrayImageSource when instantiated without required
-        rotations/angles gives an appropriate error.
-        Here we specifically test `rotations`.
-        """
-
-        # Construct the source for testing.
-        src = ArrayImageSource(self.im)
-
-        # Test we raise with expected message from getter.
-        with raises(RuntimeError, match=r"Consumer of ArrayImageSource.*"):
-            _ = src.rotations
 
     def testArrayImageSourceMeanVol(self):
         """
@@ -198,3 +162,12 @@ class ImageTestCase(TestCase):
         wrong_dim = np.random.randn(self.n, 3, 3)
         with raises(ValueError, match=msg):
             _ = ArrayImageSource(self.im, angles=wrong_dim)
+
+    def testArrayImageSourceCopy(self):
+        # test deep copy of an ArrayImageSource
+        src1 = ArrayImageSource(self.im, angles=np.random.random((self.n, 3)))
+        src2 = src1.copy()
+        self.assertTrue(
+            xforms_deepcopied(src1.generation_pipeline, src2.generation_pipeline)
+        )
+        self.assertTrue(rotations_deepcopied(src1._rotations, src2._rotations))

--- a/tests/test_array_image_source.py
+++ b/tests/test_array_image_source.py
@@ -12,7 +12,7 @@ from aspire.reconstruction import MeanEstimator
 from aspire.source import ArrayImageSource, Simulation
 from aspire.utils import Rotation, utest_tolerance
 
-from ._copy_util import *
+from ._copy_util import rotations_deepcopied, xforms_deepcopied
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "saved_test_data")
 

--- a/tests/test_array_image_source.py
+++ b/tests/test_array_image_source.py
@@ -12,7 +12,7 @@ from aspire.reconstruction import MeanEstimator
 from aspire.source import ArrayImageSource, Simulation
 from aspire.utils import Rotation, utest_tolerance
 
-from ._copy_util import rotations_deepcopied, xforms_deepcopied
+from . import _copy_util
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "saved_test_data")
 
@@ -205,7 +205,10 @@ class ImageTestCase(TestCase):
         # test deep copy of an ArrayImageSource
         src1 = ArrayImageSource(self.im, angles=np.random.random((self.n, 3)))
         src2 = src1.copy()
-        self.assertTrue(
-            xforms_deepcopied(src1.generation_pipeline, src2.generation_pipeline)
-        )
-        self.assertTrue(rotations_deepcopied(src1._rotations, src2._rotations))
+        for var in _copy_util.source_vars:
+            if hasattr(src1, var):
+                self.assertTrue(
+                    _copy_util.source_vars_deepcopied(
+                        getattr(src1, var), getattr(src2, var), var
+                    )
+                )

--- a/tests/test_array_image_source.py
+++ b/tests/test_array_image_source.py
@@ -163,6 +163,44 @@ class ImageTestCase(TestCase):
         with raises(ValueError, match=msg):
             _ = ArrayImageSource(self.im, angles=wrong_dim)
 
+    def testArrayImageSourceAngGetterError(self):
+        """
+        Test that ArrayImageSource when instantiated without required
+        rotations/angles gives an appropriate error.
+        """
+
+        # Construct the source for testing.
+        #   Rotations (via angles) are required,
+        #   but we intentionally do not pass
+        #   to instantiater here.
+        src = ArrayImageSource(self.im)
+
+        # Test we raise with expected message
+        with raises(RuntimeError, match=r"Consumer of ArrayImageSource.*"):
+            _ = src.angles
+
+        # We also test that a source consumer generates same error,
+        #   by instantiating a volume estimator.
+        estimator = MeanEstimator(src, self.basis, preconditioner="none")
+
+        # Test we raise with expected message
+        with raises(RuntimeError, match=r"Consumer of ArrayImageSource.*"):
+            _ = estimator.estimate()
+
+    def testArrayImageSourceRotGetterError(self):
+        """
+        Test that ArrayImageSource when instantiated without required
+        rotations/angles gives an appropriate error.
+        Here we specifically test `rotations`.
+        """
+
+        # Construct the source for testing.
+        src = ArrayImageSource(self.im)
+
+        # Test we raise with expected message from getter.
+        with raises(RuntimeError, match=r"Consumer of ArrayImageSource.*"):
+            _ = src.rotations
+
     def testArrayImageSourceCopy(self):
         # test deep copy of an ArrayImageSource
         src1 = ArrayImageSource(self.im, angles=np.random.random((self.n, 3)))

--- a/tests/test_coordinate_source.py
+++ b/tests/test_coordinate_source.py
@@ -18,6 +18,8 @@ from aspire.source import BoxesCoordinateSource, CentersCoordinateSource
 from aspire.storage import StarFile
 from aspire.utils import importlib_path
 
+from . import _copy_util
+
 
 class CoordinateSourceTestCase(TestCase):
     def setUp(self):
@@ -495,6 +497,17 @@ class CoordinateSourceTestCase(TestCase):
                     src.get_metadata("_rlnCoordinateY", i),
                 ],
             )
+
+    def testCopy(self):
+        src = BoxesCoordinateSource(self.files_box)
+        src_copy = src.copy()
+        for var in _copy_util.source_vars:
+            if hasattr(src, var):
+                self.assertTrue(
+                    _copy_util.source_vars_deepcopied(
+                        getattr(src, var), getattr(src_copy, var), var
+                    )
+                )
 
     def testPreprocessing(self):
         # ensure that the preprocessing methods that do not require CTF do not error

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -589,6 +589,8 @@ class SimTestCase(TestCase):
 
     def testSimCopy(self):
         sim_copy = self.sim.copy()
+        # sanity check that ASPIRE objects that are attributes of the source
+        # were deepcopied
         for var in _copy_util.source_vars:
             if hasattr(self.sim, var):
                 self.assertTrue(
@@ -596,3 +598,15 @@ class SimTestCase(TestCase):
                         getattr(self.sim, var), getattr(sim_copy, var), var
                     )
                 )
+        # make sure we can perform operations on both sources separately
+        sim_copy.downsample(4)
+        img = self.sim.images[:1]
+        img_copy = sim_copy.images[:1]
+        self.assertEqual(img.resolution, 8)
+        self.assertEqual(img_copy.resolution, 4)
+        # copy should have an updated xform pipeline
+        self.assertTrue(len(self.sim.generation_pipeline.xforms) == 0)
+        self.assertTrue(len(sim_copy.generation_pipeline.xforms) == 1)
+        # make sure metadata can be modified separately
+        sim_copy.set_metadata("test_col", 0)
+        self.assertFalse(self.sim.has_metadata("test_col"))

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -11,6 +11,8 @@ from aspire.source.simulation import Simulation
 from aspire.utils.types import utest_tolerance
 from aspire.volume import Volume
 
+from . import _copy_util
+
 DATA_DIR = os.path.join(os.path.dirname(__file__), "saved_test_data")
 
 
@@ -584,3 +586,13 @@ class SimTestCase(TestCase):
             imgs_sav = relion_src.images[:1024]
             # Compare original images with saved images
             self.assertTrue(np.allclose(imgs_org.asnumpy(), imgs_sav.asnumpy()))
+
+    def testSimCopy(self):
+        sim_copy = self.sim.copy()
+        for var in _copy_util.source_vars:
+            if hasattr(self.sim, var):
+                self.assertTrue(
+                    _copy_util.source_vars_deepcopied(
+                        getattr(self.sim, var), getattr(sim_copy, var), var
+                    )
+                )

--- a/tests/test_starfile_stack.py
+++ b/tests/test_starfile_stack.py
@@ -10,6 +10,8 @@ from aspire.image import Image
 from aspire.source.relion import RelionSource
 from aspire.utils import importlib_path
 
+from . import _copy_util
+
 DATA_DIR = os.path.join(os.path.dirname(__file__), "saved_test_data")
 
 
@@ -59,6 +61,18 @@ class StarFileMainCase(StarFileTestCase):
         self.src.downsample(16)
         first_image = self.src.images[0][0]
         self.assertEqual(first_image.shape, (16, 16))
+
+    def testRelionSourceCopy(self):
+        src_copy = self.src.copy()
+        for var in _copy_util.source_vars:
+            if hasattr(self.src, var):
+                self.assertTrue(
+                    (
+                        _copy_util.source_vars_deepcopied(
+                            getattr(self.src, var), getattr(src_copy, var), var
+                        )
+                    )
+                )
 
 
 class StarFileSingleImage(StarFileTestCase):

--- a/tests/test_starfile_stack.py
+++ b/tests/test_starfile_stack.py
@@ -64,6 +64,8 @@ class StarFileMainCase(StarFileTestCase):
 
     def testRelionSourceCopy(self):
         src_copy = self.src.copy()
+        # sanity check that ASPIRE objects that are attributes of the source
+        # were deepcopied
         for var in _copy_util.source_vars:
             if hasattr(self.src, var):
                 self.assertTrue(
@@ -73,6 +75,18 @@ class StarFileMainCase(StarFileTestCase):
                         )
                     )
                 )
+        # make sure we can perform operations on both sources separately
+        src_copy.downsample(8)
+        img = self.src.images[:1]
+        img_copy = src_copy.images[:1]
+        self.assertEqual(img.resolution, 200)
+        self.assertEqual(img_copy.resolution, 8)
+        # copy should have an updated xform pipeline
+        self.assertTrue(len(self.src.generation_pipeline.xforms) == 0)
+        self.assertTrue(len(src_copy.generation_pipeline.xforms) == 1)
+        # make sure metadata can be modified separately
+        src_copy.set_metadata("test_col", 0)
+        self.assertFalse(self.src.has_metadata("test_col"))
 
 
 class StarFileSingleImage(StarFileTestCase):


### PR DESCRIPTION
#744 

## `copy.deepcopy`
`copy.deepcopy` can generally work for user-defined classes and their dependent objects with some exceptions:
```
This module does not copy types like module, method, stack trace, stack frame, file, socket, window, or any similar types. 
```
from https://docs.python.org/3/library/copy.html

Note the important distinction that *functions* are deep-copied, *methods* are not.

## `pandas` deep copying

Pandas objects are properly deep copied themselves, but Python objects stored in them will *not* be deep copied and will share a reference: https://github.com/pandas-dev/pandas/issues/17406

We'll need to look at how this might interact with our metadata system before this PR is complete.

---------

For ASPIRE objects which may be attributes of `ImageSource`, we want to verify that all of *their* attributes have also been properly deepcopied.

I implement this in testing by designing comparison functions unique to each type we expect `ImageSource` subclasses to have, and which we want to double check. 