### PR TITLE
Diag matrix

### DIFF
--- a/src/aspire/operators/__init__.py
+++ b/src/aspire/operators/__init__.py
@@ -1,4 +1,4 @@
-from .blk_diag_matrix import BlkDiagMatrix
+from .blk_diag_matrix import BlkDiagMatrix, is_scalar_type
 from .diag_matrix import DiagMatrix
 from .filters import (
     ArrayFilter,

--- a/src/aspire/operators/__init__.py
+++ b/src/aspire/operators/__init__.py
@@ -1,4 +1,5 @@
 from .blk_diag_matrix import BlkDiagMatrix
+from .diag_matrix import DiagMatrix
 from .filters import (
     ArrayFilter,
     BlueFilter,

--- a/src/aspire/operators/blk_diag_matrix.py
+++ b/src/aspire/operators/blk_diag_matrix.py
@@ -249,6 +249,8 @@ class BlkDiagMatrix:
 
         if is_scalar_type(other):
             return self.__scalar_add(other, inplace=inplace)
+        elif not isinstance(other, BlkDiagMatrix):
+            return NotImplemented
 
         self.__check_compatible(other)
 
@@ -322,6 +324,8 @@ class BlkDiagMatrix:
 
         if is_scalar_type(other):
             return self.__scalar_sub(other, inplace=inplace)
+        elif not isinstance(other, BlkDiagMatrix):
+            return NotImplemented
 
         self.__check_compatible(other)
 

--- a/src/aspire/operators/blk_diag_matrix.py
+++ b/src/aspire/operators/blk_diag_matrix.py
@@ -11,6 +11,26 @@ from aspire.utils import make_psd
 from aspire.utils.cell import Cell2D
 
 
+def is_scalar_type(x):
+    """
+    Helper function checking scalar-ness for elementwise ops.
+
+    Essentially we are checking for a single numeric object, as opposed to
+    something like an `ndarray` or `BlkDiagMatrix`. We do this by
+    checking `numpy.isscalar(x)`.
+
+    In the future this check may require extension to include ASPIRE or
+    other third party types beyond what is provided by numpy, so we
+    implement it now as a method.
+
+    :param x: Value to check
+
+    :return: bool.
+    """
+
+    return np.isscalar(x)
+
+
 class BlkDiagMatrix:
     """
     Define a BlkDiagMatrix class which implements operations for
@@ -114,25 +134,6 @@ class BlkDiagMatrix:
         """
 
         return self.nblocks
-
-    def _is_scalar_type(self, x):
-        """
-        Internal helper function checking scalar-ness for elementwise ops.
-
-        Essentially we are checking for a single numeric object, as opposed to
-        something like an `ndarray` or `BlkDiagMatrix`. We do this by
-        checking `numpy.isscalar(x)`.
-
-        In the future this check may require extension to include ASPIRE or
-        other third party types beyond what is provided by numpy, so we
-        implement it now as a class method.
-
-        :param x: Value to check
-
-        :return: bool.
-        """
-
-        return np.isscalar(x)
 
     def __check_size_compatible_add(self, other):
         """
@@ -246,7 +247,7 @@ class BlkDiagMatrix:
             to self + other.
         """
 
-        if self._is_scalar_type(other):
+        if is_scalar_type(other):
             return self.__scalar_add(other, inplace=inplace)
 
         self.__check_compatible(other)
@@ -296,7 +297,7 @@ class BlkDiagMatrix:
             to self + other.
         """
 
-        assert self._is_scalar_type(scalar)
+        assert is_scalar_type(scalar)
 
         if inplace:
             C = self
@@ -319,7 +320,7 @@ class BlkDiagMatrix:
             self - other.
         """
 
-        if self._is_scalar_type(other):
+        if is_scalar_type(other):
             return self.__scalar_sub(other, inplace=inplace)
 
         self.__check_compatible(other)
@@ -349,7 +350,7 @@ class BlkDiagMatrix:
         Operator overloading for in-place subtraction.
         """
 
-        if self._is_scalar_type(other):
+        if is_scalar_type(other):
             return self.__scalar_sub(other, inplace=True)
 
         return self.sub(other, inplace=True)
@@ -375,7 +376,7 @@ class BlkDiagMatrix:
             self + other.
         """
 
-        assert self._is_scalar_type(scalar)
+        assert is_scalar_type(scalar)
 
         if inplace:
             C = self
@@ -470,7 +471,7 @@ class BlkDiagMatrix:
                 "BlkDiagMatrix instances, try (matmul,@)."
             )
 
-        elif not self._is_scalar_type(val):
+        elif not is_scalar_type(val):
             raise RuntimeError(
                 "Attempt numeric multiplication (*,mul) of a "
                 "BlkDiagMatrix and {}.".format(type(val))

--- a/src/aspire/operators/blk_diag_matrix.py
+++ b/src/aspire/operators/blk_diag_matrix.py
@@ -476,10 +476,8 @@ class BlkDiagMatrix:
         # Convert scalar to reduce code branching.
         if is_scalar_type(val):
             val = np.full((self.nblocks), fill_value=val, dtype=self.dtype)
-        elif hasattr(val, "as_blk_diag"):
-            val = val.as_blk_diag(self.partition)
         elif not isinstance(val, BlkDiagMatrix):
-            raise RuntimeError(f"mul not implemented for {type(val)}.")
+            raise NotImplementedError(f"mul not implemented for {type(val)}.")
 
         if inplace:
             for i in range(self.nblocks):

--- a/src/aspire/operators/blk_diag_matrix.py
+++ b/src/aspire/operators/blk_diag_matrix.py
@@ -403,7 +403,8 @@ class BlkDiagMatrix:
                 "`inplace` method not supported when " "mixing `BlkDiagMatrix`."
             )
 
-        # Convert scalar to reduce code branching.
+        # Convert operator to BlkDiagMatrix is possible.
+        # Its possible to optimize this in the future if its too slow.
         if hasattr(other, "as_blk_diag"):
             other = other.as_blk_diag(self.partition)
         elif not isinstance(other, BlkDiagMatrix):

--- a/src/aspire/operators/blk_diag_matrix.py
+++ b/src/aspire/operators/blk_diag_matrix.py
@@ -924,3 +924,17 @@ class BlkDiagMatrix:
             A.data[i] = np.array(blk_diag[i], dtype=dtype)
 
         return A
+
+    def diag(self):
+        """
+        Return the diagonal elements of this `BlkDiagMatrix`.
+        """
+
+        # Avoid circular import
+        from .diag_matrix import DiagMatrix
+
+        diag = []
+        for blk in self:
+            diag.extend(list(np.diag(blk)))
+
+        return DiagMatrix(np.array(diag, dtype=self.dtype))

--- a/src/aspire/operators/blk_diag_matrix.py
+++ b/src/aspire/operators/blk_diag_matrix.py
@@ -465,28 +465,22 @@ class BlkDiagMatrix:
         :return: A BlkDiagMatrix of self * other.
         """
 
-        if isinstance(val, BlkDiagMatrix):
-            raise RuntimeError(
-                "Attempt numeric multiplication (*,mul) of two "
-                "BlkDiagMatrix instances, try (matmul,@)."
-            )
-
-        elif not is_scalar_type(val):
-            raise RuntimeError(
-                "Attempt numeric multiplication (*,mul) of a "
-                "BlkDiagMatrix and {}.".format(type(val))
-            )
+        # Convert scalar to reduce code branching.
+        if is_scalar_type(val):
+            val = np.full((self.nblocks), fill_value=val, dtype=self.dtype)
+        elif not isinstance(val, BlkDiagMatrix):
+            val = val.as_blk_diag(self.partition)
 
         if inplace:
             for i in range(self.nblocks):
-                self[i] *= val
+                self[i] *= val[i]
 
             C = self
         else:
             C = BlkDiagMatrix(self.partition, dtype=self.dtype)
 
             for i in range(self.nblocks):
-                C[i] = self[i] * val
+                C[i] = self[i] * val[i]
 
         return C
 

--- a/src/aspire/operators/diag_matrix.py
+++ b/src/aspire/operators/diag_matrix.py
@@ -161,18 +161,28 @@ class DiagMatrix:
 
     def add(self, other):
         """
-        Define elementwise addition of `DiagMatrix` instances
+        Define elementwise addition of `DiagMatrix` instances with
+        scalars, `BlkDiagMatrix`, and `DiagMatrix`.
 
-        :param other: The rhs `DiagMatrix` instance.
+        :param other: scalar, `BlkDiagMatrix` or `DiagMatrix.
         :return:  `DiagMatrix` instance with elementwise sum equal
-            to self + other.
+            to self + other. In the case of `BlkDiagMatrix` a `BlkDiagMatrix` is returned.
         """
 
-        if not is_scalar_type(other):
+        if is_scalar_type(other):
+            res = DiagMatrix(self._data + other)
+        elif isinstance(other, DiagMatrix):
             self.__check_compatible(other)
-            other = other._data
+            res = DiagMatrix(self._data + other._data)
+        elif isinstance(other, BlkDiagMatrix):
+            # res is blk_diag_matrix
+            res = self.as_blk_diag(other.partition) + other
+        else:
+            raise NotImplementedError(
+                f"`add` operation not implemented for {type(other)}"
+            )
 
-        return DiagMatrix(self._data + other)
+        return res
 
     def __add__(self, other):
         """
@@ -190,18 +200,28 @@ class DiagMatrix:
 
     def sub(self, other):
         """
-        Define the elementwise subtraction of `DiagMatrix` instance.
+        Define elementwise subtraction of `DiagMatrix` instances by
+        scalars, `BlkDiagMatrix`, and `DiagMatrix`.
 
-        :param other: The rhs `DiagMatrix` instance.
-        :return: A `DiagMatrix` instance with elementwise subraction equal to
-            self - other.
+        :param other: scalar, `BlkDiagMatrix` or `DiagMatrix.
+        :return:  `DiagMatrix` instance with elementwise sub equal
+            to self - other. In the case of `BlkDiagMatrix` a `BlkDiagMatrix` is returned.
         """
 
-        if not is_scalar_type(other):
+        if is_scalar_type(other):
+            res = DiagMatrix(self._data - other)
+        elif isinstance(other, DiagMatrix):
             self.__check_compatible(other)
-            other = other._data
+            res = DiagMatrix(self._data - other._data)
+        elif isinstance(other, BlkDiagMatrix):
+            # res is blk_diag_matrix
+            res = self.as_blk_diag(other.partition) - other
+        else:
+            raise NotImplementedError(
+                f"`add` operation not implemented for {type(other)}"
+            )
 
-        return DiagMatrix(self._data - other)
+        return res
 
     def __sub__(self, other):
         """

--- a/src/aspire/operators/diag_matrix.py
+++ b/src/aspire/operators/diag_matrix.py
@@ -460,7 +460,7 @@ class DiagMatrix:
     def rapply(self, X):
         """
         Right apply.  Given a matrix of coefficient vectors,
-        applies the block diagonal matrix on the right hand side.
+        applies the diagonal matrix on the right hand side.
         Example, X @ self.
 
         This is the right hand side equivalent to `apply`.

--- a/src/aspire/operators/diag_matrix.py
+++ b/src/aspire/operators/diag_matrix.py
@@ -11,15 +11,15 @@ class DiagMatrix:
     """
     Implements operations for diagonal matrices as used by ASPIRE.
 
-    Currently DiagMatrix is implemented as the equivalent of square
+    Currently `DiagMatrix` is implemented as the equivalent of square
     matrices.  In the future it can be extended to support
     applications with rectangular shapes.
     """
 
     def __init__(self, data, dtype=None):
         """
-        Instantiate a `DiagMatrix` with Numpy `data` shaped (...., self.n),
-        where `self.n` is the length of one diagonal vector.
+        Instantiate a `DiagMatrix` with Numpy `data` shaped (...., self.count),
+        where `self.count` is the length of one diagonal vector.
 
         Slower axes are taken to be stack axes.
         Inputs of zero or one dimension are taken to be a stack of one.
@@ -37,7 +37,7 @@ class DiagMatrix:
         self.dtype = np.dtype(dtype)
 
         self._data = data.astype(self.dtype, copy=False)
-        self.n = self._data.shape[-1]
+        self.count = self._data.shape[-1]
         self.stack_shape = self._data.shape[:-1]
         self.shape = self._data.shape
 
@@ -102,7 +102,7 @@ class DiagMatrix:
         Convenience function for getting `n`.
         """
 
-        return self.n
+        return self.count
 
     def _is_scalar_type(self, x):
         """
@@ -131,9 +131,10 @@ class DiagMatrix:
         :param other: The DiagMatrix to compare with self.
         """
 
-        if self.n != other.n:
+        if self.count != other.count:
             raise RuntimeError(
-                "DiagMatrix instances are " f"not same dimension {self.n} != {other.n}"
+                "DiagMatrix instances are "
+                f"not same dimension {self.count} != {other.count}"
             )
 
     def __check_dtype_compatible(self, other):
@@ -483,7 +484,7 @@ class DiagMatrix:
         # Convert to np.array
         dense = np.concatenate(dense)
         # Reshape to original stack shape.
-        return dense.reshape(*original_stack_shape, self.n, self.n)
+        return dense.reshape(*original_stack_shape, self.count, self.count)
 
     def apply(self, X):
         """
@@ -596,7 +597,7 @@ class DiagMatrix:
 
     def yunpeng(self, partition, weights=None):
         if weights is None:
-            weights = np.ones(self.n, dtype=self.dtype)
+            weights = np.ones(self.count, dtype=self.dtype)
 
         B = BlkDiagMatrix(partition, dtype=self.dtype)
 

--- a/src/aspire/operators/diag_matrix.py
+++ b/src/aspire/operators/diag_matrix.py
@@ -553,7 +553,12 @@ class DiagMatrix:
         B = BlkDiagMatrix(partition, dtype=self.dtype)
         ind = 0
         for b, p in enumerate(partition):
-            assert p[0] == p[1]
+            if p[0] != p[1]:
+                raise RuntimeError(
+                    f"Block {b} of partition is not square, {p}."
+                    "Currently DiagMatrix.as_blk_diag only supports square blocks."
+                )
+
             j = p[0]
             B[b] = np.diag(self._data[ind : ind + j])
             ind += j

--- a/src/aspire/operators/diag_matrix.py
+++ b/src/aspire/operators/diag_matrix.py
@@ -144,6 +144,12 @@ class DiagMatrix:
                 "DiagMatrix instances are "
                 f"not same dimension {self.count} != {other.count}"
             )
