### PR TITLE
Normalize background dtype bug

### DIFF
--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -32,7 +32,8 @@ def normalize_bg(imgs, bg_radius=1.0, do_ramp=True):
         )
 
     L = imgs.shape[-1]
-    grid = grid_2d(L, indexing="yx")
+    input_dtype = imgs.dtype
+    grid = grid_2d(L, indexing="yx", dtype=input_dtype)
     mask = grid["r"] > bg_radius
 
     if do_ramp:
@@ -42,11 +43,15 @@ def normalize_bg(imgs, bg_radius=1.0, do_ramp=True):
             (
                 grid["x"][mask].flatten(),
                 grid["y"][mask].flatten(),
-                np.ones(grid["y"][mask].flatten().size),
+                np.ones(grid["y"][mask].flatten().size, dtype=input_dtype),
             )
         ).T
         ramp_all = np.vstack(
-            (grid["x"].flatten(), grid["y"].flatten(), np.ones(L * L))
+            (
+                grid["x"].flatten(),
+                grid["y"].flatten(),
+                np.ones(L * L, dtype=input_dtype),
+            )
         ).T
         mask_reshape = mask.reshape((L * L))
         imgs = imgs.reshape((-1, L * L))

--- a/tests/test_preprocess_pipeline.py
+++ b/tests/test_preprocess_pipeline.py
@@ -52,6 +52,9 @@ class PreprocessPLTestCase(TestCase):
             )
         )
 
