### PR TITLE
Workaround scipy 1.10.0 dtype bug 17718

### DIFF
--- a/src/aspire/operators/filters.py
+++ b/src/aspire/operators/filters.py
@@ -332,7 +332,8 @@ class ArrayFilter(Filter):
         #  for values slightly outside the interpolation grid bounds.
         interpolator = RegularGridInterpolator(
             _input_pts,
-            self.xfer_fn_array,
+            # https://github.com/scipy/scipy/issues/17718
+            self.xfer_fn_array.astype(np.float64),
             method="linear",
             bounds_error=False,
             fill_value=None,


### PR DESCRIPTION
We appear to be triggering an issue in the the latest `scipy` when passing `float32` data into their interp code.

For the time being we can probably just cast around the issue.  This will hopefully unblock the CI, even if it isn't the best permanent fix...

I reported the issue:
https://github.com/scipy/scipy/issues/17718