### PR TITLE
Change `tox.ini` to follow external command rules for `tox 4.x`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ minversion = 3.8.0
 
 [testenv]
 changedir = tests
+allowlist_externals = sh
 deps =
     parameterized
     pytest


### PR DESCRIPTION
Our Github Actions runners have recently stopped installing `tox==3.28` and started testing with `tox=4.0.16`. See #819 for details on this.

This means that our `tox` workflow is now failing because of the use of the `sh` command within the `tox.ini`. With `tox 4.x`, this command must be added to the `allowlist_external` in the tox environment. 

This PR makes that change.

I also tested this `tox` configuration file with 3.28 locally and it appears to work. So we should be safe in the unlikely event that the GA runner happens to try running 3.28 again.