### PR TITLE
Update randomized unit test that was flaky after running large trial

### DIFF
--- a/tests/test_noise.py
+++ b/tests/test_noise.py
@@ -8,7 +8,6 @@ import pytest
 from aspire.noise import CustomNoiseAdder, WhiteNoiseAdder, WhiteNoiseEstimator
 from aspire.operators import FunctionFilter, ScalarFilter
 from aspire.source.simulation import Simulation
-from aspire.utils import utest_tolerance
 from aspire.volume import AsymmetricVolume
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "saved_test_data")
@@ -62,7 +61,12 @@ def test_white_noise_estimator_clean_corners(sim_fixture):
     noise_variance = noise_estimator.estimate()
     # Using a compactly supported volume should yield
     #   virtually no noise in the image corners.
-    assert np.isclose(noise_variance, 0, atol=utest_tolerance(sim_fixture.dtype))
+    assert np.isclose(noise_variance, 0, atol=1e-6)
+    # 1e-6 was chosen by running the unit test suite 10k (x4 fixture expansion) times.
+    #   min=7.544584748608862e-12 max=1.6798412007391812e-07
+    #   mean=1.0901885456753326e-09 var=5.27460957578949e-18
+    # To reduce the randomness would require a increasing simulation `n`
+    # and/or increasing resolution. Both would increase test time.
 
 
 def test_adder_reprs(adder):


### PR DESCRIPTION
This test failed once again, just slightly out of tol.

So I set it to run 10k times in a loop.  Probably a less flaky test val will be 1e-6 here. The full results are included as a comment in the code and as a scatter plot below.

![image](https://user-images.githubusercontent.com/47759732/211311773-f8e6cc8f-9b07-4ad2-b969-d05fee7903ba.png)