+        try:
+            _ = np.broadcast_shapes(self.stack_shape, other.stack_shape)
+        except ValueError:
+            raise ValueError(
+                f"Attempting to broadcast incompatible shapes: {self.stack_shape} with {other.stack_shape}."
+            )
 
     def __check_dtype_compatible(self, other):
         """
@@ -337,6 +343,7 @@ class DiagMatrix:
         :return: A `self` * `other` as type of `other`.
         """
         if isinstance(other, DiagMatrix):
+            self.__check_compatible(other)
             res = DiagMatrix(self._data * other._data)
         elif isinstance(other, np.ndarray):
             res = self * DiagMatrix(other)

--- a/src/aspire/operators/diag_matrix.py
+++ b/src/aspire/operators/diag_matrix.py
@@ -50,7 +50,6 @@ class DiagMatrix:
         # Assign shapes from `data`
         self.count = self._data.shape[-1]
         self.stack_shape = self._data.shape[:-1]
-        self.shape = self._data.shape
         # Total number of stack elements
         self.size = np.prod(self.stack_shape)
 
@@ -120,10 +119,9 @@ class DiagMatrix:
 
     def __len__(self):
         """
-        Convenience function for getting `n`.
+        Convenience function for getting length of slowest stack axis.
         """
-
-        return self.count
+        return self.stack_shape[0]
 
     def __check_compatible(self, other):
         """
@@ -313,7 +311,7 @@ class DiagMatrix:
     def mul(self, other):
         """
         Compute the elementwise multiplication of a `DiagMatrix` instance and a
-        scalar or another `DiagMatrix`.
+        scalar, `DiagMatrix`, or `BlkDiagMatrix`.
 
         :param other: The rhs in the multiplication..
         :return: A `self` * `other` as type of `other`.
@@ -327,7 +325,7 @@ class DiagMatrix:
                 raise RuntimeError(
                     f"Mixed `mul` only implemented for singletons at this time, received {self.stack_shape}."
                 )
-            res = self.as_blk_diag(other.partition) * other
+            res = self * other.diag()
         else:  # scalar
             res = DiagMatrix(self._data * other)
 
@@ -398,9 +396,9 @@ class DiagMatrix:
     @property
     def norm(self):
         """
-        Compute the norm of a `DiagMatrix` instance.
+        Compute the 2-norm of a `DiagMatrix` instance.
 
-        :return: The norm of the `DiagMatrix` instance.
+        :return: The 2-norm of the `DiagMatrix` instance.
         """
         # Elements of a diag matrix are its singular values,
         #   and the norm is equal to the largest singular value.
