### PR TITLE
add warning and clamp for extremal snr

### DIFF
--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -1022,7 +1022,7 @@ class ImageSource(ABC):
         if snr < 0:
             logger.warning(
                 "For extremely low SNR, estimation accuracy may be impaired."
-                f"  Clamping estimated snr {snr} to 0."
+                f"  Clamping estimated SNR {snr} to 0."
             )
             snr = 0
 

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -1018,6 +1018,14 @@ class ImageSource(ABC):
         #     `estimate_signal_var`   we yield: signal_variance
         snr = (signal_power - noise_power) / noise_power
 
+        # Check for extremal values.
+        if snr < 0:
+            logger.warning(
+                "For extremely low SNR, estimation accuracy may be impaired."
+                f"  Clamping estimated snr {snr} to 0."
+            )
+            snr = 0
+
         return snr
 
 


### PR DESCRIPTION
I was able to reproduce the negative estimated SNR by applying an extremal white noise adder variance and also adding several ctf filters.  The true_snr was still positive (around ~e-7).

I don't believe this can happen via `from_snr` .