### PR TITLE
Workaround patches

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -64,7 +64,7 @@ jobs:
         shell: bash -el {0}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-20.04, macOS-latest, macOS-11, windows-2019]
+        os: [ubuntu-latest, ubuntu-20.04, macOS-latest, macOS-11]
         backend: [default, openblas]
         python-version: ['3.8']
         include:
@@ -72,6 +72,8 @@ jobs:
             backend: intel
           - os: macOS-latest
             backend: accelerate
+          - os: windows-2019
+            backend: default
 
     steps:
     - uses: actions/checkout@v3

--- a/gallery/experiments/experimental_abinitio_pipeline_10028.py
+++ b/gallery/experiments/experimental_abinitio_pipeline_10028.py
@@ -98,6 +98,9 @@ if interactive:
 # logger.info("Invert the global density contrast")
 # src = src.invert_contrast()
 
+# Caching is used for speeding up large datasets on high memory machines.
+src = src.cache()
+
 # %%
 # Optional: CWF Denoising
 # -----------------------
@@ -119,6 +122,8 @@ if do_cov2d:
     cwf_denoiser = DenoiserCov2D(src)
     # Use denoised src for classification
     classification_src = cwf_denoiser.denoise()
+    # Cache for speedup.  Avoids recomputing.
+    classification_src = classification_src.cache()
     # Peek, what do the denoised images look like...
     if interactive:
         classification_src.images[:10].show()

--- a/gallery/experiments/experimental_abinitio_pipeline_10081.py
+++ b/gallery/experiments/experimental_abinitio_pipeline_10081.py
@@ -75,6 +75,9 @@ src.phase_flip()
 aiso_noise_estimator = AnisotropicNoiseEstimator(src)
 src.whiten(aiso_noise_estimator.filter)
 
+# Caching is used for speeding up large datasets on high memory machines.
+src = src.cache()
+
 # %%
 # Class Averaging
 # ----------------------

--- a/src/aspire/source/coordinates.py
+++ b/src/aspire/source/coordinates.py
@@ -366,7 +366,7 @@ class CoordinateSource(ImageSource, ABC):
 
         # get unique ctfs from the data block
         # i'th entry of `indices` contains the index of `filter_params` with corresponding CTF params
-        ctf_data = np.stack(data_block[c] for c in CTF_params).astype(self.dtype).T
+        ctf_data = np.stack([data_block[c] for c in CTF_params]).astype(self.dtype).T
         filter_params, indices = np.unique(
             ctf_data,
             return_inverse=True,

--- a/src/aspire/source/relion.py
+++ b/src/aspire/source/relion.py
@@ -107,7 +107,7 @@ class RelionSource(ImageSource):
         # If these all exist in the STAR file, we may create CTF filters for the source
         if set(CTF_params).issubset(metadata.keys()):
             # partition particles according to unique CTF parameters
-            ctf_data = np.stack(metadata[k] for k in CTF_params).T
+            ctf_data = np.stack([metadata[k] for k in CTF_params]).T
             filter_params, filter_indices = np.unique(
                 ctf_data,
                 return_inverse=True,


### PR DESCRIPTION
Still isolating the memory leak issue, but the second commit here (adding cache) allows the experiments to complete without crashing due to OOM

Previously caching was not required, and I intentionally avoided it to keep the memory footprint lower on all but one of the pipelines before #902 ... Historically I would be more worried about OOM with the use of cache... so there is still something afoul, but this might allow us to move forward with the release while I continue to debug with the information I have been gathering.