@@ -470,9 +468,6 @@ class DiagMatrix:
         :return: A matrix with new coefficient vectors.
         """
 
-        #  Note there is an optimization opportunity here,
-        #  but the current application of this method is only called once
-        #  per FSPCA/RIR classification.
         return X * self
 
     # `eigval` method is provided for reasons of interoperability

--- a/src/aspire/operators/diag_matrix.py
+++ b/src/aspire/operators/diag_matrix.py
@@ -1,0 +1,635 @@
+"""
+Define a DiagMatrix module which implements operations for
+diagonal matrices as used by ASPIRE.
+"""
+
+import numpy as np
+
+from .blk_diag_matrix import BlkDiagMatrix
+
+
+class DiagMatrix:
+    """
+    Define a DiagMatrix class which implements operations for
+    diagonal matrices as used by ASPIRE.
+
+    Currently DiagMatrix is implemented as the equivalent of square
+    matrices.  In the future it can be extended to support
+    applications with rectangular shapes.
+    """
+
+    # # # Check, do we need this here like i did for blkdiag?
+    # # Developers' Note:
+    # # All instances of this class should have priority over ndarray ops
+    # #   because we implement them here ourselves.
+    # # This is a more np current implementation of __array_priority__
+    # #   operator precedence schedule.
+    # # Mainly this effects rmul, radd, rsub eg:
+    # #   blk_y = scalar_a + ( scalar_b * blk_x)
+    # __array_ufunc__ = None
+
+    def __init__(self, data, dtype=None):
+        """
+        Instantiate a `DiagMatrix` with `data`.
+
+        `DiagMatrix` size corresponds to the last (fast) moving axis.
+        Slower axes are taken to be stack axes.
+        Inputs of zero or one dimension are taken to be a stack of one.
+
+        :param data: Diagonal matrix entries.
+        :param dtype: Datatype. Default of `None` will attempt
+        passthrough of `data.dtype`.  When explicitly provided, will
+        attempt casting `adata` as needed.
+        :return: `DiagMatrix` instance.
+        """
+
+        # Assign the datatype.
+        if dtype is None:
+            dtype = data.dtype
+        self.dtype = np.dtype(dtype)
+
+        self._data = data.astype(self.dtype, copy=False)
+        self.n = self._data.shape[-1]
+        self.stack_shape = self._data.shape[:-1]
+        self.shape = self._data.shape
+
+        # Numpy interop
+        # https://numpy.org/devdocs/user/basics.interoperability.html#the-array-interface-protocol
+        self.__array_interface__ = self.asnumpy().__array_interface__
+        self.__array__ = self.asnumpy()
+
+    def stack_reshape(self, *args):
+        """
+        Reshape the stack axis.
+
+        :*args: Integer(s) or tuple describing the intended shape.
+
+        :returns: DiagMatrix instance.
+        """
+
+        # If we're passed a tuple, use that
+        if len(args) == 1 and isinstance(args[0], tuple):
+            shape = args[0]
+        else:
+            # Otherwise use the variadic args
+            shape = args
+
+        # Sanity check the size
+        if shape != (-1,) and np.prod(shape) != self.n_stack:
+            raise ValueError(
+                f"Number of images {self.n_stack} cannot be reshaped to {shape}."
+            )
+
+        return DiagMatrix(self._data.reshape(*shape, self._data.shape[-1]))
+
+    def asnumpy(self):
+        view = self._data.view()
+        view.flags.writeable = False
+        return view
+
+    # def isfinite(self):
+    #     """
+    #     Check entries are finite.
+    #     Supports Numpy interoperability.
+    #     """
+    #     return np.isfinite(self.asnumpy())
+
+    def __repr__(self):
+        """
+        String represention describing instance.
+        """
+        return "DiagMatrix({}, {})".format(repr(self._data), repr(self.dtype))
+
+    def copy(self):
+        """
+        Returns new DiagMatrix which is a copy of `self`.
+
+        :return DiagMatrix like self
+        """
+
+        return DiagMatrix(self._data.copy())
+
+    # Not sure if I want these on the stack only, or generic yet.
+    # # Manually overload get/set methods,
+    # #   This is just for syntax which allows us to reference self[i] etc
+    # #     instead of writing self._data all the time. You may use either.
+    def __getitem__(self, key):
+        """
+        Convenience wrapper, getter on self._data.
+        """
+
+        return self._data[key]
+
+    # def __setitem__(self, key, value):
+    #     """
+    #     Convenience wrapper, setter on self._data.
+    #     """
+
+    #     self._data[key] = value
+    #     self.reset_cache()
+
+    def __len__(self):
+        """
+        Convenience function for getting `n`.
+        """
+
+        return self.n
+
+    def _is_scalar_type(self, x):
+        """
+        Internal helper function checking scalar-ness for elementwise ops.
+
+        Essentially we are checking for a single numeric object, as opposed to
+        something like an `ndarray` or `DiagMatrix`. We do this by
+        checking `numpy.isscalar(x)`.
+
+        In the future this check may require extension to include ASPIRE or
+        other third party types beyond what is provided by numpy, so we
+        implement it now as a class method.
+
+        :param x: Value to check
+
+        :return: bool.
+        """
+
+        return np.isscalar(x)
+
+    def __check_size_compatible(self, other):
+        """
+        Sanity check two DiagMatrix instances are compatible in size
+        for addition operators. (Same size)
+
+        :param other: The DiagMatrix to compare with self.
+        """
+
+        if self.n != other.n:
+            raise RuntimeError(
+                "DiagMatrix instances are " f"not same dimension {self.n} != {other.n}"
+            )
+
+    def __check_dtype_compatible(self, other):
+        """
+        Sanity check two DiagMatrix instances are compatible in dtype.
+
+        :param other: The DiagMatrix to compare with self.
+        """
+
+        if self.dtype != other.dtype:
+            raise RuntimeError(
+                "DiagMatrix received different types,"
+                f"self: {self.dtype} and other: {other.dtype}.  Please validate and cast"
+                " as appropriate."
+            )
+
+    def add(self, other, inplace=False):
+        """
+        Define elementwise addition of DiagMatrix instances
+
+        :param other: The rhs DiagMatrix instance.
+        :param inplace: Boolean, when set to True change values in place,
+            otherwise return a new instance (default).
+        :return:  DiagMatrix instance with elementwise sum equal
+            to self + other.
+        """
+        return self._data + other._data
+
+    def __add__(self, other):
+        """
+        Operator overloading for addition.
+        """
+
+        return self.add(other)
+
+    def __iadd__(self, other):
+        """
+        Operator overloading for in-place addition.
+        """
+
+        return self.add(other, inplace=True)
+
+    def __radd__(self, other):
+        """
+        Convenience function for elementwise scalar addition.
+        """
+
+        return self.add(other)
+
+    def sub(self, other, inplace=False):
+        """
+        Define the element subtraction of DiagMatrix instance.
+
+        :param other: The rhs DiagMatrix instance.
+        :param inplace: Boolean, when set to True change values in place,
+            otherwise return a new instance (default).
+        :return: A DiagMatrix instance with elementwise subraction equal to
+            self - other.
+        """
+        return self._data - other._data
+
+    def __sub__(self, other):
+        """
+        Operator overloading for subtraction.
+        """
+
+        return self.sub(other)
+
+    def __isub__(self, other):
+        """
+        Operator overloading for in-place subtraction.
+        """
+
+        if self._is_scalar_type(other):
+            return self.__scalar_sub(other, inplace=True)
+
+        return self.sub(other, inplace=True)
+
+    def __rsub__(self, other):
+        """
+        Convenience function for elementwise scalar subtraction.
+        """
+
+        # Note, the case of DiagMatrix_L - DiagMatrix_R would be
+        #   evaluated as L.sub(R), so this is only for other
+        #   Object - DiagMatrix situations, namely scalars.
+
+        return -(self - other)
+
+    def matmul(self, other, inplace=False):
+        """
+        Compute the matrix multiplication of two DiagMatrix instances.
+
+        :param other: The rhs `DiagMatrix`, or 2d dense Numpy array.
+        :param inplace: Boolean, when set to True change values in place,
+            otherwise return a new instance (default).
+        :return: Returns `self` @ `other`, as type of `other`
+        """
+        if isinstance(other, DiagMatrix):
+            res = self.mul(other, inplace=inplace)
+        elif isinstance(other, BlkDiagMatrix):
+            res = BlkDiagMatrix.zeros_like(other)
+
+            ind = 0
+            for b, blk in enumerate(other):
+                i = len(blk)
+
+                res[b] = np.diag(self._data[ind : ind + i]) * blk
+                ind += i
+
+        elif isinstance(other, np.ndarray):
+            # inplace infeasable, as the result will be dense.
+            if inplace:
+                raise RuntimeError(
+                    "Inplace infeasable between DiagMatrix and dense ndarray matrix."
+                )
+            # For now, lets just interop with 2D `other` arrays,
+            # assumed to represent matrices.
+            if other.ndim != 2:
+                raise ValueError(
+                    f"DiagMatrix.matmul of ndarray only supports 2D, received {other.shape}."
+                )
+
+            # Then the mathematical `DA` for diag D and matrix A,
+            # is expressed in code as `D@A`.
+            #
+            # The operation `DA` is known as Left Scaling,
+            # and means to scale the row A_i by d_i in D.
+            # This can be accomplished by broadcasting an elemental multiply.
+
+            res = self._data[..., np.newaxis] * other
+
+        return res
+
+    def __matmul__(self, other):
+        """
+        Operator overload for matrix multiply of DiagMatrix instances.
+        """
+
+        return self.matmul(other)
+
+    def __rmatmul__(self, lhs):
+        """
+        Compute the right matrix multiplication with a DiagMatrix instance,
+        and a numpy array, `lhs` @ `self`.
+
+        :param other: The lhs Numpy instance.
+        :return: Returns numpy array representing `other @ self`.
+        """
+
+        # Note, we should only hit this method when mixing DiagMatrix with numpy.
+        #   This is because if both a and b are DiagMatrix,
+        #   then a@b would be handled first by a.__matmul__(b), never reaching here.
+        if not isinstance(lhs, np.ndarray):
+            raise RuntimeError("__rmatmul__ only defined for np.ndarray @ DiagMatrix.")
+
+        # For now, lets just interop with 2D `other` arrays,
+        # assumed to represent matrices.
+        if lhs.ndim != 2:
+            raise ValueError(
+                f"DiagMatrix.matmul of ndarray only supports 2D, received {lhs.shape}."
+            )
+
+        # Then the mathematical `AD` for diag D and matrix A,
+        # is expressed in code as `A@D`.
+        #
+        # The operation `AD` is known as Right Scaling,
+        # and means to scale the column A_j by d_j in D.
+        # This can be accomplished by broadcasting an elemental multiply.
+        # In this case A is the variable `lhs`
+
+        return lhs * self._data[np.newaxis]
+
+    def __imatmul__(self, other):
+        """
+        Operator overload for in-place matrix multiply of DiagMatrix
+         instances.
+        """
+
+        return self.matmul(other, inplace=True)
+
+    def mul(self, other, inplace=False):
+        """
+        Compute the elementwise multiplication of a DiagMatrix instance and a
+        scalar or another DiagMatrix.
+
+        :param other: The rhs in the multiplication..
+        :param inplace: Boolean, when set to True change values in place,
+            otherwise return a new instance (default).
+        :return: A DiagMatrix of self * other.
+        """
+        if isinstance(other, DiagMatrix):
+            if inplace:
+                self._data *= other._data
+                res = self
+            else:
+                res = DiagMatrix(self._data * other._data)
+        elif isinstance(other, np.ndarray):
+            res = self * DiagMatrix(other)
+        elif isinstance(other, BlkDiagMatrix):
+            raise NotImplementedError("not yet")
+        else:  # scalar
+            res = DiagMatrix(self._data * other)
+
+        return res
+
+    def __mul__(self, val):
+        """
+        Operator overload for DiagMatrix scalar multiply.
+        """
+
+        return self.mul(val)
+
+    def __imul__(self, val):
+        """
+        Operator overload for in-place DiagMatrix scalar multiply.
+        """
+
+        return self.mul(val, inplace=True)
+
+    def __rmul__(self, other):
+        """
+        Convenience function, elementwise rmul commutes to mul.
+        """
+        if isinstance(other, BlkDiagMatrix):
+            raise NotImplementedError("todo")
+        else:
+            return self.mul(other)
+
+    def neg(self):
+        """
+        Compute the unary negation of DiagMatrix instance.
+
+        :return: A DiagMatrix like self.
+        """
+        return DiagMatrix(-self._data)
+
+    def __neg__(self):
+        """
+        Operator overload for unary negation of DiagMatrix instance.
+        """
+
+        return self.neg()
+
+    def abs(self):
+        """
+        Compute the elementwise absolute value of DiagMatrix instance.
+
+        :return: A DiagMatrix like self.
+        """
+        pass
+
+    def __abs__(self):
+        """
+        Operator overload for absolute value of DiagMatrix instance.
+        """
+
+        return DiagMatrix(self.abs(self._data))
+
+    def pow(self, val, inplace=False):
+        """
+        Compute the elementwise power of DiagMatrix instance.
+
+        :param inplace: Boolean, when set to True change values in place,
+            otherwise return a new instance (default).
+        :return: A DiagMatrix like self.
+        """
+
+        if inplace:
+            self._data[:] = self._data**val
+            res = self
+        else:
+            res = DiagMatrix(self._data**val)
+
+        return res
+
+    def __pow__(self, val):
+        """
+        Operator overload for inplace pow of DiagMatrix instance.
+        """
+
+        return self.pow(val)
+
+    def __ipow__(self, val):
+        """
+        Compute the in-place elementwise power of DiagMatrix instance.
+
+        :return: self raised to power, elementwise.
+        """
+
+        return self.pow(val, inplace=True)
+
+    @property
+    def norm(self):
+        """
+        Compute the norm of a DiagMatrix instance.
+
+        :return: The norm of the DiagMatrix instance.
+        """
+        # Elements of a diag matrix are its singular values,
+        #   and the norm is equal to the largest singular value.
+        return np.abs(self._data).max(axis=-1)
+
+    def transpose(self):
+        """
+        Get the transpose matrix of a DiagMatrix instance.
+
+        :return: The corresponding transpose form as a DiagMatrix.
+        """
+        # This is sort of silly no?
+        return self.copy()
+
+    @property
+    def T(self):
+        """
+        Syntactic sugar for self.transpose().
+        """
+
+        return self.transpose()
+
+    @property
+    def dense(self):
+        """
+        Convert DiagMatrix instance into full matrix.
+
+        :return: The DiagMatrix instance including the zero elements of
+        non-diagonal elements.
+        """
+
+        if self._data.ndim == 1:
+            return np.diag(self._data)
+
+        original_stack_shape = self.stack_shape
+        diags = self.stack_reshape(-1)  # Flatten stack
+
+        dense = []
+        for d in diags.asnumpy():
+            dense.append(np.diag(d))
+        # Convert to np.array
+        dense = np.concatenate(dense)
+        # Reshape to original stack shape.
+        return dense.reshape(*original_stack_shape, self.n, self.n)
+
+    def apply(self, X):
+        """
+        Define the apply option of a diagonal matrix with a matrix of
+        coefficient vectors.
+
+        :param X: Coefficient matrix, each column is a coefficient vector.
+        :return: A matrix with new coefficient vectors.
+        """
+
+        return self * X
+
+    def rapply(self, X):
+        """
+        Right apply.  Given a matrix of coefficient vectors,
+        applies the block diagonal matrix on the right hand side.
+        Example, X @ self.
+
+        This is the right hand side equivalent to `apply`.
+
+        :param X: Coefficient matrix, each column is a coefficient vector.
+
+        :return: A matrix with new coefficient vectors.
+        """
+
+        # For now do the transposes a @ b = (b.T @ a.T).T.
+        #  Note there is an optimization opportunity here,
+        #  but the current application of this method is only called once
+        #  per FSPCA/RIR classification.
+        return self.T.apply(X.T).T
+
+    def eigvals(self):
+        """
+        Compute the eigenvalues of a DiagMatrix.
+        :return: Array of eigvals, with length equal to the fully expanded matrix diagonal.
+
+        """
+        # this might be silly too.
+        return self._data.asnumpy()
+
+    @staticmethod
+    def empty(n, dtype=np.float32):
+        """
+        Instantiate an empty DiagMatrix with length `n`.
+        This corresponds to the diag(A) where A is (n,n).
+        Note, like Numpy, empty values are uninitialized.
+
+        :param n: Length of diagonal.
+        :param dtype: Datatype, defaults to np.float32.
+        :return: DiagMatrix instance.
+        """
+
+        return DiagMatrix(np.empty(n, dtype=dtype))
+
+    @staticmethod
+    def zeros(n, dtype=np.float32):
+        """
+        Instantiate a zero intialized DiagMatrix with length `n`.
+        This corresponds to the diag(A) where A is (n,n).
+
+        :param n: Length of diagonal.
+        :param dtype: Datatype, defaults to np.float32.
+        :return: DiagMatrix instance.
+        """
+
+        return DiagMatrix(np.zeros(n, dtype=dtype))
+
+    @staticmethod
+    def ones(n, dtype=np.float32):
+        """
+        Instantiate ones intialized DiagMatrix with length `n`.
+        This corresponds to the diag(A) where A is (n,n).
+
+        :param n: Length of diagonal.
+        :param dtype: Datatype, defaults to np.float32.
+        :return: DiagMatrix instance.
+        """
+
+        return DiagMatrix(np.ones(n, dtype=dtype))
+
+    # Silly?
+    @staticmethod
+    def eye(n, dtype=np.float32):
+        """
+        Build a DiagMatrix eye (identity) matrix.
+
+        :param n: Length of diagonal.
+        :param dtype: Datatype, defaults to np.float32.
+        :return: DiagMatrix instance.
+        """
+
+        return DiagMatrix.ones(n, dtype=dtype)
+
+    def as_blk_diag(self, partition):
+        B = BlkDiagMatrix(partition, dtype=self.dtype)
+        ind = 0
+        for b, p in enumerate(partition):
+            assert p[0] == p[1]
+            j = p[0]
+            B[b] = np.diag(self._data[ind : ind + j])
+            ind += j
+
+        return B
+
+    def yunpeng(self, partition, weights=None):
+        if weights is None:
+            weights = np.ones(self.n, dtype=self.dtype)
+
+        B = BlkDiagMatrix(partition, dtype=self.dtype)
+        ind = 0
+        for b, p in enumerate(partition):
+            assert p[0] == p[1]
+            j = p[0]
+            Ai = self._data[ind : ind + j].reshape(-1, 1)
+            wi = weights[ind : ind + j]
+            B[b] = wi * Ai * Ai.T
+            ind += j
+
+        return B
+
+    def solve(self, b):
+        """
+        Solve a x = b for `x`, given diagonal matrix `b`.
+        """
+
+        return b / self[:, None]

