### PR TITLE
Workaround grpc#32163

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         "confuse>=2.0.0",
         "finufft",
         "gemmi>=0.4.8",
+        "grpcio<=1.48.2",
         "joblib",
         "matplotlib>=3.2.0",
         "mrcfile",


### PR DESCRIPTION
Closes #859 

We should use the older version of this until the upstream version is ready (then switch it to >=XYZ).  This morning the latest non rc release did not fix for me, but the older resolved.