### PR TITLE
Tox and Docs 828

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -69,6 +69,9 @@ extend-ignore = E203, E501
 per-file-ignores =
   __init__.py: F401
  gallery/tutorials/configuration.py: T201, E402
+ # Ignore Sphinx gallery builds
+ docs/build/html/_downloads/*/*.py: T201, E402
+ docs/source/auto*/*.py: T201, E402
 
 [isort]
 default_section = THIRDPARTY


### PR DESCRIPTION
This PR adds the sphinx gallery build files to the `per-file-ignore` list for `Flake8`. 

closes #828