+        # dtype of returned images should be the same
+        self.assertTrue(self.dtype, imgs_pf.dtype)
+
     def testEmptyPhaseFlip(self):
         """
         Attempting phase_flip without CTFFilters should raise.
@@ -81,6 +84,8 @@ class PreprocessPLTestCase(TestCase):
 
         # new mean of noise should be close to zero and variance should be close to 1
         self.assertTrue(new_mean < 1e-7 and abs(new_variance - 1) < 1e-7)
+        # dtype of returned images should be the same
+        self.assertEqual(self.dtype, imgs_nb.dtype)
 
     def testWhiten(self):
         noise_estimator = AnisotropicNoiseEstimator(self.sim)
@@ -94,6 +99,8 @@ class PreprocessPLTestCase(TestCase):
 
         # correlation matrix should be close to identity
         self.assertTrue(np.allclose(np.eye(2), corr_coef, atol=1e-1))
+        # dtype of returned images should be the same
+        self.assertEqual(self.dtype, imgs_wt.dtype)
 
     def testWhiten2(self):
         # Excercises missing cases using odd image resolutions with filter.
@@ -133,3 +140,6 @@ class PreprocessPLTestCase(TestCase):
 
         # all images should be the same after inverting contrast
         self.assertTrue(np.allclose(imgs1_rc.asnumpy(), imgs2_rc.asnumpy()))
+        # dtype of returned images should be the same
+        self.assertEqual(self.dtype, imgs1_rc.dtype)
+        self.assertEqual(self.dtype, imgs2_rc.dtype)

--- a/tests/test_preprocess_pipeline.py
+++ b/tests/test_preprocess_pipeline.py
@@ -9,7 +9,7 @@ from aspire.noise import AnisotropicNoiseEstimator
 from aspire.operators.filters import FunctionFilter, RadialCTFFilter
 from aspire.source import ArrayImageSource
 from aspire.source.simulation import Simulation
-from aspire.utils import grid_2d
+from aspire.utils import grid_2d, utest_tolerance
 from aspire.utils.matrix import anorm
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "saved_test_data")
@@ -83,7 +83,10 @@ class PreprocessPLTestCase(TestCase):
         new_variance = np.var(imgs_nb[:, mask])
 
         # new mean of noise should be close to zero and variance should be close to 1
-        self.assertTrue(new_mean < 1e-7 and abs(new_variance - 1) < 1e-7)
+        self.assertTrue(
+            new_mean < utest_tolerance(self.dtype)
+            and abs(new_variance - 1) < utest_tolerance(self.dtype)
+        )
         # dtype of returned images should be the same
         self.assertEqual(self.dtype, imgs_nb.dtype)
 

--- a/tests/test_preprocess_pipeline.py
+++ b/tests/test_preprocess_pipeline.py
@@ -96,9 +96,7 @@ def testWhiten(dtype):
     imgs_wt = sim.images[:num_images].asnumpy()
 
     # calculate correlation between two neighboring pixels from background
-    corr_coef = np.corrcoef(
-        imgs_wt[:, sim.L - 1, sim.L - 1], imgs_wt[:, sim.L - 2, sim.L - 1]
-    )
+    corr_coef = np.corrcoef(imgs_wt[:, L - 1, L - 1], imgs_wt[:, L - 2, L - 1])
 
     # correlation matrix should be close to identity
     assert np.allclose(np.eye(2), corr_coef, atol=1e-1)

--- a/tests/test_preprocess_pipeline.py
+++ b/tests/test_preprocess_pipeline.py
@@ -126,11 +126,11 @@ def testWhiten2(dtype):
 @pytest.mark.parametrize("dtype", dtypes)
 def testInvertContrast(dtype):
     sim1 = get_sim_object(L, dtype)
-    imgs1 = sim1.images[:num_images]
+    imgs_org = sim1.images[:num_images]
     sim1.invert_contrast()
     imgs1_rc = sim1.images[:num_images]
     # need to set the negative images to the second simulation object
-    sim2 = ArrayImageSource(-imgs1)
+    sim2 = ArrayImageSource(-imgs_org)
     sim2.invert_contrast()
     imgs2_rc = sim2.images[:num_images]
 

--- a/tests/test_preprocess_pipeline.py
+++ b/tests/test_preprocess_pipeline.py
@@ -1,6 +1,5 @@
 import logging
 import os.path
-from unittest import TestCase
 
 import numpy as np
 import pytest
@@ -14,135 +13,133 @@ from aspire.utils.matrix import anorm
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "saved_test_data")
 
+dtypes = [np.float32, np.float64]
 
-class PreprocessPLTestCase(TestCase):
-    def setUp(self):
+num_images = 128
 
-        self.L = 64
-        self.n = 128
-        self.dtype = np.float32
-        self.noise_filter = FunctionFilter(lambda x, y: np.exp(-(x**2 + y**2) / 2))
 
-        self.sim = Simulation(
-            L=self.L,
-            n=self.n,
-            unique_filters=[
-                RadialCTFFilter(defocus=d) for d in np.linspace(1.5e4, 2.5e4, 7)
-            ],
-            noise_filter=self.noise_filter,
-            dtype=self.dtype,
-        )
-        self.imgs_org = self.sim.images[: self.n]
+def get_sim_object(L, dtype):
+    noise_filter = FunctionFilter(lambda x, y: np.exp(-(x**2 + y**2) / 2))
+    sim = Simulation(
+        L=L,
+        n=num_images,
+        unique_filters=[
+            RadialCTFFilter(defocus=d) for d in np.linspace(1.5e4, 2.5e4, 7)
+        ],
+        noise_filter=noise_filter,
+        dtype=dtype,
+    )
+    return sim
 
-    # This is a workaround to use a `pytest` fixture with `unittest` style cases.
-    # We use it below to capture and inspect the log
-    @pytest.fixture(autouse=True)
-    def inject_fixtures(self, caplog):
-        self._caplog = caplog
 
-    def testPhaseFlip(self):
-        self.sim.phase_flip()
-        imgs_pf = self.sim.images[: self.n]
+@pytest.mark.parametrize("dtype", dtypes)
+def testPhaseFlip(dtype):
+    L = 64
+    sim = get_sim_object(L, dtype)
+    imgs_org = sim.images[:num_images]
+    sim.phase_flip()
+    imgs_pf = sim.images[:num_images]
 
-        # check energy conservation
-        self.assertTrue(
-            np.allclose(
-                anorm(self.imgs_org.asnumpy(), axes=(1, 2)),
-                anorm(imgs_pf.asnumpy(), axes=(1, 2)),
-            )
-        )
+    # check energy conservation
+    assert np.allclose(
+        anorm(imgs_org.asnumpy(), axes=(1, 2)),
+        anorm(imgs_pf.asnumpy(), axes=(1, 2)),
+    )
 
-        # dtype of returned images should be the same
-        self.assertTrue(self.dtype, imgs_pf.dtype)
+    # dtype of returned images should be the same
+    assert dtype == imgs_pf.dtype
 
-    def testEmptyPhaseFlip(self):
-        """
-        Attempting phase_flip without CTFFilters should raise.
-        """
 
-        # Create a Simulation without any CTFFilters
-        sim = Simulation(
-            L=self.L,
-            n=self.n,
-            noise_filter=self.noise_filter,
-            dtype=self.dtype,
-        )
+def testEmptyPhaseFlip(caplog):
+    """
+    Attempting phase_flip without CTFFilters should warn.
+    """
+    L = 64
+    # this test doesn't depend on dtype, not parametrized
+    # Create a Simulation without any CTFFilters
+    sim = Simulation(
+        L=L,
+        n=num_images,
+        dtype=np.float32,
+    )
+    # assert we log a warning to the user
+    with caplog.at_level(logging.WARNING):
+        sim.phase_flip()
+        assert "No Filters found" in caplog.text
 
-        # Test we warn
-        with self._caplog.at_level(logging.WARN):
-            sim.phase_flip()
-            assert "No Filters found" in self._caplog.text
 
-    def testNormBackground(self):
-        bg_radius = 1.0
-        grid = grid_2d(self.L, indexing="yx")
-        mask = grid["r"] > bg_radius
-        self.sim.normalize_background()
-        imgs_nb = self.sim.images[: self.n].asnumpy()
-        new_mean = np.mean(imgs_nb[:, mask])
-        new_variance = np.var(imgs_nb[:, mask])
+@pytest.mark.parametrize("dtype", dtypes)
+def testNormBackground(dtype):
+    L = 64
+    sim = get_sim_object(L, dtype)
+    bg_radius = 1.0
+    grid = grid_2d(sim.L, indexing="yx")
+    mask = grid["r"] > bg_radius
+    sim.normalize_background()
+    imgs_nb = sim.images[:num_images].asnumpy()
+    new_mean = np.mean(imgs_nb[:, mask])
+    new_variance = np.var(imgs_nb[:, mask])
 
-        # new mean of noise should be close to zero and variance should be close to 1
-        self.assertTrue(
-            new_mean < utest_tolerance(self.dtype)
-            and abs(new_variance - 1) < utest_tolerance(self.dtype)
-        )
-        # dtype of returned images should be the same
-        self.assertEqual(self.dtype, imgs_nb.dtype)
+    # new mean of noise should be close to zero and variance should be close to 1
+    assert new_mean < utest_tolerance(dtype) and abs(
+        new_variance - 1
+    ) < utest_tolerance(dtype)
 
-    def testWhiten(self):
-        noise_estimator = AnisotropicNoiseEstimator(self.sim)
-        self.sim.whiten(noise_estimator.filter)
-        imgs_wt = self.sim.images[: self.n].asnumpy()
+    # dtype of returned images should be the same
+    assert dtype == imgs_nb.dtype
 
-        # calculate correlation between two neighboring pixels from background
-        corr_coef = np.corrcoef(
-            imgs_wt[:, self.L - 1, self.L - 1], imgs_wt[:, self.L - 2, self.L - 1]
-        )
 
-        # correlation matrix should be close to identity
-        self.assertTrue(np.allclose(np.eye(2), corr_coef, atol=1e-1))
-        # dtype of returned images should be the same
-        self.assertEqual(self.dtype, imgs_wt.dtype)
+@pytest.mark.parametrize("dtype", dtypes)
+def testWhiten(dtype):
+    L = 64
+    sim = get_sim_object(L, dtype)
+    noise_estimator = AnisotropicNoiseEstimator(sim)
+    sim.whiten(noise_estimator.filter)
+    imgs_wt = sim.images[:num_images].asnumpy()
 
-    def testWhiten2(self):
-        # Excercises missing cases using odd image resolutions with filter.
-        #  Relates to GitHub issue #401.
-        # Otherwise this is the same as testWhiten, though the accuracy
-        #  (atol) for odd resolutions seems slightly worse.
-        L = self.L - 1
-        assert L % 2 == 1, "Test resolution should be odd"
+    # calculate correlation between two neighboring pixels from background
+    corr_coef = np.corrcoef(
+        imgs_wt[:, sim.L - 1, sim.L - 1], imgs_wt[:, sim.L - 2, sim.L - 1]
+    )
 
-        sim = Simulation(
-            L=L,
-            n=self.n,
-            unique_filters=[
-                RadialCTFFilter(defocus=d) for d in np.linspace(1.5e4, 2.5e4, 7)
-            ],
-            noise_filter=self.noise_filter,
-            dtype=self.dtype,
-        )
-        noise_estimator = AnisotropicNoiseEstimator(sim)
-        sim.whiten(noise_estimator.filter)
-        imgs_wt = sim.images[: self.n].asnumpy()
+    # correlation matrix should be close to identity
+    assert np.allclose(np.eye(2), corr_coef, atol=1e-1)
+    # dtype of returned images should be the same
+    assert dtype == imgs_wt.dtype
 
-        corr_coef = np.corrcoef(imgs_wt[:, L - 1, L - 1], imgs_wt[:, L - 2, L - 1])
 
-        # Correlation matrix should be close to identity
-        self.assertTrue(np.allclose(np.eye(2), corr_coef, atol=2e-1))
+@pytest.mark.parametrize("dtype", dtypes)
+def testWhiten2(dtype):
+    # Excercises missing cases using odd image resolutions with filter.
+    #  Relates to GitHub issue #401.
+    # Otherwise this is the same as testWhiten, though the accuracy
+    #  (atol) for odd resolutions seems slightly worse.
+    L = 63
+    sim = get_sim_object(L, dtype)
+    noise_estimator = AnisotropicNoiseEstimator(sim)
+    sim.whiten(noise_estimator.filter)
+    imgs_wt = sim.images[:num_images].asnumpy()
 
-    def testInvertContrast(self):
-        sim1 = self.sim
-        imgs1 = sim1.images[:128]
-        sim1.invert_contrast()
-        imgs1_rc = sim1.images[:128]
-        # need to set the negative images to the second simulation object
-        sim2 = ArrayImageSource(-imgs1)
-        sim2.invert_contrast()
-        imgs2_rc = sim2.images[:128]
+    corr_coef = np.corrcoef(imgs_wt[:, L - 1, L - 1], imgs_wt[:, L - 2, L - 1])
 
-        # all images should be the same after inverting contrast
-        self.assertTrue(np.allclose(imgs1_rc.asnumpy(), imgs2_rc.asnumpy()))
-        # dtype of returned images should be the same
-        self.assertEqual(self.dtype, imgs1_rc.dtype)
-        self.assertEqual(self.dtype, imgs2_rc.dtype)
+    # Correlation matrix should be close to identity
+    assert np.allclose(np.eye(2), corr_coef, atol=2e-1)
+
+
+@pytest.mark.parametrize("dtype", dtypes)
+def testInvertContrast(dtype):
+    L = 64
+    sim1 = get_sim_object(L, dtype)
+    imgs1 = sim1.images[:num_images]
+    sim1.invert_contrast()
+    imgs1_rc = sim1.images[:num_images]
+    # need to set the negative images to the second simulation object
+    sim2 = ArrayImageSource(-imgs1)
+    sim2.invert_contrast()
+    imgs2_rc = sim2.images[:num_images]
+
+    # all images should be the same after inverting contrast
+    assert np.allclose(imgs1_rc.asnumpy(), imgs2_rc.asnumpy())
+    # dtype of returned images should be the same
+    assert dtype == imgs1_rc.dtype
+    assert dtype == imgs2_rc.dtype


### PR DESCRIPTION
This PR fixes the bug in #812, and adjusts the tolerance of the closeness check to depend on the `dtype`.

Also, adds result dtype checks for the rest of the preprocessing tests, and parametrizes for dtype (tests are approx. doubled)