--- a/src/aspire/operators/diag_matrix.py
+++ b/src/aspire/operators/diag_matrix.py
@@ -542,6 +542,7 @@ class DiagMatrix:
         """
         Express `DiagMatrix` as a `BlkDiagMatrix` using `partition`.
 
+        :param partition: BlkDiagMatrix partition.
         :return: `BlkDiagMatrix`
         """
         if self.stack_shape != ():

--- a/src/aspire/operators/diag_matrix.py
+++ b/src/aspire/operators/diag_matrix.py
@@ -470,11 +470,9 @@ class DiagMatrix:
         :return: A matrix with new coefficient vectors.
         """
 
-        # For now do the transposes a @ b = (b.T @ a.T).T.
         #  Note there is an optimization opportunity here,
         #  but the current application of this method is only called once
         #  per FSPCA/RIR classification.
-        # return #self.T.apply(X.T).T
         return X * self
 
     # `eigval` method is provided for reasons of interoperability
@@ -604,10 +602,11 @@ class DiagMatrix:
 
     def solve(self, b):
         """
-        Solve a x = b for `x`, given diagonal matrix `b`.
+        For this `DiagMatrix` `a` and diagonal matrix `b`.
+        solve a x = b for `x`.
 
         :param b: `DiagMatrix`, right hand side.
-        :return: `DiagMatrix`, solution.
+        :return: `DiagMatrix`, solution `x`.
         """
 
         if self.stack_shape != ():

--- a/src/aspire/operators/diag_matrix.py
+++ b/src/aspire/operators/diag_matrix.py
@@ -486,57 +486,76 @@ class DiagMatrix:
         return self.asnumpy()
 
     @staticmethod
-    def empty(n, dtype=np.float32):
+    def empty(shape, dtype=np.float32):
         """
-        Instantiate an empty `DiagMatrix` with length `n`.
-        This corresponds to the diag(A) where A is (n,n).
+        Instantiate an empty `DiagMatrix` with `shape`.
+        When shape is an integer, this corresponds to
+        the diag(A) where A is (n,n).
         Note, like Numpy, empty values are uninitialized.
 
-        :param n: Length of diagonal.
+        :param shape: Shape of matrix.
+            When integer, corresponds to len(diag(A)).  Otherwise,
+            when a tuple (..., n), the last dimension `n` defines the
+            length of diagonal, while prior dimensions define any
+            stack axes.
         :param dtype: Datatype, defaults to np.float32.
         :return: `DiagMatrix` instance.
         """
 
-        return DiagMatrix(np.empty(n, dtype=dtype))
+        return DiagMatrix(np.empty(shape, dtype=dtype))
 
     @staticmethod
-    def zeros(n, dtype=np.float32):
+    def zeros(shape, dtype=np.float32):
         """
-        Instantiate a zero intialized `DiagMatrix` with length `n`.
-        This corresponds to the diag(A) where A is (n,n).
+        Instantiate a zero intialized `DiagMatrix`.
+        When `shape` is an integer, this corresponds to
+        the diag(A) where A is (n,n).
 
-        :param n: Length of diagonal.
+        :param shape: Shape of matrix.
+            When integer, corresponds to len(diag(A)).  Otherwise,
+            when a tuple (..., n), the last dimension `n` defines the
+            length of diagonal, while prior dimensions define any
+            stack axes.
         :param dtype: Datatype, defaults to np.float32.
         :return: `DiagMatrix` instance.
         """
 
-        return DiagMatrix(np.zeros(n, dtype=dtype))
+        return DiagMatrix(np.zeros(shape, dtype=dtype))
 
     @staticmethod
-    def ones(n, dtype=np.float32):
+    def ones(shape, dtype=np.float32):
         """
-        Instantiate ones intialized `DiagMatrix` with length `n`.
-        This corresponds to the diag(A) where A is (n,n).
+        Instantiate ones intialized `DiagMatrix`.
+        When `shape` is an integer, this corresponds to
+        the diag(A) where A is (n,n).
 
-        :param n: Length of diagonal.
+        :param shape: Shape of matrix.
+            When integer, corresponds to len(diag(A)).  Otherwise,
+            when a tuple (..., n), the last dimension `n` defines the
+            length of diagonal, while prior dimensions define any
+            stack axes.
         :param dtype: Datatype, defaults to np.float32.
         :return: `DiagMatrix` instance.
         """
 
-        return DiagMatrix(np.ones(n, dtype=dtype))
+        return DiagMatrix(np.ones(shape, dtype=dtype))
 
     @staticmethod
-    def eye(n, dtype=np.float32):
+    def eye(shape, dtype=np.float32):
         """
         Build a `DiagMatrix` eye (identity) matrix.
         This is simply an alias for `ones`.
 
-        :param n: Length of diagonal.
+        :param shape: Shape of matrix.
+            When integer, corresponds to len(diag(A)).  Otherwise,
+            when a tuple (..., n), the last dimension `n` defines the
+            length of diagonal, while prior dimensions define any
+            stack axes.
         :param dtype: Datatype, defaults to np.float32.
         :return: `DiagMatrix` instance.
         """
 
-        return DiagMatrix.ones(n, dtype=dtype)
+        return DiagMatrix.ones(shape, dtype=dtype)
 
     def as_blk_diag(self, partition):
         """

--- a/src/aspire/operators/diag_matrix.py
+++ b/src/aspire/operators/diag_matrix.py
@@ -606,27 +606,6 @@ class DiagMatrix:
 
         return B
 
-    def lr_scale(self, weights=None):
-        """
-        Performs L and R scaling of `weights` by this `DiagMatrix`
-        instance simultaneously, returning a `DiagMatrix`.
-
-        Given `weights` this computes B = A * w * A.T via B = w * A**2
-        where A is this `DiagMatrix` instance.
-
-        :weights: Optional weight vector, defaults to ones.
-        :return: `DiagMatrix`
-        """
-        if self.stack_shape != ():
-            raise RuntimeError(
-                f"lr_scale only implemented for singletons at this time, received {self.stack_shape}."
-            )
-
-        if weights is None:
-            weights = np.ones(self.count, dtype=self.dtype)
-
-        return weights * self**2
-
     def solve(self, b):
         """
         For this `DiagMatrix` `a` and vector `b`.

--- a/src/aspire/operators/diag_matrix.py
+++ b/src/aspire/operators/diag_matrix.py
@@ -465,7 +465,7 @@ class DiagMatrix:
 
         :return: Array of eigvals, with length equal to the fully expanded matrix diagonal.
         """
-        return self._data.asnumpy()
+        return self.asnumpy()
 
     @staticmethod
     def empty(n, dtype=np.float32):
