### PR TITLE
Rename `master`~~>`main`

### DIFF
--- a/.github/workflows/long_workflow.yml
+++ b/.github/workflows/long_workflow.yml
@@ -3,7 +3,7 @@ name: ASPIRE Python Long Running Test Suite
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
       - 'develop'
 
 jobs:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -98,9 +98,9 @@ jobs:
         # -n runs test in parallel using pytest-xdist
         pytest -n2 --durations=50 -s
 
-  # Build and Deploy production (master) docs.
+  # Build and Deploy production (main) docs.
   docs_deploy:
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Please submit any Pull Requests (PR) against the `develop` branch.
 
 ![Gitflow Diagram](https://wac-cdn.atlassian.com/dam/jcr:61ccc620-5249-4338-be66-94d563f2843c/05%20(2).svg?cdnVersion=357)
 
-The basic idea is that we have `feature` branches,  `develop` as an integration focused branch, and `master` for releases.
+The basic idea is that we have `feature` branches,  `develop` as an integration focused branch, and `main` for releases.
 We do not currently have a need for a dedicated release or staging branch; in our case `develop` also serves this purpose.
 Generally feature branches should branch off of the latest `develop` branch.
 
@@ -44,8 +44,8 @@ When `develop` is at a milestone where we want to cut a release,
 following the controls below we will commit with a
 [PEP440](https://www.python.org/dev/peps/pep-0440/)
 compliant `Major.Minor` version scheme
-and complete a reviewed merge to `master`.
-Once in `master` a formal Git (version) tag can be applied to the commit,
+and complete a reviewed merge to `main`.
+Once in `main` a formal Git (version) tag can be applied to the commit,
 and at this point the release would be a candidate to upload to PyPI.
 
 The process for these steps will be documented in a Google Doc.
@@ -69,8 +69,8 @@ This is both for code quality and so CI maintenance is not overlooked.
 
 All of these controls will be managed automatically by the GitHub server.
 
-Releases and merges to `master` should be coordinated between developers and the project PI.
-This will be documented with an additional required review from the PI when merging into `master`.
+Releases and merges to `main` should be coordinated between developers and the project PI.
+This will be documented with an additional required review from the PI when merging into `main`.
 
 ### Git Workflow Courtesy
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ![Logo](http://spr.math.princeton.edu/sites/spr.math.princeton.edu/files/ASPIRE_1.jpg)
 
-[![Azure Build Status](https://dev.azure.com/ComputationalCryoEM/Aspire-Python/_apis/build/status/ComputationalCryoEM.ASPIRE-Python?branchName=master)](https://dev.azure.com/ComputationalCryoEM/Aspire-Python/_build/latest?definitionId=3&branchName=master)
+[![Azure Build Status](https://dev.azure.com/ComputationalCryoEM/Aspire-Python/_apis/build/status/ComputationalCryoEM.ASPIRE-Python?branchName=main)](https://dev.azure.com/ComputationalCryoEM/Aspire-Python/_build/latest?definitionId=3&branchName=main)
 [![Github Actions Status](https://github.com/ComputationalCryoEM/ASPIRE-Python/actions/workflows/workflow.yml/badge.svg)](https://github.com/ComputationalCryoEM/ASPIRE-Python/actions/workflows/workflow.yml)
-[![codecov](https://codecov.io/gh/ComputationalCryoEM/ASPIRE-Python/branch/master/graph/badge.svg?token=3XFC4VONX0)](https://codecov.io/gh/ComputationalCryoEM/ASPIRE-Python)
+[![codecov](https://codecov.io/gh/ComputationalCryoEM/ASPIRE-Python/branch/main/graph/badge.svg?token=3XFC4VONX0)](https://codecov.io/gh/ComputationalCryoEM/ASPIRE-Python)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5657281.svg)](https://doi.org/10.5281/zenodo.5657281)
 
 # ASPIRE - Algorithms for Single Particle Reconstruction - v0.11.1

--- a/gallery/tutorials/aspire_introduction.py
+++ b/gallery/tutorials/aspire_introduction.py
@@ -14,7 +14,7 @@ MAT586.
 # ASPIRE can generally install on Linux, Mac, and Windows under
 # Anaconda Python, by following the instructions in the README.  `The
 # instructions for developers is the most comprehensive
-# <https://github.com/ComputationalCryoEM/ASPIRE-Python/blob/master/README.md#for-developers>`_.
+# <https://github.com/ComputationalCryoEM/ASPIRE-Python/blob/main/README.md#for-developers>`_.
 # Windows is provided, but generally Linux and MacOS are recommended,
 # with Linux being the most diversely tested platform.
 #


### PR DESCRIPTION
Probably we should migrate towards Github's/Git community default.  (https://github.com/github/renaming)

This PR should be coordinated with renaming the master branch.

I have been holding off because this has the potential to be slightly disruptive, it would be best to do it when we do not have a lot of outstanding PRs (which might me this upcoming release).

With that said, I don't think we need to, it is probably just good practice to stick with the herd on this. Can discuss at out dev meeting