### PR TITLE
`CTFEstimator` has incorrect column name in STAR output

### DIFF
--- a/src/aspire/ctf/ctf_estimator.py
+++ b/src/aspire/ctf/ctf_estimator.py
@@ -686,7 +686,7 @@ class CtfEstimator:
         data_block["_rlnSphericalAberration"] = params_dict["cs"]
         data_block["_rlnAmplitudeContrast"] = params_dict["amplitude_contrast"]
         data_block["_rlnVoltage"] = params_dict["voltage"]
-        data_block["_rlnDetectorPixelSize"] = params_dict["pixel_size"]
+        data_block["_rlnMicrographPixelSize"] = params_dict["pixel_size"]
         df = DataFrame([data_block])
         blocks = OrderedDict()
         blocks["root"] = df

--- a/tests/test_CtfEstimate.py
+++ b/tests/test_CtfEstimate.py
@@ -122,4 +122,7 @@ class CtfEstimatorTestCase(TestCase):
                 data = mrc_in.data[slice_range]
                 mrc_in.set_data(data)
             # make sure we can estimate with no errors
-            _ = estimate_ctf(data_folder=tmp_input_dir, psd_size=64)
+            with tempfile.TemporaryDirectory() as tmp_output_dir:
+                _ = estimate_ctf(
+                    data_folder=tmp_input_dir, output_dir=tmp_output_dir, psd_size=64
+                )


### PR DESCRIPTION
`rlnDetectorPixelSize` is a Relion parameter whose units are micrometers, not angstroms. In addition, the pixel size saved in Relion CTF files is `rlnMicrographPixelSize`, (in angstroms). The detector pixel size does not appear except in movies.

See discussion in #742 


Also a small patch to the `CtfEstimator` test so that it cleans up the `result` dir created by one of the tests.