@@ -526,6 +526,11 @@ class DiagMatrix:
 
         :return: `BlkDiagMatrix`
         """
+        if self.stack_shape != ():
+            raise RuntimeError(
+                f"as_blk_diag only implemented for singletons at this time, received {self.stack_shape}."
+            )
+
         B = BlkDiagMatrix(partition, dtype=self.dtype)
         ind = 0
         for b, p in enumerate(partition):

--- a/src/aspire/operators/diag_matrix.py
+++ b/src/aspire/operators/diag_matrix.py
@@ -264,6 +264,8 @@ class DiagMatrix:
             # This can be accomplished by broadcasting an elemental multiply.
 
             res = self._data[..., np.newaxis] * other
+        else:
+            raise RuntimeError(f"__matmul__ not implemented for {type(other)}.")
 
         return res
 
@@ -286,10 +288,9 @@ class DiagMatrix:
         # Note, we should only hit this method when mixing DiagMatrix with numpy.
         #   This is because if both a and b are DiagMatrix,
         #   then a@b would be handled first by a.__matmul__(b), never reaching here.
-        if isinstance(lhs, BlkDiagMatrix):
-            # convert
-            return lhs @ self.as_blk_diag(self.partition)
-        elif not isinstance(lhs, np.ndarray):
+        #   If a is BlkDiagMatrix, then it will handle the conversion of DiagMatrix b.
+
+        if not isinstance(lhs, np.ndarray):
             raise RuntimeError(f"__rmatmul__ not implemented for {type(lhs)}.")
 
         # For now, lets just interop with 2D `other` arrays,

--- a/src/aspire/operators/diag_matrix.py
+++ b/src/aspire/operators/diag_matrix.py
@@ -337,7 +337,7 @@ class DiagMatrix:
     def mul(self, other):
         """
         Compute the elementwise multiplication of a `DiagMatrix` instance and a
-        scalar, `DiagMatrix`, or `BlkDiagMatrix`.
+        scalar or `DiagMatrix`.
 
         :param other: The rhs in the multiplication..
         :return: A `self` * `other` as type of `other`.
@@ -345,16 +345,10 @@ class DiagMatrix:
         if isinstance(other, DiagMatrix):
             self.__check_compatible(other)
             res = DiagMatrix(self._data * other._data)
-        elif isinstance(other, np.ndarray):
-            res = self * DiagMatrix(other)
-        elif isinstance(other, BlkDiagMatrix):
-            if self.stack_shape != ():
-                raise RuntimeError(
-                    f"Mixed `mul` only implemented for singletons at this time, received {self.stack_shape}."
-                )
-            res = self * other.diag()
-        else:  # scalar
+        elif is_scalar_type(other):  # scalar
             res = DiagMatrix(self._data * other)
+        else:
+            raise NotImplementedError(f"mul not implemented for {type(other)}.")
 
         return res
 
@@ -480,7 +474,7 @@ class DiagMatrix:
         :return: A matrix with new coefficient vectors.
         """
 
-        return self * X
+        return self * DiagMatrix(X)
 
     def rapply(self, X):
         """
@@ -488,14 +482,17 @@ class DiagMatrix:
         applies the diagonal matrix on the right hand side.
         Example, X @ self.
 
-        This is the right hand side equivalent to `apply`.
+        This is the right hand side equivalent to `apply`,
+        which due to being diagonal, is the same as `apply`.
+        This method exists purely for interoperability with code
+        originally targeting `BlkDiagMatrix`.
 
         :param X: Coefficient matrix, each column is a coefficient vector.
 
         :return: A matrix with new coefficient vectors.
         """
 
-        return X * self
+        return self.apply(X)
 
     # `eigval` method is provided for reasons of interoperability
     # in code that also uses with `BlkDiagMatrix`.

--- a/src/aspire/operators/diag_matrix.py
+++ b/src/aspire/operators/diag_matrix.py
@@ -608,10 +608,10 @@ class DiagMatrix:
 
     def solve(self, b):
         """
-        For this `DiagMatrix` `a` and diagonal matrix `b`.
+        For this `DiagMatrix` `a` and vector `b`.
         solve a x = b for `x`.
 
-        :param b: `DiagMatrix`, right hand side.
+        :param b: Right hand side, Numpy array.
         :return: `DiagMatrix`, solution `x`.
         """
 
@@ -620,4 +620,4 @@ class DiagMatrix:
                 f"`solve` only implemented for singletons at this time, received {self.stack_shape}."
             )
 
-        return b / self._data
+        return DiagMatrix(b / self._data)

--- a/tests/test_BlkDiagMatrix.py
+++ b/tests/test_BlkDiagMatrix.py
@@ -185,6 +185,11 @@ class BlkDiagMatrixTestCase(TestCase):
         self.blk_a.matmul(self.blk_b)
         self.allallfunc(blk_c, result)
 
+    def testBlkDiagMultBadType(self):
+        foo = [1, 2, 3]
+        with pytest.raises(RuntimeError, match=r".*not implemented.*"):
+            _ = self.blk_a * foo
+
     def testBlkDiagMatrixScalarMult(self):
         result = [blk * 42.0 for blk in self.blk_a]
 

--- a/tests/test_BlkDiagMatrix.py
+++ b/tests/test_BlkDiagMatrix.py
@@ -373,6 +373,16 @@ class BlkDiagMatrixTestCase(TestCase):
         self.assertTrue(np.allclose(results[0], results[1].dense()))
 
 
+    def test_blk_diag_to_diag(self):
+        """
+        Compare BlkDiagMatrix.diag with taking the diagonal of the dense matrix.
+        """
+        self.assertTrue(np.allclose(
+            np.diag(self.blk_a.dense()),
+            self.blk_a.diag()
+        ))
+
+
 class IrrBlkDiagMatrixTestCase(TestCase):
     """
     Tests Irregular (non square) Block Diagonal Matrices.

--- a/tests/test_BlkDiagMatrix.py
+++ b/tests/test_BlkDiagMatrix.py
@@ -372,15 +372,11 @@ class BlkDiagMatrixTestCase(TestCase):
 
         self.assertTrue(np.allclose(results[0], results[1].dense()))
 
-
     def test_blk_diag_to_diag(self):
         """
         Compare BlkDiagMatrix.diag with taking the diagonal of the dense matrix.
         """
-        self.assertTrue(np.allclose(
-            np.diag(self.blk_a.dense()),
-            self.blk_a.diag()
-        ))
+        self.assertTrue(np.allclose(np.diag(self.blk_a.dense()), self.blk_a.diag()))
 
 
 class IrrBlkDiagMatrixTestCase(TestCase):

--- a/tests/test_BlkDiagMatrix.py
+++ b/tests/test_BlkDiagMatrix.py
@@ -4,7 +4,14 @@ import numpy as np
 import pytest
 from numpy.linalg import norm, solve
 
-from aspire.operators import BlkDiagMatrix
+from aspire.operators import BlkDiagMatrix, is_scalar_type
+
+
+def test_is_scalar_type():
+    assert is_scalar_type(1) is True
+    assert is_scalar_type([1, 2, 3]) is False
+    assert is_scalar_type(np.empty(3)) is False
+    assert is_scalar_type(lambda x: x) is False
 
 
 class BlkDiagMatrixTestCase(TestCase):

--- a/tests/test_diag_matrix.py
+++ b/tests/test_diag_matrix.py
@@ -628,3 +628,14 @@ def test_diag_blk_mul(diag_matrix_fixture, blk_diag):
         # Compare with numpy
         ref = d1.dense() * blk_diag.dense()
         np.testing.assert_allclose((d1 * blk_diag).dense(), ref)
+
+
+def test_non_square_as_blk_diag():
+    """
+    Test non square partition blocks raise an error in as_blk_diag.
+    """
+    d = DiagMatrix(np.empty(8))
+
+    partition = [(4, 5), (4, 3)]
+    with pytest.raises(RuntimeError, match=r".*not square.*"):
+        _ = d.as_blk_diag(partition)

--- a/tests/test_diag_matrix.py
+++ b/tests/test_diag_matrix.py
@@ -99,8 +99,6 @@ def test_get(diag_matrix_fixture):
     ref = d_np[0][0]
     np.testing.assert_allclose(d[0], ref)
 
-    assert str(d).startswith("DiagMatrix(")
-
 
 def test_len():
     """

--- a/tests/test_diag_matrix.py
+++ b/tests/test_diag_matrix.py
@@ -163,7 +163,7 @@ def test_conversion():
     # Zero Dimension stack
     d_np = np.arange(42)  # defaults double
     A_np = np.diag(d_np)  # make dense with numpy
-    # hrmm singleton
+    # Singleton
     np.testing.assert_allclose(DiagMatrix(d_np).dense(), A_np)
 
     # One Dimension singleton

--- a/tests/test_diag_matrix.py
+++ b/tests/test_diag_matrix.py
@@ -554,14 +554,16 @@ def test_eigs(diag_matrix_fixture):
     np.testing.assert_equal(d.eigvals(), d_np[0])
 
 
-def test_eye(matrix_size, dtype):
+def test_eye(diag_matrix_fixture):
     """
     Test helper for identity matrix.
     Same as `ones` for `DiagMatrix`.
     """
-    d = DiagMatrix.eye(matrix_size, dtype=dtype)
+    _, _, d_np = diag_matrix_fixture
+    d = DiagMatrix.eye(d_np.shape)
 
-    np.testing.assert_equal(d, np.ones(matrix_size, dtype=dtype))
+    np.testing.assert_allclose(d, 1)
+    np.testing.assert_equal(d.shape, d_np.shape)
 
 
 def test_apply(diag_matrix_fixture):

--- a/tests/test_diag_matrix.py
+++ b/tests/test_diag_matrix.py
@@ -114,6 +114,9 @@ def test_len():
 
 
 def test_size_mismatch():
+    """
+    Test we raise operating on `DiagMatrix` having different counts.
+    """
     d1 = DiagMatrix(np.empty((10, 8)))
     d2 = DiagMatrix(np.empty((10, 7)))
 
@@ -122,6 +125,9 @@ def test_size_mismatch():
 
 
 def test_dtype_mismatch():
+    """
+    Test we raise operating on `DiagMatrix` having different dtypes.
+    """
     d1 = DiagMatrix(np.empty((10, 8)), dtype=np.float32)
     d2 = DiagMatrix(np.empty((10, 8)), dtype=np.float64)
 
@@ -194,7 +200,7 @@ def test_stack_reshape_tuple(diag_matrix_fixture, stack):
 
 def test_stack_reshape_bad_size(diag_matrix_fixture, stack):
     """
-    Test stack reshape with tuple.
+    Test stack reshape with incorrect size.
     """
     d1, _, _ = diag_matrix_fixture
 
@@ -205,7 +211,7 @@ def test_stack_reshape_bad_size(diag_matrix_fixture, stack):
 
 def test_diag_diag_add(diag_matrix_fixture):
     """
