### PR TITLE
AsymmetricVolume Patch

### DIFF
--- a/src/aspire/volume/volume_synthesis.py
+++ b/src/aspire/volume/volume_synthesis.py
@@ -338,7 +338,7 @@ class AsymmetricVolume(CnSymmetricVolume):
     """
 
     def __init__(self, L, C, K=16, seed=None, dtype=np.float64):
-        super().__init__(L=L, C=C, order=1, seed=seed, dtype=dtype)
+        super().__init__(L=L, C=C, K=K, order=1, seed=seed, dtype=dtype)
 
     def _check_order(self):
         if self.order != 1:

--- a/src/aspire/volume/volume_synthesis.py
+++ b/src/aspire/volume/volume_synthesis.py
@@ -337,7 +337,7 @@ class AsymmetricVolume(CnSymmetricVolume):
     An asymmetric Volume constructed of random 3D Gaussian blobs with compact support in the unit sphere.
     """
 
-    def __init__(self, L, C, K=16, seed=None, dtype=np.float64):
+    def __init__(self, L, C, K=64, seed=None, dtype=np.float64):
         super().__init__(L=L, C=C, K=K, order=1, seed=seed, dtype=dtype)
 
     def _check_order(self):


### PR DESCRIPTION
In `AsymmetricVolume` the parameter `K` for number of Gaussian blobs used to generate the volume was not being passed to `super` causing the value to be fixed at 16. 

Added the parameter and set the default value to 64 which produces "better looking" volumes.