### PR TITLE
add missing assignment in 10073

### DIFF
--- a/gallery/experiments/experimental_abinitio_pipeline_10073.py
+++ b/gallery/experiments/experimental_abinitio_pipeline_10073.py
@@ -75,7 +75,7 @@ src = RelionSource(
 
 # Downsample the images
 logger.info(f"Set the resolution to {img_size} X {img_size}")
-src.downsample(img_size)
+src = src.downsample(img_size)
 
 src = src.cache()
 


### PR DESCRIPTION
Missing merge line. Patches 10073.

Doesn't resolve the larger issue, but corrects this experiment script.