-    Test addition.
+    Test addition of two `DiagMatrix`.
     """
     d1, d2, d_np = diag_matrix_fixture
 
@@ -214,7 +220,7 @@ def test_diag_diag_add(diag_matrix_fixture):
 
 def test_diag_diag_scalar_add(diag_matrix_fixture):
     """
-    Test addition.
+    Test addition of `DiagMatrix` and scalar.
     """
     d1, _, d_np = diag_matrix_fixture
 
@@ -223,7 +229,7 @@ def test_diag_diag_scalar_add(diag_matrix_fixture):
 
 def test_diag_diag_scalar_radd(diag_matrix_fixture):
     """
-    Test addition.
+    Test right addition of `DiagMatrix` and scalar.
     """
     d1, _, d_np = diag_matrix_fixture
 
@@ -232,7 +238,7 @@ def test_diag_diag_scalar_radd(diag_matrix_fixture):
 
 def test_diag_diag_sub(diag_matrix_fixture):
     """
-    Test subtraction.
+    Test subtraction of two `DiagMatrix`.
     """
     d1, d2, d_np = diag_matrix_fixture
 
@@ -241,7 +247,7 @@ def test_diag_diag_sub(diag_matrix_fixture):
 
 def test_diag_diag_scalar_sub(diag_matrix_fixture):
     """
-    Test subtraction.
+    Test subtraction of `DiagMatrix` and scalar.
     """
     d1, _, d_np = diag_matrix_fixture
 
@@ -252,7 +258,7 @@ def test_diag_diag_scalar_sub(diag_matrix_fixture):
 
 def test_diag_diag_scalar_rsub(diag_matrix_fixture):
     """
-    Test subtraction.
+    Test right subtraction of `DiagMatrix` and scalar.
     """
     d1, _, d_np = diag_matrix_fixture
 
@@ -357,10 +363,7 @@ def test_diag_np_matmul(diag_matrix_fixture):
 
 def test_diag_badtype_matmul():
     """
-    Test matrix multiply of `DiagMatrix` with `BlkDiagMatrix` instances.
-
-    Note, this should be the equivalent of expanding to full dense
-    matrices and computing the matrix multiply.
+    Test matrix multiply of `DiagMatrix` with incompatible type raises.
     """
     d1 = DiagMatrix(np.empty(8))
 
@@ -532,6 +535,9 @@ def test_as_blk_diag(matrix_size, blk_diag):
 
 
 def test_bad_as_blk_diag(matrix_size, blk_diag):
+    """
+    Test unimplemented conversion raises.
+    """
     with pytest.raises(RuntimeError, match=r".*only implemented for singletons.*"):
         # Construct via Numpy.
         d_np = np.empty((2, matrix_size), dtype=blk_diag.dtype)
@@ -551,12 +557,19 @@ def test_eigs(diag_matrix_fixture):
 
 
 def test_eye(matrix_size, dtype):
+    """
+    Test helper for identity matrix.
+    Same as `ones` for `DiagMatrix`.
+    """
     d = DiagMatrix.eye(matrix_size, dtype=dtype)
 
     np.testing.assert_equal(d, np.ones(matrix_size, dtype=dtype))
 
 
 def test_apply(diag_matrix_fixture):
+    """
+    Test the `apply` method against numpy.
+    """
     d1, _, d_np = diag_matrix_fixture
 
     x = d1.apply(d_np)
@@ -565,6 +578,10 @@ def test_apply(diag_matrix_fixture):
 
 
 def test_rapply(diag_matrix_fixture):
+    """
+    Test the `rapply` method against numpy.
+    """
+
     d1, _, d_np = diag_matrix_fixture
 
     x = d1.rapply(d_np)
@@ -574,7 +591,7 @@ def test_rapply(diag_matrix_fixture):
 
 def test_solve(diag_matrix_fixture):
     """
-    Test `solve`.
+    Test `solve` output is a valid solution.
     """
     a, _, d_np = diag_matrix_fixture
 

--- a/tests/test_diag_matrix.py
+++ b/tests/test_diag_matrix.py
@@ -1,0 +1,195 @@
+"""
+Tests for `DiagMatrix` class and interoperability with dense Numpy arrays.
+"""
+
+from itertools import product
+
+import numpy as np
+import pytest
+
+from aspire.operators import DiagMatrix
+
+MATRIX_SIZE = [
+    32,
+]
+
+DTYPES = [
+    np.float64,
+    np.float32,
+]
+
+STACKS = [
+    (),
+    (1,),
+    (2,),
+    (3, 4),
+]
+
+
+@pytest.fixture(params=DTYPES, ids=lambda x: f"dtype={x}")
+def dtype(request):
+    return request.param
+
+
+@pytest.fixture(params=MATRIX_SIZE, ids=lambda x: f"count={x}")
+def matrix_size(request):
+    return request.param
+
+
+@pytest.fixture(params=STACKS, ids=lambda x: f"stack={x}")
+def stack(request):
+    return request.param
+
+
+@pytest.fixture
+def diag_matrix_fixture(stack, matrix_size, dtype):
+    """
+    Generate some random diagonal matrix instance with stack, matrix_size and dtype.
+    """
+    shape = (2,) + stack + (matrix_size,)
+    # Internally convert dtype.  Passthrough will be checked explicitly in `test_dtype_passthrough` and `test_dtype_cast`
+    d_np = np.random.random(shape).astype(dtype, copy=False)
+    d1 = DiagMatrix(d_np[0])
+    d2 = DiagMatrix(d_np[1])
+
+    return d1, d2, d_np
+
+
+# Explicit Tests (non parameterized).
+def test_dtype_passthrough():
+    for dtype in (int, np.float32, np.float64, np.complex64, np.complex128):
+        d_np = np.empty(42, dtype=dtype)
+        d = DiagMatrix(d_np)
+        assert d.dtype == dtype
+
+
+def test_dtype_cast():
+    for dtype in (int, np.float32, np.float64, np.complex64, np.complex128):
+        d_np = np.empty(42, dtype=np.float16)
+        d = DiagMatrix(d_np, dtype)
+        assert d.dtype == dtype
+
+
+def test_dtype_conversion():
+    # Zero Dimension stack
+    d_np = np.arange(42)
+    A_np = np.diag(d_np)
+    # hrmm singleton
+    np.testing.assert_allclose(DiagMatrix(d_np).dense, A_np)
+
+    # One Dimension singleton
+    d_np = np.arange(42).reshape(1, 42)
+    diag = DiagMatrix(d_np).dense
+    for i, d in enumerate(d_np):
+        np.testing.assert_allclose(diag[i], np.diag(d))
+
+    # One Dimension stack
+    d_np = np.arange(2 * 42).reshape(2, 42)
+    diag = DiagMatrix(d_np).dense
+    for i, d in enumerate(d_np):
+        np.testing.assert_allclose(diag[i], np.diag(d))
+
+    # Two Dimension stack
+    stack_shape = (2, 3)
+    d_np = np.arange(np.prod(stack_shape) * 42).reshape(*stack_shape, 42)
+    stackA = DiagMatrix(d_np).dense
+    for i, j in product(range(stack_shape[0]), range(stack_shape[1])):
+        np.testing.assert_allclose(stackA[i][j], np.diag(d_np[i][j]))
+
+
+def test_diag_diag_add(diag_matrix_fixture):
+    d1, d2, d_np = diag_matrix_fixture
+
+    np.testing.assert_allclose(d1 + d2, np.sum(d_np, axis=0))
+
+
+def test_diag_diag_sub(diag_matrix_fixture):
+    d1, d2, d_np = diag_matrix_fixture
+
+    np.testing.assert_allclose(d1 - d2, np.subtract(*d_np))
+
+
+def test_diag_diag_mul(diag_matrix_fixture):
+    d1, d2, d_np = diag_matrix_fixture
+
+    np.testing.assert_allclose(d1 * d2, np.multiply(*d_np))
+
+
+def test_diag_diag_matmul(diag_matrix_fixture):
+    d1, d2, d_np = diag_matrix_fixture
+
+    # compute the matmuls
+    d = d1 @ d2
+
+    _d1 = d1.stack_reshape(-1).asnumpy()
+    _d2 = d2.stack_reshape(-1).asnumpy()
+
+    for i, _d in enumerate(d.stack_reshape(-1).asnumpy()):
+        np.testing.assert_allclose(_d, np.diag(np.diag(_d1[i]) @ np.diag(_d2[i])))
+
+
+def test_neg(diag_matrix_fixture):
+    d1, _, d_np = diag_matrix_fixture
+
+    np.testing.assert_allclose(-d1, -d_np[0])
+
+
+def test_pow(diag_matrix_fixture):
+    d1, _, d_np = diag_matrix_fixture
+
+    ref = d_np[0] ** 2
+    np.testing.assert_allclose(d1**2, ref)
+    np.testing.assert_allclose(d1.pow(2), ref)
+
+    _d1 = d1
+    d1 = d1.pow(2, inplace=True)
+    np.testing.assert_allclose(d1, ref)
+    assert d1 is _d1, "Object refs should be identical for inplace ops"
+
+
+def test_norm(diag_matrix_fixture):
+    d1, _, d_np = diag_matrix_fixture
+
+    # Expand to dense matrix and compute norm
+    A = np.diag(d_np.reshape(-1, d_np.shape[-1])[0])
+    ref = np.linalg.norm(A, 2)  # 2-norm
+
+    np.testing.assert_allclose(d1.stack_reshape(-1).norm[0], ref)
+    np.testing.assert_allclose(d1.norm.flatten()[0], ref)
+
+
+def test_transpose(diag_matrix_fixture):
+    """
+    silly?
+    """
+    d1, _, d_np = diag_matrix_fixture
+
+    # Expand to dense matrix and compute transpose
+    A = np.diag(d_np.reshape(-1, d_np.shape[-1])[0])
+    ref = A.T.copy()
+
+    np.testing.assert_allclose(d1.stack_reshape(-1).T.dense[0], ref)
+    np.testing.assert_allclose(d1.stack_reshape(-1).transpose().dense[0], ref)
+
+
+def test_ones(diag_matrix_fixture):
+    _, _, d_np = diag_matrix_fixture
+    d = DiagMatrix.ones(d_np.shape)
+
+    np.testing.assert_allclose(d, 1)
+    np.testing.assert_equal(d.shape, d_np.shape)
+
+
+def test_zeros(diag_matrix_fixture):
+    _, _, d_np = diag_matrix_fixture
+    d = DiagMatrix.zeros(d_np.shape)
+
+    np.testing.assert_allclose(d, 0)
+    np.testing.assert_equal(d.shape, d_np.shape)
+
+
+def test_empty(diag_matrix_fixture):
+    _, _, d_np = diag_matrix_fixture
+    d = DiagMatrix.empty(d_np.shape)
+
+    np.testing.assert_equal(d.shape, d_np.shape)

--- a/tests/test_diag_matrix.py
+++ b/tests/test_diag_matrix.py
@@ -11,6 +11,7 @@ from aspire.operators import DiagMatrix
 
 MATRIX_SIZE = [
     32,
+    33,
 ]
 
 DTYPES = [
@@ -57,6 +58,9 @@ def diag_matrix_fixture(stack, matrix_size, dtype):
 
 # Explicit Tests (non parameterized).
 def test_dtype_passthrough():
+    """
+    Test that the datatype is inferred correctly.
+    """
     for dtype in (int, np.float32, np.float64, np.complex64, np.complex128):
         d_np = np.empty(42, dtype=dtype)
         d = DiagMatrix(d_np)
@@ -64,16 +68,22 @@ def test_dtype_passthrough():
 
 
 def test_dtype_cast():
+    """
+    Test that a datatype is cast when overridden.
+    """
     for dtype in (int, np.float32, np.float64, np.complex64, np.complex128):
         d_np = np.empty(42, dtype=np.float16)
         d = DiagMatrix(d_np, dtype)
         assert d.dtype == dtype
 
 
-def test_dtype_conversion():
+def test_conversion():
+    """
+    Test conversion between iterating over DiagMatrix.dense vs `np.diag`.
+    """
     # Zero Dimension stack
-    d_np = np.arange(42)
-    A_np = np.diag(d_np)
+    d_np = np.arange(42)  # defaults double
+    A_np = np.diag(d_np)  # make dense with numpy
     # hrmm singleton
     np.testing.assert_allclose(DiagMatrix(d_np).dense, A_np)
 
@@ -98,24 +108,40 @@ def test_dtype_conversion():
 
 
 def test_diag_diag_add(diag_matrix_fixture):
+    """
+    Test addition.
+    """
     d1, d2, d_np = diag_matrix_fixture
 
     np.testing.assert_allclose(d1 + d2, np.sum(d_np, axis=0))
 
 
 def test_diag_diag_sub(diag_matrix_fixture):
+    """
+    Test subtraction.
+    """
     d1, d2, d_np = diag_matrix_fixture
 
     np.testing.assert_allclose(d1 - d2, np.subtract(*d_np))
 
 
 def test_diag_diag_mul(diag_matrix_fixture):
+    """
+    Test element-wise multiply of two `DiagMatrix` instances.
+    """
     d1, d2, d_np = diag_matrix_fixture
 
     np.testing.assert_allclose(d1 * d2, np.multiply(*d_np))
 
 
 def test_diag_diag_matmul(diag_matrix_fixture):
+    """
+    Test matrix multiply of two `DiagMatrix` instances.
+
+    Note, this should be the equivalent of expanding to full dense
+    matrices and computing the matrix multiply.  This is tested in a
+    loop over the stack axes.
+    """
     d1, d2, d_np = diag_matrix_fixture
 
     # compute the matmuls
@@ -129,12 +155,18 @@ def test_diag_diag_matmul(diag_matrix_fixture):
 
 
 def test_neg(diag_matrix_fixture):
+    """
+    Test negation.
+    """
     d1, _, d_np = diag_matrix_fixture
 
     np.testing.assert_allclose(-d1, -d_np[0])
 
 
 def test_pow(diag_matrix_fixture):
+    """
+    Test element-wise exponentiation.
+    """
     d1, _, d_np = diag_matrix_fixture
 
     ref = d_np[0] ** 2
@@ -148,6 +180,9 @@ def test_pow(diag_matrix_fixture):
 
 
 def test_norm(diag_matrix_fixture):
+    """
+    Test the `norm` compared to Numpy.
+    """
     d1, _, d_np = diag_matrix_fixture
 
     # Expand to dense matrix and compute norm
@@ -160,7 +195,10 @@ def test_norm(diag_matrix_fixture):
 
 def test_transpose(diag_matrix_fixture):
     """
