### PR TITLE
Common Lines: `n_theta` even check

### DIFF
--- a/src/aspire/abinitio/commonline_base.py
+++ b/src/aspire/abinitio/commonline_base.py
@@ -26,7 +26,7 @@ class CLOrient3D:
         :param src: The source object of 2D denoised or class-averaged imag
         :param n_rad: The number of points in the radial direction. If None,
             n_rad will default to the ceiling of half the resolution of the source.
-        :param n_theta: The number of points in the theta direction.
+        :param n_theta: The number of points in the theta direction. This value must be even.
             Default is 360.
         :param n_check: For each image/projection find its common-lines with
             n_check images. If n_check is less than the total number of images,
@@ -59,6 +59,10 @@ class CLOrient3D:
             self.n_rad = math.ceil(0.5 * self.n_res)
         if self.n_check is None:
             self.n_check = self.n_img
+        if self.n_theta % 2 == 1:
+            msg = "n_theta must be even"
+            logger.error(msg)
+            raise NotImplementedError(msg)
 
         imgs = self.src.images[:]
 
@@ -68,11 +72,6 @@ class CLOrient3D:
         )
         self.pf = self.basis.evaluate_t(imgs)
         self.pf = self.pf.reshape(self.n_img, self.n_theta, self.n_rad).T  # RCOPT
-
-        if self.n_theta % 2 == 1:
-            msg = "n_theta must be even"
-            logger.error(msg)
-            raise NotImplementedError(msg)
 
         n_theta_half = self.n_theta // 2
 

--- a/src/aspire/basis/polar_2d.py
+++ b/src/aspire/basis/polar_2d.py
@@ -51,6 +51,11 @@ class PolarBasis2D(Basis):
             # try to use the same number as Fast FB basis
             self.ntheta = 8 * self.nrad
 
+        if self.ntheta % 2 == 1:
+            msg = "Only even values for ntheta are supported."
+            logger.error(msg)
+            raise NotImplementedError(msg)
+
         self.count = self.nrad * self.ntheta
         self._sz_prod = self.sz[0] * self.sz[1]
 

--- a/tests/test_PolarBasis2D.py
+++ b/tests/test_PolarBasis2D.py
@@ -2,6 +2,7 @@ import logging
 from unittest import TestCase
 
 import numpy as np
+from pytest import raises
 
 from aspire.basis import PolarBasis2D
 from aspire.image import Image
@@ -25,6 +26,16 @@ class PolarBasis2DTestCase(TestCase, UniversalBasisMixin):
 
     def tearDown(self):
         pass
+
+    def testPolarBasis2DThetaError(self):
+        """
+        Test that PolarBasis2D when instantiated with odd value for `ntheta`
+        gives appropriate error.
+        """
+
+        # Test we raise with expected error.
+        with raises(NotImplementedError, match=r"Only even values for ntheta*"):
+            _ = PolarBasis2D(size=self.L, ntheta=143, dtype=self.dtype)
 
     def testPolarBasis2DEvaluate_t(self):
         x = Image(

--- a/tests/test_orient_sync.py
+++ b/tests/test_orient_sync.py
@@ -5,6 +5,7 @@ from unittest import TestCase
 
 import numpy as np
 from click.testing import CliRunner
+from pytest import raises
 
 from aspire.abinitio import CLSyncVoting
 from aspire.commands.orient3d import orient3d
@@ -42,9 +43,11 @@ class OrientSyncTestCase(TestCase):
         )
         vols = vols.downsample(L)
 
-        sim = Simulation(L=L, n=n, vols=vols, unique_filters=filters, dtype=self.dtype)
+        self.sim = Simulation(
+            L=L, n=n, vols=vols, unique_filters=filters, dtype=self.dtype
+        )
 
-        self.orient_est = CLSyncVoting(sim, L // 2, 36)
+        self.orient_est = CLSyncVoting(self.sim, L // 2, 36)
 
     def tearDown(self):
         pass
@@ -88,6 +91,16 @@ class OrientSyncTestCase(TestCase):
         self.assertTrue(
             np.allclose(results, self.est_shifts, atol=utest_tolerance(self.dtype))
         )
+
+    def testThetaError(self):
+        """
+        Test that CLSyncVoting when instantiated with odd value for `n_theta`
+        gives appropriate error.
+        """
+
+        # Test we raise with expected error.
+        with raises(NotImplementedError, match=r"n_theta must be even*"):
+            _ = CLSyncVoting(self.sim, 16, 35)
 
     def testCommandLine(self):
         # Ensure that the command line tool works as expected


### PR DESCRIPTION
This PR closes #792

Moves the check for `n_theta` even above polar fft step which requires `n_theta` to be even. Note added to docstring param.

`NotImplementedError` now raised with message "n_theta must be even".