### PR TITLE
Fle ordering

### DIFF
--- a/src/aspire/basis/fle_2d.py
+++ b/src/aspire/basis/fle_2d.py
@@ -40,13 +40,14 @@ class FLEBasis2D(SteerableBasis2D, FBBasisMixin):
             resolution of the basis.
         :param epsilon: Relative precision between FLE fast method and dense matrix multiplication.
         :param dtype: Datatype of images and coefficients represented.
-        :param match_fb:
-              With this flag set the following will ensure that the basis functions are
-              identical to `FBBasis2D`:
-            - The initial heuristic for the number of basis functions, based on the resolution, will
-              be set to that of `FBBasis2D`, and the FLE frequency thresholding procedure to reduce the
-              number of functions will not be carried out. This means the number of basis functions for
-              a given image size will be identical across the two bases.
+        :param match_fb: This flag constructs basis functions
+            identical to `FBBasis2D`. The initial heuristic for the
+            number of basis functions, based on the image size, will
+            be set to that of `FBBasis2D`, and the FLE frequency
+            thresholding procedure to reduce the number of functions
+            will not be carried out. This means the number of basis
+            functions for a given image size will be identical across
+            the two bases.
         """
         if isinstance(size, int):
             size = (size, size)

--- a/src/aspire/basis/fle_2d.py
+++ b/src/aspire/basis/fle_2d.py
@@ -109,7 +109,7 @@ class FLEBasis2D(SteerableBasis2D, FBBasisMixin):
         # store the reverse mapping (used during evaluate input)
         self._fb_to_fle_indices = np.argsort(self._fle_to_fb_indices)
 
-        #
+        # User facing indices, should follow FB ordering.
         self.angular_indices = self._fle_angular_indices[self._fle_to_fb_indices]
         self.radial_indices = self._fle_radial_indices[self._fle_to_fb_indices]
         self.signs_indices = self._fle_signs_indices[self._fle_to_fb_indices]

--- a/src/aspire/basis/fle_2d_utils.py
+++ b/src/aspire/basis/fle_2d_utils.py
@@ -2,29 +2,29 @@ import numpy as np
 import scipy.sparse as sparse
 
 
-def transform_complex_to_real(B_conj, ells):
+def transform_complex_to_real(B, ells):
     """
     Transforms coefficients of the matrix B (see Eq. 3) from complex
         to real. B is the linear transformation that takes FLE coefficients
         to images.
 
-    :param B_conj: Complex conjugate of the matrix B.
+    :param B: Complex matrix B.
     :param ells: List of ells (Bessel function orders) in this basis.
     :return: Transformed matrix.
     """
-    num_basis_functions = B_conj.shape[1]
-    X = np.zeros(B_conj.shape, dtype=np.float64)
+    num_basis_functions = B.shape[1]
+    X = np.zeros(B.shape, dtype=np.float64)
 
     for i in range(num_basis_functions):
         ell = ells[i]
         if ell == 0:
-            X[:, i] = np.real(B_conj[:, i])
+            X[:, i] = np.real(B[:, i])
         # for each ell != 0, we can populate two entries of the matrix
         # by taking the complex conjugate of the ell with the opposite sign
         if ell < 0:
             s = (-1) ** np.abs(ell)
-            x0 = (B_conj[:, i] + s * B_conj[:, i + 1]) / np.sqrt(2)
-            x1 = (-B_conj[:, i] + s * B_conj[:, i + 1]) / (1j * np.sqrt(2))
+            x0 = (B[:, i] + s * B[:, i + 1]) / np.sqrt(2)
+            x1 = (-B[:, i] + s * B[:, i + 1]) / (1j * np.sqrt(2))
             X[:, i] = np.real(x0)
             X[:, i + 1] = np.real(x1)
 

--- a/src/aspire/basis/fle_2d_utils.py
+++ b/src/aspire/basis/fle_2d_utils.py
@@ -87,7 +87,7 @@ def precomp_transform_complex_to_real(ells):
 
     A = sparse.csr_matrix((vals, (idx, jdx)), shape=(count, count), dtype=np.complex128)
 
-    return A
+    return A.conjugate()
 
 
 def barycentric_interp_sparse(target_points, known_points, numsparse):

--- a/tests/test_FLEbasis2D.py
+++ b/tests/test_FLEbasis2D.py
@@ -156,6 +156,7 @@ def testMatchFBDenseEvaluate(basis):
 
     # Matrix column reording in match_fb mode flips signs of some of the basis functions
     assert np.allclose(np.abs(fb_images), np.abs(fle_images), atol=1e-3)
+    assert np.allclose(fb_images, fle_images, atol=1e-3)
 
 
 @pytest.mark.parametrize("basis", test_bases_match_fb, ids=show_fle_params)

--- a/tests/test_FLEbasis2D.py
+++ b/tests/test_FLEbasis2D.py
@@ -299,7 +299,7 @@ def testRotate45():
     dtype = np.float64
 
     L = 128
-    fb_basis = FBBasis2D(L, dtype=dtype)
+    fb_basis = FFBBasis2D(L, dtype=dtype)
     basis = FLEBasis2D(L, match_fb=True, dtype=dtype)
 
     # sample image


### PR DESCRIPTION
WIP, stashing some progress.

This PR should provide a few incremental improvements relating to FLE.  Namely migrating the FLE coefficients to always use our FB ordering convention and breaking-out/resolving several issues I encountered using FLE in the larger basis/cov2d reconciliation effort (in `match_fb` mode, issues with rotations, radial_convolve, indices ).  `match_fb` mode should now only change the selection of basis functions (and so count and indices), but the conventions for ordering etc should always be the same.

~I was able to remove the "flipped_sign_indices" by conjugating the result of the FLE real to complex conversion and reversing the rotation convention.  I want to look into this more.  I feel like there should be a corresponding change I can make so the rotations do not require this negation.  However, at the moment I can live with it if the API and usage is consistent and working. (So I can get back to the larger basis/cov effort).~  I was able to make the rotation convention correspond by flipping the sign of the indices after implementing the conjugation and `ell=0` `sgn=1` case.

Also adds a test for rotating by 45*.  I have found that 90* can be very misleading.