-    silly?
+    Test the transpose operations.
+
+    Note the transpose operation is implemented for only for
+    interoperability with other operators (ie `BlkDiagMatrix`).
     """
     d1, _, d_np = diag_matrix_fixture
 
@@ -173,6 +211,9 @@ def test_transpose(diag_matrix_fixture):
 
 
 def test_ones(diag_matrix_fixture):
+    """
+    Test constructing a `DiagMatrix` initialized with ones.
+    """
     _, _, d_np = diag_matrix_fixture
     d = DiagMatrix.ones(d_np.shape)
 
@@ -181,6 +222,9 @@ def test_ones(diag_matrix_fixture):
 
 
 def test_zeros(diag_matrix_fixture):
+    """
+    Test constructing a `DiagMatrix` initialized with zeros.
+    """
     _, _, d_np = diag_matrix_fixture
     d = DiagMatrix.zeros(d_np.shape)
 
@@ -189,6 +233,9 @@ def test_zeros(diag_matrix_fixture):
 
 
 def test_empty(diag_matrix_fixture):
+    """
+    Test constructing an uninitialized (empty) `DiagMatrix`.
+    """
     _, _, d_np = diag_matrix_fixture
     d = DiagMatrix.empty(d_np.shape)
 

--- a/tests/test_diag_matrix.py
+++ b/tests/test_diag_matrix.py
@@ -649,26 +649,22 @@ def test_solve(diag_matrix_fixture):
         )
 
 
-def test_diag_blk_mul(diag_matrix_fixture, blk_diag):
+def test_diag_blk_mul():
     """
-    Test mixing `BlkDiagMatrix` with `DiagMatrix` element-wise multiplication.
+    Test mixing `BlkDiagMatrix` with `DiagMatrix` element-wise multiplication raises.
     """
-    d1, _, d_np = diag_matrix_fixture
+    d = DiagMatrix(np.empty(8))
 
-    # Test we raise combining stacks with BlkDiagMatrix.
-    if d1.stack_shape != ():
-        with pytest.raises(RuntimeError, match=r".*only implemented for singletons.*"):
-            _ = d1 * blk_diag
+    partition = [(4, 4), (4, 4)]
+    b = BlkDiagMatrix.ones(partition, dtype=d.dtype)
 
-    else:
-        # Compare commutation (tests rmul with blk)
-        db = d1 * blk_diag
-        bd = blk_diag * d1
-        np.testing.assert_allclose(db.dense(), bd.dense())
+    # left mul
+    with pytest.raises(NotImplementedError, match=r".*mul not implemented for.*"):
+        _ = d * b
 
-        # Compare with numpy
-        ref = d1.dense() * blk_diag.dense()
-        np.testing.assert_allclose((d1 * blk_diag).dense(), ref)
+    # right mul
+    with pytest.raises(NotImplementedError, match=r".*mul not implemented for.*"):
+        _ = b * d
 
 
 def test_non_square_as_blk_diag():

--- a/tests/test_diag_matrix.py
+++ b/tests/test_diag_matrix.py
@@ -231,6 +231,44 @@ def test_diag_diag_scalar_add(diag_matrix_fixture):
     np.testing.assert_allclose(d1 + 123, d_np[0] + 123)
 
 
+def test_diag_blk_add(diag_matrix_fixture, blk_diag):
+    """
+    Test addition of `DiagMatrix` and `BlkDiagMatrix`.
+    """
+    d1, _, d_np = diag_matrix_fixture
+
+    ref = d1.dense() + blk_diag.dense()
+
+    # Test we raise combining stacks with BlkDiagMatrix.
+    if d1.stack_shape != ():
+        with pytest.raises(RuntimeError, match=r".*only implemented for singletons.*"):
+            _ = d1 + blk_diag
+
+    else:
+        res = d1 + blk_diag
+        assert isinstance(res, BlkDiagMatrix)
+        np.testing.assert_allclose(res.dense(), ref)
+
+
+def test_blk_diag_add(diag_matrix_fixture, blk_diag):
+    """
+    Test addition of `BlkDiagMatrix` and `DiagMatrix`.
+    """
+    d1, _, d_np = diag_matrix_fixture
+
+    ref = d1.dense() + blk_diag.dense()
+
+    # Test we raise combining stacks with BlkDiagMatrix.
+    if d1.stack_shape != ():
+        with pytest.raises(RuntimeError, match=r".*only implemented for singletons.*"):
+            _ = blk_diag + d1
+
+    else:
+        res = blk_diag + d1
+        assert isinstance(res, BlkDiagMatrix)
+        np.testing.assert_allclose(res.dense(), ref)
+
+
 def test_diag_diag_scalar_radd(diag_matrix_fixture):
     """
     Test right addition of `DiagMatrix` and scalar.
@@ -269,6 +307,44 @@ def test_diag_diag_scalar_rsub(diag_matrix_fixture):
     d1 = 123 - d1
 
     np.testing.assert_allclose(d1, 123 - d_np[0])
+
+
+def test_diag_blk_sub(diag_matrix_fixture, blk_diag):
+    """
+    Test subtraction of `DiagMatrix` and `BlkDiagMatrix`.
+    """
+    d1, _, d_np = diag_matrix_fixture
+
+    ref = d1.dense() - blk_diag.dense()
+
+    # Test we raise combining stacks with BlkDiagMatrix.
+    if d1.stack_shape != ():
+        with pytest.raises(RuntimeError, match=r".*only implemented for singletons.*"):
+            _ = d1 - blk_diag
+
+    else:
+        res = d1 - blk_diag
+        assert isinstance(res, BlkDiagMatrix)
+        np.testing.assert_allclose(res.dense(), ref)
+
+
+def test_blk_diag_sub(diag_matrix_fixture, blk_diag):
+    """
+    Test subtraction of `BlkDiagMatrix` and `DiagMatrix`.
+    """
+    d1, _, d_np = diag_matrix_fixture
+
+    ref = blk_diag.dense() - d1.dense()
+
+    # Test we raise combining stacks with BlkDiagMatrix.
+    if d1.stack_shape != ():
+        with pytest.raises(RuntimeError, match=r".*only implemented for singletons.*"):
+            _ = blk_diag - d1
+
+    else:
+        res = blk_diag - d1
+        assert isinstance(res, BlkDiagMatrix)
+        np.testing.assert_allclose(res.dense(), ref)
 
 
 def test_diag_diag_mul(diag_matrix_fixture):

--- a/tests/test_diag_matrix.py
+++ b/tests/test_diag_matrix.py
@@ -220,6 +220,14 @@ def test_diag_diag_scalar_add(diag_matrix_fixture):
 
     np.testing.assert_allclose(d1 + 123, d_np[0] + 123)
 
