### PR TITLE
Downgrade windows CI from 2022 to 2019 (fixes single test fail in CI)

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -64,7 +64,7 @@ jobs:
         shell: bash -el {0}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-20.04, macOS-latest, macOS-11, windows-latest]
+        os: [ubuntu-latest, ubuntu-20.04, macOS-latest, macOS-11, windows-2019]
         backend: [default, openblas]
         python-version: ['3.8']
         include:


### PR DESCRIPTION
~Try windows server 2019 instead of latest (2022).~

~Please disregard this PR. I'm just triggering the CI to see if this has the same failed test as windows 2022.~

~If it fails this PR will be removed.  Succeeds, I will edit this message.~

CI is reporting success using Win2019.  I would like to merge this patch. Will leave issue open so we can revisit what is unhappy in Windows Server 2022 at a later date.