### PR TITLE
Add seed to flaky class average test

### DIFF
--- a/src/aspire/classification/rir_class2d.py
+++ b/src/aspire/classification/rir_class2d.py
@@ -364,7 +364,7 @@ class RIRClass2D(Class2D):
 
         # ### The following was from legacy code. Be careful wrt order.
         M = M.T
-        u, s, v = pca_y(M, self.bispectrum_components)
+        u, s, v = pca_y(M, self.bispectrum_components, seed=self.seed)
 
         # Contruct coefficients
         coef_b = np.einsum("i, ij -> ij", s, np.conjugate(v))
@@ -500,6 +500,7 @@ class RIRClass2D(Class2D):
                 eigval=complex_eigvals,
                 alpha=self.alpha,
                 sample_n=self.sample_n,
+                seed=self.seed,
             )
             # If we have produced a feature vector
             if coef_b.size != 0:

--- a/src/aspire/utils/random.py
+++ b/src/aspire/utils/random.py
@@ -68,9 +68,7 @@ def random(*args, **kwargs):
     """
     Wraps numpy.random.random with ASPIRE Random context manager.
     """
-    seed = None
-    if "seed" in kwargs:
-        seed = kwargs.pop("seed")
+    seed = kwargs.pop("seed", None)
 
     with Random(seed):
         return np.random.random(*args, **kwargs)

--- a/tests/test_class2D.py
+++ b/tests/test_class2D.py
@@ -19,6 +19,9 @@ logger = logging.getLogger(__name__)
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "saved_test_data")
 
+# This seed is to stabilize the extremely small unit test (img size 16 etc).
+SEED = 42
+
 
 class FSPCATestCase(TestCase):
     def setUp(self):
@@ -35,10 +38,7 @@ class FSPCATestCase(TestCase):
 
         # Create a src from the volume
         self.src = Simulation(
-            L=self.resolution,
-            n=321,
-            vols=v,
-            dtype=self.dtype,
+            L=self.resolution, n=321, vols=v, dtype=self.dtype, seed=SEED
         )
         self.src.cache()  # Precompute image stack
 
@@ -125,10 +125,7 @@ class RIRClass2DTestCase(TestCase):
 
         # Clean
         self.clean_src = Simulation(
-            L=self.resolution,
-            n=self.n_img,
-            vols=v,
-            dtype=self.dtype,
+            L=self.resolution, n=self.n_img, vols=v, dtype=self.dtype, seed=SEED
         )
 
         # With Noise
@@ -140,6 +137,7 @@ class RIRClass2DTestCase(TestCase):
             vols=v,
             dtype=self.dtype,
             noise_adder=noise_adder,
+            seed=SEED,
         )
 
         # Set up FFB
@@ -199,6 +197,7 @@ class RIRClass2DTestCase(TestCase):
             large_pca_implementation="legacy",
             nn_implementation="legacy",
             bispectrum_implementation="legacy",
+            seed=SEED,
         )
 
     def testRIRLegacy(self):
@@ -217,6 +216,7 @@ class RIRClass2DTestCase(TestCase):
             large_pca_implementation="legacy",
             nn_implementation="legacy",
             bispectrum_implementation="legacy",
+            seed=SEED,
         )
 
         _ = rir.classify()
@@ -253,6 +253,7 @@ class RIRClass2DTestCase(TestCase):
             large_pca_implementation="sklearn",
             nn_implementation="sklearn",
             bispectrum_implementation="devel",
+            seed=SEED,
         )
 
         _ = rir.classify()


### PR DESCRIPTION
Adds seed to pca_y and legacy bispec codes. Both make significant use of `random` and struggle finding enough relavant values at the low image sizes (16) which make for fast tests.