### PR TITLE
Author updates

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -18,7 +18,7 @@
 	    "name": "Junchao Xia"
 	},
 	{
-	    "affiliation": "Princeton University",
+	    "affiliation": "Columbia University",
 	    "name": "Chris Langfield",
 	    "orcid": "0000-0003-4151-203X"
 	},

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -22,7 +22,7 @@ Developers of the Python and Matlab collection of ASPIRE codes are listed below.
    +------------------+-----------------+---------------------------+-----------------------------------+
    | Ayelet Heimowitz | ayeltg          | ayeleth@ariel.ac.il       | Ariel University                  |
    +------------------+-----------------+---------------------------+-----------------------------------+
-   | Chris Langfield  | chris-langfield | langfield@princeton.edu   | Princeton University              |
+   | Chris Langfield  | chris-langfield | cal2254@columbia.edu      | Columbia University               |
    +------------------+-----------------+---------------------------+-----------------------------------+
    | Amit Moscovich   | mosco           | mosco@tauex.tau.ac.il     | Tel Aviv University               |
    +------------------+-----------------+---------------------------+-----------------------------------+
@@ -36,7 +36,7 @@ Developers of the Python and Matlab collection of ASPIRE codes are listed below.
    +------------------+-----------------+---------------------------+-----------------------------------+
    | Garrett Wright   | garrettwrong    | gbwright@princeton.edu    | Princeton University              |
    +------------------+-----------------+---------------------------+-----------------------------------+
-   | Junchao Xia      | junchaoxia      | junchao.xia@princeton.edu | Princeton University              |
+   | Junchao Xia      | junchaoxia      | junchaoxiacn@gmail.com    | OpenEye                           |
    +------------------+-----------------+---------------------------+-----------------------------------+
 
 |

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     long_description_content_type="text/markdown",
     license="GPLv3",
     url="https://github.com/ComputationalCryoEM/ASPIRE-Python",
-    author="Joakim Anden, Ayelet Heimowitz, Vineet Bansal, Robbie Brook, Itay Sason, Yoel Shkolnisky, Garrett Wright, Junchao Xia",
+    author="Joakim Anden, Vineet Bansal, Josh Carmichael, Chris Langfield, Ayelet Heimowitz, Yoel Shkolnisky, Amit Singer, Garrett Wright, Junchao Xia",
     author_email="devs.aspire@gmail.com",
     install_requires=[
         "click",


### PR DESCRIPTION
Update details for Chris and Junchao in contributors and Zenodo.

Add/rm authors in `setup.py`.  Some of the authors listed there did not make significant code contributions to the current package.  Also, we were missing Amit, Josh, Chris (added).  The contributors list still includes anyone removed from `setup.py`.

Now would be a good time to update anything else I suppose.  We should discuss that email again during out meeting...