+def test_diag_diag_scalar_radd(diag_matrix_fixture):
+    """
+    Test addition.
+    """
+    d1, _, d_np = diag_matrix_fixture
+
+    np.testing.assert_allclose(123 + d1 , d_np[0] + 123)
+
 
 def test_diag_diag_sub(diag_matrix_fixture):
     """
@@ -239,6 +247,16 @@ def test_diag_diag_scalar_sub(diag_matrix_fixture):
     d1 = d1 - 123
 
     np.testing.assert_allclose(d1, d_np[0] - 123)
+
+def test_diag_diag_scalar_rsub(diag_matrix_fixture):
+    """
+    Test subtraction.
+    """
+    d1, _, d_np = diag_matrix_fixture
+
+    d1 = 123 - d1
+
+    np.testing.assert_allclose(d1, 123 - d_np[0])
 
 
 def test_diag_diag_mul(diag_matrix_fixture):
@@ -392,6 +410,9 @@ def test_lr_scale(diag_matrix_fixture, blk_diag):
 
 
 def test_bad_partition():
+    """
+    Test incorrect partitions raise an error.
+    """
     d = DiagMatrix(np.empty(8))
 
     partition = [(9, 9)]
@@ -401,3 +422,29 @@ def test_bad_partition():
     partition = [(4, 4), (3, 4)]
     with pytest.raises(RuntimeError, match=r".*was not square.*"):
         _ = d.lr_scale(partition)
+
+def test_as_blk_diag(matrix_size, blk_diag):
+    """
+    Test conversion from `DiagMatrix` to `BlkDiagMatrix`.
+
+    Note this relies on `BlkDiagMatrix.dense`.
+    """
+
+    # Construct via Numpy.
+    d_np = np.random.randn(matrix_size).astype(blk_diag.dtype)
+    A = np.diag(d_np)
+
+    # Create DiagMatrix then convert to BlkDiagMatrix
+    d = DiagMatrix(d_np)
+    B = d.as_blk_diag(blk_diag.partition)
+
+    # Compare the dense B with the dense A.
+    np.testing.assert_equal(B.dense(), A)
+
+def test_eigs(diag_matrix_fixture):
+    """
+    Test the `eigvals` util method.
+    """
+    d, _, d_np = diag_matrix_fixture
+
+    np.testing.assert_equal(d.eigvals(), d_np[0])

--- a/tests/test_diag_matrix.py
+++ b/tests/test_diag_matrix.py
@@ -108,7 +108,13 @@ def test_len():
 
     assert d.size == 10
     assert d.count == 8
-    assert len(d) == 8
+    assert len(d) == 10
+
+    d = DiagMatrix(np.empty((2, 5, 8)))
+
+    assert d.size == 10
+    assert d.count == 8
+    assert len(d) == 2
 
 
 def test_size_mismatch():
@@ -446,7 +452,7 @@ def test_ones(diag_matrix_fixture):
     d = DiagMatrix.ones(d_np.shape)
 
     np.testing.assert_allclose(d, 1)
-    np.testing.assert_equal(d.shape, d_np.shape)
+    np.testing.assert_equal(d._data.shape, d_np.shape)
 
 
 def test_zeros(diag_matrix_fixture):
@@ -457,7 +463,7 @@ def test_zeros(diag_matrix_fixture):
     d = DiagMatrix.zeros(d_np.shape)
 
     np.testing.assert_allclose(d, 0)
-    np.testing.assert_equal(d.shape, d_np.shape)
+    np.testing.assert_equal(d._data.shape, d_np.shape)
 
 
 def test_empty(diag_matrix_fixture):
@@ -467,7 +473,7 @@ def test_empty(diag_matrix_fixture):
     _, _, d_np = diag_matrix_fixture
     d = DiagMatrix.empty(d_np.shape)
 
-    np.testing.assert_equal(d.shape, d_np.shape)
+    np.testing.assert_equal(d._data.shape, d_np.shape)
 
 
 def test_lr_scale(diag_matrix_fixture):
@@ -551,7 +557,7 @@ def test_eye(diag_matrix_fixture):
     d = DiagMatrix.eye(d_np.shape)
 
     np.testing.assert_allclose(d, 1)
-    np.testing.assert_equal(d.shape, d_np.shape)
+    np.testing.assert_equal(d._data.shape, d_np.shape)
 
 
 def test_apply(diag_matrix_fixture):

--- a/tests/test_diag_matrix.py
+++ b/tests/test_diag_matrix.py
@@ -107,6 +107,18 @@ def test_conversion():
         np.testing.assert_allclose(stackA[i][j], np.diag(d_np[i][j]))
 
 
+def test_stack_reshape_tuple(diag_matrix_fixture, stack):
+    """
+    Test stack reshape with tuple.
+    """
+    d1, _, _ = diag_matrix_fixture
+
+    # This should be an no-op, but will excercise the code.
+    x = d1.stack_reshape(stack)
+
+    np.testing.assert_allclose(x, d1)
+
+
 def test_diag_diag_add(diag_matrix_fixture):
     """
     Test addition.
@@ -161,6 +173,19 @@ def test_neg(diag_matrix_fixture):
     d1, _, d_np = diag_matrix_fixture
 
     np.testing.assert_allclose(-d1, -d_np[0])
+
+
+def test_abs(diag_matrix_fixture):
+    """
+    Test absolute value method.
+    """
+    d1, _, d_np = diag_matrix_fixture
+
+    # Compute reference via Numpy
+    ref = np.abs(d_np[0])
+
+    np.testing.assert_allclose(d1.abs(), ref)
+    np.testing.assert_allclose(abs(d1), ref)
 
 
 def test_pow(diag_matrix_fixture):

--- a/tests/test_diag_matrix.py
+++ b/tests/test_diag_matrix.py
@@ -337,8 +337,13 @@ def test_diag_np_matmul(diag_matrix_fixture):
     d1, d2, _ = diag_matrix_fixture
 
     if d1.stack_shape != ():
+        # matmul
         with pytest.raises(ValueError, match=r".*only supports 2D.*"):
             _ = d1 @ d2.dense()
+
+        # rmatmul
+        with pytest.raises(ValueError, match=r".*only supports 2D.*"):
+            _ = d1.dense() @ d2
 
     else:
         # compute the reference matmuls
@@ -348,6 +353,24 @@ def test_diag_np_matmul(diag_matrix_fixture):
 
         np.testing.assert_allclose(d1 @ A, DA)
         np.testing.assert_allclose(A @ d1, AD)
+
+
+def test_diag_badtype_matmul():
+    """
+    Test matrix multiply of `DiagMatrix` with `BlkDiagMatrix` instances.
+
+    Note, this should be the equivalent of expanding to full dense
+    matrices and computing the matrix multiply.
+    """
+    d1 = DiagMatrix(np.empty(8))
+
+    # matmul
+    with pytest.raises(RuntimeError, match=r".*not implemented for.*"):
+        _ = d1 @ [1, 2, 3]
+
+    # rmatmul
+    with pytest.raises(RuntimeError, match=r".*not implemented for.*"):
+        _ = [1, 2, 3] @ d1
 
 
 def test_neg(diag_matrix_fixture):

--- a/tests/test_diag_matrix.py
+++ b/tests/test_diag_matrix.py
@@ -552,37 +552,6 @@ def test_empty(diag_matrix_fixture):
     np.testing.assert_equal(d._data.shape, d_np.shape)
 
 
-def test_lr_scale(diag_matrix_fixture):
-    """
-    Test `lr_scale` method.
-    """
-
-    d1 = diag_matrix_fixture[0]
-
-    # Check we raise on stacks.
-
-    if d1.stack_shape != ():
-        with pytest.raises(RuntimeError, match=r".*only implemented for singletons.*"):
-            _ = d1.lr_scale()
-    else:
-        # Test default unit weight scaling
-        x = d1.lr_scale()
-
-        # Create reference expand A @ w @ A.T
-        # It is understood the transpose is redundant here,
-        # but the test formula is being written out intentionally.
-        w = np.ones(d1.count, dtype=d1.dtype)
-        ref = d1.dense() @ np.diag(w) @ d1.dense().T
-
-        np.testing.assert_allclose(x.dense(), ref, atol=utest_tolerance(d1.dtype))
-
-        # Test with different weights
-        w = np.arange(d1.count, dtype=d1.dtype)
-        x = d1.lr_scale(weights=w)
-        ref = d1.dense() @ np.diag(w) @ d1.dense().T
-        np.testing.assert_allclose(x.dense(), ref, atol=utest_tolerance(d1.dtype))
-
-
 def test_as_blk_diag(matrix_size, blk_diag):
     """
     Test conversion from `DiagMatrix` to `BlkDiagMatrix`.

--- a/tests/test_diag_matrix.py
+++ b/tests/test_diag_matrix.py
@@ -711,3 +711,14 @@ def test_non_square_as_blk_diag():
     partition = [(4, 5), (4, 3)]
     with pytest.raises(RuntimeError, match=r".*not square.*"):
         _ = d.as_blk_diag(partition)
+
+
+def test_bad_broadcast():
+    """
+    Test incompatible stack shapes raise appropriate error.
+    """
+    d1 = DiagMatrix(np.empty((2, 3, 8)))
+    d2 = DiagMatrix(np.empty((2, 2, 8)))
+
+    with pytest.raises(ValueError, match=r".*incompatible shapes.*"):
+        _ = d1 + d2

--- a/tests/test_diag_matrix.py
+++ b/tests/test_diag_matrix.py
@@ -605,7 +605,9 @@ def test_solve(diag_matrix_fixture):
     else:
         x = a.solve(b)
 
-        np.testing.assert_allclose(a.dense() @ x, b, atol=utest_tolerance(a.dtype))
+        np.testing.assert_allclose(
+            np.diag(a.dense() @ x.dense()), b, atol=utest_tolerance(a.dtype)
+        )
 
 
 def test_diag_blk_mul(diag_matrix_fixture, blk_diag):


### PR DESCRIPTION
Breaking this off of my large basis coefficient branch.

This adds a `DiagMatrix` class which interoperates with scalars, numpy array, and `BlkDiagMatrix` for most operations.

Unlike `BlkDiagMatrix`, `DiagMatrix` has a stack access.  Combined with operator overloading, this enables broadcasting while using the regular operator symbols.  In particular the `@` and l/r/lr scaling operations support most of the code in cov2d being able to run with either block or diag basis coefficients.

One question I have is regards to naming the operation I've called `lr_scaling` here.  Previously I just called this the `yunpeng` operation.  This is the math trick in the cov2d application which only works for diagonal matrices... Unless I am misinterpreting I believe it is performing both an L scale and R scale in the traditional BLAS naming.

I want to take a fresh look at this then I can open it up for review.