### PR TITLE
fuzzy mask for common line algorithms

### DIFF
--- a/gallery/experiments/simulated_abinitio_pipeline.py
+++ b/gallery/experiments/simulated_abinitio_pipeline.py
@@ -28,11 +28,7 @@ from aspire.noise import AnisotropicNoiseEstimator, CustomNoiseAdder
 from aspire.operators import FunctionFilter, RadialCTFFilter
 from aspire.reconstruction import MeanEstimator
 from aspire.source import OrientedSource, Simulation
-from aspire.utils.coor_trans import (
-    get_aligned_rotations,
-    get_rots_mse,
-    register_rotations,
-)
+from aspire.utils import check_rotations
 
 logger = logging.getLogger(__name__)
 
@@ -198,12 +194,11 @@ orient_est = CLSyncVoting(avgs, n_theta=180)
 oriented_src = OrientedSource(avgs, orient_est)
 
 logger.info("Compare with known rotations")
-# Compare with known true rotations
-Q_mat, flag = register_rotations(oriented_src.rotations, true_rotations)
-regrot = get_aligned_rotations(oriented_src.rotations, Q_mat, flag)
-mse_reg = get_rots_mse(regrot, true_rotations)
+# Compare with known true rotations. ``check_rotations`` globally aligns the estimated
+# rotations to the ground truth and finds the mean angular distance between them.
+mean_ang_dist = check_rotations(oriented_src.rotations, true_rotations)
 logger.info(
-    f"MSE deviation of the estimated rotations using register_rotations : {mse_reg}\n"
+    f"Mean angular distance between globally aligned estimates and ground truth rotations: {mean_ang_dist}\n"
 )
 
 # %%

--- a/gallery/experiments/simulated_abinitio_pipeline.py
+++ b/gallery/experiments/simulated_abinitio_pipeline.py
@@ -28,7 +28,7 @@ from aspire.noise import AnisotropicNoiseEstimator, CustomNoiseAdder
 from aspire.operators import FunctionFilter, RadialCTFFilter
 from aspire.reconstruction import MeanEstimator
 from aspire.source import OrientedSource, Simulation
-from aspire.utils import check_rotations
+from aspire.utils import mean_aligned_angular_distance
 
 logger = logging.getLogger(__name__)
 
@@ -194,9 +194,9 @@ orient_est = CLSyncVoting(avgs, n_theta=180)
 oriented_src = OrientedSource(avgs, orient_est)
 
 logger.info("Compare with known rotations")
-# Compare with known true rotations. ``check_rotations`` globally aligns the estimated
+# Compare with known true rotations. ``mean_aligned_angular_distance`` globally aligns the estimated
 # rotations to the ground truth and finds the mean angular distance between them.
-mean_ang_dist = check_rotations(oriented_src.rotations, true_rotations)
+mean_ang_dist = mean_aligned_angular_distance(oriented_src.rotations, true_rotations)
 logger.info(
     f"Mean angular distance between globally aligned estimates and ground truth rotations: {mean_ang_dist}\n"
 )

--- a/gallery/tutorials/pipeline_demo.py
+++ b/gallery/tutorials/pipeline_demo.py
@@ -223,7 +223,7 @@ from aspire.utils import mean_aligned_angular_distance
 
 # Compare with known true rotations
 mean_ang_dist = mean_aligned_angular_distance(oriented_src.rotations, true_rotations)
-mean_ang_dist
+print(f"Mean aligned angular distance: {mean_ang_dist} degrees")
 
 
 # %%

--- a/gallery/tutorials/pipeline_demo.py
+++ b/gallery/tutorials/pipeline_demo.py
@@ -215,21 +215,15 @@ oriented_src = OrientedSource(avgs, orient_est)
 # %%
 # Mean Squared Error
 # ------------------
-# ASPIRE has some built-in utility functions for globally aligning the
-# estimated rotations to the true rotations and computing the mean
-# squared error.
+# ASPIRE has the built-in utility function, ``check_rotations``, which globally
+# aligns the estimated rotations to the true rotations and computes the mean
+# angular distance (in degrees).
 
-from aspire.utils.coor_trans import (
-    get_aligned_rotations,
-    get_rots_mse,
-    register_rotations,
-)
+from aspire.utils import check_rotations
 
 # Compare with known true rotations
-Q_mat, flag = register_rotations(oriented_src.rotations, true_rotations)
-regrot = get_aligned_rotations(oriented_src.rotations, Q_mat, flag)
-mse_reg = get_rots_mse(regrot, true_rotations)
-mse_reg
+mean_ang_dist = check_rotations(oriented_src.rotations, true_rotations)
+mean_ang_dist
 
 
 # %%

--- a/gallery/tutorials/pipeline_demo.py
+++ b/gallery/tutorials/pipeline_demo.py
@@ -215,14 +215,14 @@ oriented_src = OrientedSource(avgs, orient_est)
 # %%
 # Mean Squared Error
 # ------------------
-# ASPIRE has the built-in utility function, ``check_rotations``, which globally
+# ASPIRE has the built-in utility function, ``mean_aligned_angular_distance``, which globally
 # aligns the estimated rotations to the true rotations and computes the mean
 # angular distance (in degrees).
 
-from aspire.utils import check_rotations
+from aspire.utils import mean_aligned_angular_distance
 
 # Compare with known true rotations
-mean_ang_dist = check_rotations(oriented_src.rotations, true_rotations)
+mean_ang_dist = mean_aligned_angular_distance(oriented_src.rotations, true_rotations)
 mean_ang_dist
 
 

--- a/gallery/tutorials/tutorials/orient3d_simulation.py
+++ b/gallery/tutorials/tutorials/orient3d_simulation.py
@@ -14,7 +14,7 @@ import numpy as np
 from aspire.abinitio import CLSyncVoting
 from aspire.operators import RadialCTFFilter
 from aspire.source import OrientedSource, Simulation
-from aspire.utils import check_rotations
+from aspire.utils import mean_aligned_angular_distance
 from aspire.volume import Volume
 
 logger = logging.getLogger(__name__)
@@ -101,9 +101,9 @@ rots_est = oriented_src.rotations
 # Mean Angular Distance
 # ---------------------
 
-# ``check_rotations`` will perform global alignment of the estimated rotations
+# ``mean_aligned_angular_distance`` will perform global alignment of the estimated rotations
 # to the ground truth and find the mean angular distance between them (in degrees).
-mean_ang_dist = check_rotations(rots_est, rots_true)
+mean_ang_dist = mean_aligned_angular_distance(rots_est, rots_true)
 logger.info(
     f"Mean angular distance between estimates and ground truth: {mean_ang_dist} degrees"
 )

--- a/gallery/tutorials/tutorials/orient3d_simulation.py
+++ b/gallery/tutorials/tutorials/orient3d_simulation.py
@@ -87,7 +87,11 @@ rots_true = sim.rotations
 # ----------------------------------------
 
 # Initialize an orientation estimation object and create an ``OrientedSource`` object
-# to perform viewing angle estimation
+# to perform viewing angle estimation. Here, because of the small image size of the
+# ``Simulation``, we customize the ``CLSyncVoting`` method to use fewer theta values
+# when searching for common-lines between pairs of images. Additionally, since we are
+# processing images with no noise, we opt not to use a ``fuzzy_mask``, an option that
+# improves common-line detection in higher noise regimes.
 logger.info("Estimate rotation angles using synchronization matrix and voting method.")
 orient_est = CLSyncVoting(sim, n_theta=36, mask=False)
 oriented_src = OrientedSource(sim, orient_est)

--- a/gallery/tutorials/tutorials/orient3d_simulation.py
+++ b/gallery/tutorials/tutorials/orient3d_simulation.py
@@ -89,7 +89,7 @@ rots_true = sim.rotations
 # Initialize an orientation estimation object and create an ``OrientedSource`` object
 # to perform viewing angle estimation
 logger.info("Estimate rotation angles using synchronization matrix and voting method.")
-orient_est = CLSyncVoting(sim, n_theta=36)
+orient_est = CLSyncVoting(sim, n_theta=36, mask=False)
 oriented_src = OrientedSource(sim, orient_est)
 rots_est = oriented_src.rotations
 

--- a/gallery/tutorials/tutorials/orient3d_simulation.py
+++ b/gallery/tutorials/tutorials/orient3d_simulation.py
@@ -14,7 +14,7 @@ import numpy as np
 from aspire.abinitio import CLSyncVoting
 from aspire.operators import RadialCTFFilter
 from aspire.source import OrientedSource, Simulation
-from aspire.utils import get_aligned_rotations, get_rots_mse, register_rotations
+from aspire.utils import check_rotations
 from aspire.volume import Volume
 
 logger = logging.getLogger(__name__)
@@ -98,16 +98,15 @@ oriented_src = OrientedSource(sim, orient_est)
 rots_est = oriented_src.rotations
 
 # %%
-# Mean Squared Error
-# ------------------
+# Mean Angular Distance
+# ---------------------
 
-# Get register rotations after performing global alignment
-Q_mat, flag = register_rotations(rots_est, rots_true)
-regrot = get_aligned_rotations(rots_est, Q_mat, flag)
-mse_reg = get_rots_mse(regrot, rots_true)
+# ``check_rotations`` will perform global alignment of the estimated rotations
+# to the ground truth and find the mean angular distance between them (in degrees).
+mean_ang_dist = check_rotations(rots_est, rots_true)
 logger.info(
-    f"MSE deviation of the estimated rotations using register_rotations : {mse_reg}"
+    f"Mean angular distance between estimates and ground truth: {mean_ang_dist} degrees"
 )
 
 # Basic Check
-assert mse_reg < 0.06
+assert mean_ang_dist < 10

--- a/src/aspire/abinitio/commonline_base.py
+++ b/src/aspire/abinitio/commonline_base.py
@@ -80,10 +80,7 @@ class CLOrient3D:
         imgs = self.src.images[:]
 
         if self.mask:
-            # Apply fuzzy mask to images using values for risetime and rad found in the Matlab code.
-            risetime = np.floor(0.05 * self.n_res)
-            rad = np.floor(0.45 * self.n_res)
-            fuzz_mask = fuzzy_mask((self.n_res, self.n_res), rad, risetime, self.dtype)
+            fuzz_mask = fuzzy_mask((self.n_res, self.n_res), self.dtype)
             imgs = imgs * fuzz_mask
 
         # Obtain coefficients of polar Fourier transform for input 2D images

--- a/src/aspire/abinitio/commonline_base.py
+++ b/src/aspire/abinitio/commonline_base.py
@@ -80,7 +80,7 @@ class CLOrient3D:
         imgs = self.src.images[:]
 
         if self.mask:
-            # Apply fuzzy mask to images using Matlab default values for risetime and rad.
+            # Apply fuzzy mask to images using values for risetime and rad found in the Matlab code.
             risetime = np.floor(0.05 * self.n_res)
             rad = np.floor(0.45 * self.n_res)
             fuzz_mask = fuzzy_mask((self.n_res, self.n_res), rad, risetime, self.dtype)

--- a/src/aspire/abinitio/commonline_base.py
+++ b/src/aspire/abinitio/commonline_base.py
@@ -24,7 +24,7 @@ class CLOrient3D:
         n_check=None,
         max_shift=0.15,
         shift_step=1,
-        mask=False,
+        mask=True,
     ):
         """
         Initialize an object for estimating 3D orientations using common lines
@@ -42,7 +42,7 @@ class CLOrient3D:
         :param shift_step: Resolution of shift estimation in pixels.
             Default is 1 pixel.
         :param mask: Option to mask `src.images` with a fuzzy mask (boolean).
-            Default, `False`, does not apply a mask.
+            Default, `True`, applies a mask.
         """
         self.src = src
         # Note dtype is inferred from self.src

--- a/src/aspire/abinitio/commonline_base.py
+++ b/src/aspire/abinitio/commonline_base.py
@@ -5,7 +5,7 @@ import numpy as np
 import scipy.sparse as sparse
 
 from aspire.operators import PolarFT
-from aspire.utils import common_line_from_rots
+from aspire.utils import common_line_from_rots, fuzzy_mask
 from aspire.utils.random import choice
 
 logger = logging.getLogger(__name__)
@@ -17,7 +17,14 @@ class CLOrient3D:
     """
 
     def __init__(
-        self, src, n_rad=None, n_theta=360, n_check=None, max_shift=0.15, shift_step=1
+        self,
+        src,
+        n_rad=None,
+        n_theta=360,
+        n_check=None,
+        max_shift=0.15,
+        shift_step=1,
+        mask=False,
     ):
         """
         Initialize an object for estimating 3D orientations using common lines
@@ -34,6 +41,8 @@ class CLOrient3D:
             of the resolution. Default is 0.15.
         :param shift_step: Resolution of shift estimation in pixels.
             Default is 1 pixel.
+        :param mask: Option to mask `src.images` with a fuzzy mask (boolean).
+            Default, `False`, does not apply a mask.
         """
         self.src = src
         # Note dtype is inferred from self.src
@@ -46,6 +55,7 @@ class CLOrient3D:
         self.clmatrix = None
         self.max_shift = math.ceil(max_shift * self.n_res)
         self.shift_step = shift_step
+        self.mask = mask
         self.rotations = None
 
         self._build()
@@ -68,6 +78,13 @@ class CLOrient3D:
             raise NotImplementedError(msg)
 
         imgs = self.src.images[:]
+
+        if self.mask:
+            # Apply fuzzy mask to images using Matlab default values for risetime and rad.
+            risetime = np.floor(0.05 * self.n_res)
+            rad = np.floor(0.45 * self.n_res)
+            fuzz_mask = fuzzy_mask((self.n_res, self.n_res), rad, risetime, self.dtype)
+            imgs = imgs * fuzz_mask
 
         # Obtain coefficients of polar Fourier transform for input 2D images
         self.pft = PolarFT(

--- a/src/aspire/abinitio/commonline_c2.py
+++ b/src/aspire/abinitio/commonline_c2.py
@@ -43,6 +43,7 @@ class CLSymmetryC2(CLSymmetryC3C4):
         degree_res=1,
         min_dist_cls=25,
         seed=None,
+        mask=False,
     ):
         """
         Initialize object for estimating 3D orientations for molecules with C2 symmetry.
@@ -57,6 +58,8 @@ class CLSymmetryC2(CLSymmetryC3C4):
         :param degree_res: Degree resolution for estimating in-plane rotations.
         :param min_dist_cls: Minimum distance between mutual common-lines. Default = 25 degrees.
         :param seed: Optional seed for RNG.
+        :param mask: Option to mask `src.images` with a fuzzy mask (boolean).
+            Default, `False`, does not apply a mask.
         """
         super().__init__(
             src,
@@ -69,6 +72,7 @@ class CLSymmetryC2(CLSymmetryC3C4):
             max_iters=max_iters,
             degree_res=degree_res,
             seed=seed,
+            mask=mask,
         )
 
         self.min_dist_cls = min_dist_cls

--- a/src/aspire/abinitio/commonline_c2.py
+++ b/src/aspire/abinitio/commonline_c2.py
@@ -43,7 +43,7 @@ class CLSymmetryC2(CLSymmetryC3C4):
         degree_res=1,
         min_dist_cls=25,
         seed=None,
-        mask=False,
+        mask=True,
     ):
         """
         Initialize object for estimating 3D orientations for molecules with C2 symmetry.
@@ -59,7 +59,7 @@ class CLSymmetryC2(CLSymmetryC3C4):
         :param min_dist_cls: Minimum distance between mutual common-lines. Default = 25 degrees.
         :param seed: Optional seed for RNG.
         :param mask: Option to mask `src.images` with a fuzzy mask (boolean).
-            Default, `False`, does not apply a mask.
+            Default, `True`, applies a mask.
         """
         super().__init__(
             src,

--- a/src/aspire/abinitio/commonline_c3_c4.py
+++ b/src/aspire/abinitio/commonline_c3_c4.py
@@ -51,7 +51,7 @@ class CLSymmetryC3C4(CLOrient3D, SyncVotingMixin):
         max_iters=1000,
         degree_res=1,
         seed=None,
-        mask=False,
+        mask=True,
     ):
         """
         Initialize object for estimating 3D orientations for molecules with C3 and C4 symmetry.
@@ -67,7 +67,7 @@ class CLSymmetryC3C4(CLOrient3D, SyncVotingMixin):
         :param degree_res: Degree resolution for estimating in-plane rotations.
         :param seed: Optional seed for RNG.
         :param mask: Option to mask `src.images` with a fuzzy mask (boolean).
-            Default, `False`, does not apply a mask.
+            Default, `True`, applies a mask.
         """
 
         super().__init__(

--- a/src/aspire/abinitio/commonline_c3_c4.py
+++ b/src/aspire/abinitio/commonline_c3_c4.py
@@ -51,6 +51,7 @@ class CLSymmetryC3C4(CLOrient3D, SyncVotingMixin):
         max_iters=1000,
         degree_res=1,
         seed=None,
+        mask=False,
     ):
         """
         Initialize object for estimating 3D orientations for molecules with C3 and C4 symmetry.
@@ -65,6 +66,8 @@ class CLSymmetryC3C4(CLOrient3D, SyncVotingMixin):
         :param max_iter: Maximum iterations for the power method.
         :param degree_res: Degree resolution for estimating in-plane rotations.
         :param seed: Optional seed for RNG.
+        :param mask: Option to mask `src.images` with a fuzzy mask (boolean).
+            Default, `False`, does not apply a mask.
         """
 
         super().__init__(
@@ -73,6 +76,7 @@ class CLSymmetryC3C4(CLOrient3D, SyncVotingMixin):
             n_theta=n_theta,
             max_shift=max_shift,
             shift_step=shift_step,
+            mask=mask,
         )
 
         self._check_symmetry(symmetry)

--- a/src/aspire/abinitio/commonline_cn.py
+++ b/src/aspire/abinitio/commonline_cn.py
@@ -40,7 +40,7 @@ class CLSymmetryCn(CLSymmetryC3C4):
         n_points_sphere=500,
         equator_threshold=10,
         seed=None,
-        mask=False,
+        mask=True,
     ):
         """
         Initialize object for estimating 3D orientations for molecules with Cn symmetry, n>4.
@@ -59,7 +59,7 @@ class CLSymmetryCn(CLSymmetryC3C4):
             degrees of being an equator image. Default is 10 degrees.
         :param seed: Optional seed for RNG.
         :param mask: Option to mask `src.images` with a fuzzy mask (boolean).
-            Default, `False`, does not apply a mask.
+            Default, `True`, applies a mask.
         """
 
         super().__init__(

--- a/src/aspire/abinitio/commonline_cn.py
+++ b/src/aspire/abinitio/commonline_cn.py
@@ -40,6 +40,7 @@ class CLSymmetryCn(CLSymmetryC3C4):
         n_points_sphere=500,
         equator_threshold=10,
         seed=None,
+        mask=False,
     ):
         """
         Initialize object for estimating 3D orientations for molecules with Cn symmetry, n>4.
@@ -57,6 +58,8 @@ class CLSymmetryCn(CLSymmetryC3C4):
         :param equator_threshold: Threshold for removing candidate rotations within `equator_threshold`
             degrees of being an equator image. Default is 10 degrees.
         :param seed: Optional seed for RNG.
+        :param mask: Option to mask `src.images` with a fuzzy mask (boolean).
+            Default, `False`, does not apply a mask.
         """
 
         super().__init__(
@@ -70,6 +73,7 @@ class CLSymmetryCn(CLSymmetryC3C4):
             max_iters=max_iters,
             degree_res=degree_res,
             seed=seed,
+            mask=mask,
         )
 
         self.n_points_sphere = n_points_sphere

--- a/src/aspire/abinitio/commonline_sync.py
+++ b/src/aspire/abinitio/commonline_sync.py
@@ -22,7 +22,9 @@ class CLSyncVoting(CLOrient3D, SyncVotingMixin):
     Journal of Structural Biology, 169, 312-322 (2010).
     """
 
-    def __init__(self, src, n_rad=None, n_theta=360, max_shift=0.15, shift_step=1):
+    def __init__(
+        self, src, n_rad=None, n_theta=360, max_shift=0.15, shift_step=1, mask=False
+    ):
         """
         Initialize an object for estimating 3D orientations using synchronization matrix
 
@@ -33,6 +35,8 @@ class CLSyncVoting(CLOrient3D, SyncVotingMixin):
         :param max_shift: Determines maximum range for shifts as a proportion
             of the resolution. Default is 0.15.
         :param shift_step: Resolution for shift estimation in pixels. Default is 1 pixel.
+        :param mask: Option to mask `src.images` with a fuzzy mask (boolean).
+            Default, `False`, does not apply a mask.
         """
         super().__init__(
             src,
@@ -40,6 +44,7 @@ class CLSyncVoting(CLOrient3D, SyncVotingMixin):
             n_theta=n_theta,
             max_shift=max_shift,
             shift_step=shift_step,
+            mask=mask,
         )
         self.syncmatrix = None
 

--- a/src/aspire/abinitio/commonline_sync.py
+++ b/src/aspire/abinitio/commonline_sync.py
@@ -23,7 +23,7 @@ class CLSyncVoting(CLOrient3D, SyncVotingMixin):
     """
 
     def __init__(
-        self, src, n_rad=None, n_theta=360, max_shift=0.15, shift_step=1, mask=False
+        self, src, n_rad=None, n_theta=360, max_shift=0.15, shift_step=1, mask=True
     ):
         """
         Initialize an object for estimating 3D orientations using synchronization matrix
@@ -36,7 +36,7 @@ class CLSyncVoting(CLOrient3D, SyncVotingMixin):
             of the resolution. Default is 0.15.
         :param shift_step: Resolution for shift estimation in pixels. Default is 1 pixel.
         :param mask: Option to mask `src.images` with a fuzzy mask (boolean).
-            Default, `False`, does not apply a mask.
+            Default, `True`, applies a mask.
         """
         super().__init__(
             src,

--- a/src/aspire/utils/__init__.py
+++ b/src/aspire/utils/__init__.py
@@ -1,7 +1,7 @@
 from .types import complex_type, real_type, utest_tolerance  # isort:skip
 from .coor_trans import (  # isort:skip
     common_line_from_rots,
-    check_rotations,
+    mean_aligned_angular_distance,
     crop_pad_2d,
     crop_pad_3d,
     get_aligned_rotations,

--- a/src/aspire/utils/__init__.py
+++ b/src/aspire/utils/__init__.py
@@ -1,6 +1,7 @@
 from .types import complex_type, real_type, utest_tolerance  # isort:skip
 from .coor_trans import (  # isort:skip
     common_line_from_rots,
+    check_rotations,
     crop_pad_2d,
     crop_pad_3d,
     get_aligned_rotations,

--- a/src/aspire/utils/coor_trans.py
+++ b/src/aspire/utils/coor_trans.py
@@ -9,6 +9,7 @@ from numpy.linalg import norm
 from scipy.linalg import svd
 
 from aspire.utils.random import Random
+from aspire.utils.rotation import Rotation
 
 
 def cart2pol(x, y):
@@ -281,6 +282,24 @@ def get_rots_mse(rots_reg, rots_ref):
         mse += diff[k] ** 2
     mse = mse / K
     return mse
+
+
+def check_rotations(rots_est, rots_gt):
+    """
+    Register estimates to ground truth rotations and compute the
+    mean angular distance between them (in degrees).
+
+    :param rots_est: A set of estimated rotations of size nx3x3.
+    :param rots_gt: A set of ground truth rotations of size nx3x3.
+
+    :return: The mean angular distance between registered estimates
+        and the ground truth (in degrees).
+    """
+    Q_mat, flag = register_rotations(rots_est, rots_gt)
+    regrot = get_aligned_rotations(rots_est, Q_mat, flag)
+    mean_ang_dist = Rotation.mean_angular_distance(regrot, rots_gt) * 180 / np.pi
+
+    return mean_ang_dist
 
 
 def common_line_from_rots(r1, r2, ell):

--- a/src/aspire/utils/coor_trans.py
+++ b/src/aspire/utils/coor_trans.py
@@ -304,7 +304,6 @@ def mean_aligned_angular_distance(rots_est, rots_gt, degree_tol=None):
 
     if degree_tol is not None:
         np.testing.assert_array_less(mean_ang_dist, degree_tol)
-        return
 
     return mean_ang_dist
 

--- a/src/aspire/utils/coor_trans.py
+++ b/src/aspire/utils/coor_trans.py
@@ -284,7 +284,7 @@ def get_rots_mse(rots_reg, rots_ref):
     return mse
 
 
-def check_rotations(rots_est, rots_gt, degree_tol=None):
+def mean_aligned_angular_distance(rots_est, rots_gt, degree_tol=None):
     """
     Register estimates to ground truth rotations and compute the
     mean angular distance between them (in degrees).

--- a/src/aspire/utils/coor_trans.py
+++ b/src/aspire/utils/coor_trans.py
@@ -284,13 +284,16 @@ def get_rots_mse(rots_reg, rots_ref):
     return mse
 
 
-def check_rotations(rots_est, rots_gt):
+def check_rotations(rots_est, rots_gt, degree_tol=None):
     """
     Register estimates to ground truth rotations and compute the
     mean angular distance between them (in degrees).
 
     :param rots_est: A set of estimated rotations of size nx3x3.
     :param rots_gt: A set of ground truth rotations of size nx3x3.
+    :param degree_tol: Option to assert if the mean angular distance is
+        less than `degree_tol` degrees. If `None`, returns the mean
+        aligned angular distance.
 
     :return: The mean angular distance between registered estimates
         and the ground truth (in degrees).
@@ -298,6 +301,10 @@ def check_rotations(rots_est, rots_gt):
     Q_mat, flag = register_rotations(rots_est, rots_gt)
     regrot = get_aligned_rotations(rots_est, Q_mat, flag)
     mean_ang_dist = Rotation.mean_angular_distance(regrot, rots_gt) * 180 / np.pi
+
+    if degree_tol is not None:
+        np.testing.assert_array_less(mean_ang_dist, degree_tol)
+        return
 
     return mean_ang_dist
 

--- a/src/aspire/utils/misc.py
+++ b/src/aspire/utils/misc.py
@@ -280,7 +280,8 @@ def fuzzy_mask(L, dtype, r0=None, risetime=None):
 
     Made with an error function with effective rise time.
 
-    :param L: The sizes of image in tuple structure.
+    :param L: The sizes of image in tuple structure. Must be 1D, 2D square,
+        or 3D cube.
     :param dtype: dtype for fuzzy mask.
     :param r0: The specified radius. Defaults to floor(0.45 * L)
     :param risetime: The rise time for `erf` function. Defaults to floor(0.05 * L)
@@ -299,12 +300,19 @@ def fuzzy_mask(L, dtype, r0=None, risetime=None):
 
     if dim == 1:
         grid = grid_1d(**grid_kwargs)
+
     elif dim == 2:
+        if not (L[0] == L[1]):
+            raise ValueError(f"A 2D fuzzy_mask must be square, found L={L}.")
         grid = grid_2d(**grid_kwargs)
         axes.append("y")
+
     elif dim == 3:
+        if not (L[0] == L[1] == L[2]):
+            raise ValueError(f"A 3D fuzzy_mask must be cubic, found L={L}.")
         grid = grid_3d(**grid_kwargs)
         axes.extend(["y", "z"])
+
     else:
         raise RuntimeError(
             f"Only 1D, 2D, or 3D fuzzy_mask supported. Found {dim}-dimensional `L`."

--- a/src/aspire/utils/misc.py
+++ b/src/aspire/utils/misc.py
@@ -274,7 +274,7 @@ def inverse_r(size, x0=0, y0=0, peak=1, dtype=np.float64):
     return (peak / vals).astype(dtype)
 
 
-def fuzzy_mask(L, r0, risetime, origin=None):
+def fuzzy_mask(L, r0, risetime, dtype, origin=None):
     """
     Create a centered 1D to 3D fuzzy mask of radius r0
 
@@ -283,6 +283,7 @@ def fuzzy_mask(L, r0, risetime, origin=None):
     :param L: The sizes of image in tuple structure
     :param r0: The specified radius
     :param risetime: The rise time for `erf` function
+    :param dtype: dtype for fuzzy mask
     :param origin: The coordinates of origin
     :return: The desired fuzzy mask
     """
@@ -291,7 +292,9 @@ def fuzzy_mask(L, r0, risetime, origin=None):
     if origin is None:
         origin = center
 
-    grids = [np.arange(1 - org, ell - org + 1) for ell, org in zip(L, origin)]
+    grids = [
+        np.arange(1 - org, ell - org + 1, dtype=dtype) for ell, org in zip(L, origin)
+    ]
     XYZ = np.meshgrid(*grids, indexing="ij")
     XYZ_sq = [X**2 for X in XYZ]
     R = np.sqrt(np.sum(XYZ_sq, axis=0))

--- a/src/aspire/utils/misc.py
+++ b/src/aspire/utils/misc.py
@@ -274,19 +274,24 @@ def inverse_r(size, x0=0, y0=0, peak=1, dtype=np.float64):
     return (peak / vals).astype(dtype)
 
 
-def fuzzy_mask(L, r0, risetime, dtype):
+def fuzzy_mask(L, dtype, r0=None, risetime=None):
     """
-    Create a centered 1D to 3D fuzzy mask of radius r0
+    Create a centered 1D to 3D fuzzy mask of radius r0.
 
     Made with an error function with effective rise time.
 
-    :param L: The sizes of image in tuple structure
-    :param r0: The specified radius
-    :param risetime: The rise time for `erf` function
-    :param dtype: dtype for fuzzy mask
+    :param L: The sizes of image in tuple structure.
+    :param dtype: dtype for fuzzy mask.
+    :param r0: The specified radius. Defaults to floor(0.45 * L)
+    :param risetime: The rise time for `erf` function. Defaults to floor(0.05 * L)
 
     :return: The desired fuzzy mask
     """
+    # Note: default values for r0 and risetime are from Matlab common-lines code.
+    if r0 is None:
+        r0 = np.floor(0.45 * L[0])
+    if risetime is None:
+        risetime = np.floor(0.05 * L[0])
 
     dim = len(L)
     axes = ["x"]

--- a/tests/test_coor_trans.py
+++ b/tests/test_coor_trans.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from aspire.utils import (
     Rotation,
+    check_rotations,
     crop_pad_2d,
     crop_pad_3d,
     get_aligned_rotations,
@@ -335,3 +336,15 @@ class UtilsTestCase(TestCase):
         a = np.ones((4, 4, 3))
         b = crop_pad_3d(a, 4, fill_value=-1)
         self.assertTrue(np.array_equal(b[:, :, 0], -1 * np.ones((4, 4))))
+
+
+def test_check_rotations():
+    n_rots = 10
+    dtype = np.float32
+    rots_gt = Rotation.generate_random_rotations(n_rots, dtype=dtype).matrices
+
+    # Create a set of rotations that can be exactly globally aligned to rots_gt.
+    rots_est = rots_gt[0] @ rots_gt
+
+    # Check that the mean angular distance is zero degrees.
+    np.testing.assert_allclose(check_rotations(rots_est, rots_gt), 0.0)

--- a/tests/test_coor_trans.py
+++ b/tests/test_coor_trans.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from aspire.utils import (
     Rotation,
-    check_rotations,
+    mean_aligned_angular_distance,
     crop_pad_2d,
     crop_pad_3d,
     get_aligned_rotations,
@@ -338,7 +338,7 @@ class UtilsTestCase(TestCase):
         self.assertTrue(np.array_equal(b[:, :, 0], -1 * np.ones((4, 4))))
 
 
-def test_check_rotations():
+def test_mean_aligned_angular_distance():
     n_rots = 10
     dtype = np.float32
     rots_gt = Rotation.generate_random_rotations(n_rots, dtype=dtype).matrices
@@ -347,4 +347,4 @@ def test_check_rotations():
     rots_est = rots_gt[0] @ rots_gt
 
     # Check that the mean angular distance is zero degrees.
-    np.testing.assert_allclose(check_rotations(rots_est, rots_gt), 0.0)
+    np.testing.assert_allclose(mean_aligned_angular_distance(rots_est, rots_gt), 0.0)

--- a/tests/test_coor_trans.py
+++ b/tests/test_coor_trans.py
@@ -5,12 +5,12 @@ import numpy as np
 
 from aspire.utils import (
     Rotation,
-    mean_aligned_angular_distance,
     crop_pad_2d,
     crop_pad_3d,
     get_aligned_rotations,
     grid_2d,
     grid_3d,
+    mean_aligned_angular_distance,
     register_rotations,
     uniform_random_angles,
 )
@@ -348,3 +348,6 @@ def test_mean_aligned_angular_distance():
 
     # Check that the mean angular distance is zero degrees.
     np.testing.assert_allclose(mean_aligned_angular_distance(rots_est, rots_gt), 0.0)
+
+    # Test internal assert using the `degree_tol` argument.
+    mean_aligned_angular_distance(rots_est, rots_gt, degree_tol=0.1)

--- a/tests/test_orient_symmetric.py
+++ b/tests/test_orient_symmetric.py
@@ -84,6 +84,7 @@ def source_orientation_objs(n_img, L, order, dtype):
         n_theta=360,
         max_shift=1 / L,
         seed=seed,
+        mask=False,
     )
 
     if order in [3, 4]:

--- a/tests/test_orient_symmetric.py
+++ b/tests/test_orient_symmetric.py
@@ -10,7 +10,7 @@ from aspire.utils import (
     J_conjugate,
     Rotation,
     all_pairs,
-    check_rotations,
+    mean_aligned_angular_distance,
     cyclic_rotations,
     randn,
     utest_tolerance,
@@ -124,7 +124,7 @@ def test_estimate_rotations(n_img, L, order, dtype):
 
     # Register estimates to ground truth rotations and compute the
     # angular distance between them (in degrees).
-    mean_ang_dist = check_rotations(rots_est, rots_gt_sync)
+    mean_ang_dist = mean_aligned_angular_distance(rots_est, rots_gt_sync)
 
     # Assert mean angular distance is reasonable.
     assert mean_ang_dist < 3

--- a/tests/test_orient_symmetric.py
+++ b/tests/test_orient_symmetric.py
@@ -6,10 +6,15 @@ from numpy.linalg import det, norm
 from aspire.abinitio import CLSymmetryC2, CLSymmetryC3C4, CLSymmetryCn
 from aspire.abinitio.commonline_cn import MeanOuterProductEstimator
 from aspire.source import Simulation
-from aspire.utils import Rotation, utest_tolerance
-from aspire.utils.coor_trans import get_aligned_rotations, register_rotations
-from aspire.utils.misc import J_conjugate, all_pairs, cyclic_rotations
-from aspire.utils.random import randn
+from aspire.utils import (
+    J_conjugate,
+    Rotation,
+    all_pairs,
+    check_rotations,
+    cyclic_rotations,
+    randn,
+    utest_tolerance,
+)
 from aspire.volume import CnSymmetricVolume
 
 # A set of these parameters are marked expensive to reduce testing time.
@@ -119,9 +124,7 @@ def test_estimate_rotations(n_img, L, order, dtype):
 
     # Register estimates to ground truth rotations and compute the
     # angular distance between them (in degrees).
-    Q_mat, flag = register_rotations(rots_est, rots_gt_sync)
-    regrot = get_aligned_rotations(rots_est, Q_mat, flag)
-    mean_ang_dist = Rotation.mean_angular_distance(regrot, rots_gt_sync) * 180 / np.pi
+    mean_ang_dist = check_rotations(rots_est, rots_gt_sync)
 
     # Assert mean angular distance is reasonable.
     assert mean_ang_dist < 3

--- a/tests/test_orient_symmetric.py
+++ b/tests/test_orient_symmetric.py
@@ -10,8 +10,8 @@ from aspire.utils import (
     J_conjugate,
     Rotation,
     all_pairs,
-    mean_aligned_angular_distance,
     cyclic_rotations,
+    mean_aligned_angular_distance,
     randn,
     utest_tolerance,
 )
@@ -122,12 +122,9 @@ def test_estimate_rotations(n_img, L, order, dtype):
     # g-synchronize ground truth rotations.
     rots_gt_sync = cl_symm.g_sync(rots_est, order, rots_gt)
 
-    # Register estimates to ground truth rotations and compute the
-    # angular distance between them (in degrees).
-    mean_ang_dist = mean_aligned_angular_distance(rots_est, rots_gt_sync)
-
-    # Assert mean angular distance is reasonable.
-    assert mean_ang_dist < 3
+    # Register estimates to ground truth rotations and check that the
+    # mean angular distance between them is less than 3 degrees.
+    mean_aligned_angular_distance(rots_est, rots_gt_sync, degree_tol=3)
 
 
 @pytest.mark.parametrize("n_img, L, order, dtype", param_list_c3_c4)

--- a/tests/test_orient_sync_voting.py
+++ b/tests/test_orient_sync_voting.py
@@ -144,7 +144,11 @@ def test_estimate_rotations_fuzzy_mask():
         orient_est_fuzzy.rotations, noisy_src.rotations
     )
 
-    assert mean_angle_dist_fuzzy < mean_angle_dist < 10
+    # Check that the estimate is reasonable, ie. mean_angle_dist < 10 degrees.
+    np.testing.assert_array_less(mean_angle_dist, 10)
+
+    # Check that fuzzy_mask improves the estimate.
+    np.testing.assert_array_less(mean_angle_dist_fuzzy, mean_angle_dist)
 
 
 def test_theta_error():

--- a/tests/test_orient_sync_voting.py
+++ b/tests/test_orient_sync_voting.py
@@ -117,11 +117,11 @@ def test_estimate_shifts(source_orientation_objs):
 
 def test_estimate_rotations_fuzzy_mask():
     noisy_src = Simulation(
-        n=30,
-        vols=AsymmetricVolume(L=40, C=1, K=100, seed=0).generate(),
+        n=35,
+        vols=AsymmetricVolume(L=128, C=1, K=400, seed=0).generate(),
         offsets=0,
         amplitudes=1,
-        noise_adder=WhiteNoiseAdder.from_snr(snr=5),
+        noise_adder=WhiteNoiseAdder.from_snr(snr=2),
         seed=0,
     )
 
@@ -145,7 +145,7 @@ def test_estimate_rotations_fuzzy_mask():
         orient_est_fuzzy.rotations, noisy_src.rotations
     )
 
-    assert mean_angle_dist_fuzzy < mean_angle_dist
+    assert mean_angle_dist_fuzzy < mean_angle_dist < 10
 
 
 def test_theta_error():

--- a/tests/test_orient_sync_voting.py
+++ b/tests/test_orient_sync_voting.py
@@ -10,7 +10,7 @@ from aspire.abinitio import CLOrient3D, CLSyncVoting
 from aspire.commands.orient3d import orient3d
 from aspire.noise import WhiteNoiseAdder
 from aspire.source import Simulation
-from aspire.utils import Rotation, check_rotations, rots_to_clmatrix
+from aspire.utils import check_rotations, rots_to_clmatrix
 from aspire.volume import AsymmetricVolume
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "saved_test_data")

--- a/tests/test_orient_sync_voting.py
+++ b/tests/test_orient_sync_voting.py
@@ -69,7 +69,9 @@ def source_orientation_objs(resolution, offsets, dtype):
     if src.offsets.all() != 0:
         max_shift = 0.20
         shift_step = 0.25  # Reduce shift steps for non-integer offsets of Simulation.
-    orient_est = CLSyncVoting(src, max_shift=max_shift, shift_step=shift_step)
+    orient_est = CLSyncVoting(
+        src, max_shift=max_shift, shift_step=shift_step, mask=False
+    )
 
     return src, orient_est
 
@@ -131,12 +133,14 @@ def test_estimate_rotations_fuzzy_mask():
     # Orientation estimation without fuzzy_mask.
     max_shift = 1 / noisy_src.L
     shift_step = 1
-    orient_est = CLSyncVoting(noisy_src, max_shift=max_shift, shift_step=shift_step)
+    orient_est = CLSyncVoting(
+        noisy_src, max_shift=max_shift, shift_step=shift_step, mask=False
+    )
     orient_est.estimate_rotations()
 
     # Orientation estimation with fuzzy mask.
     orient_est_fuzzy = CLSyncVoting(
-        noisy_src, max_shift=max_shift, shift_step=shift_step, mask=True
+        noisy_src, max_shift=max_shift, shift_step=shift_step
     )
     orient_est_fuzzy.estimate_rotations()
 

--- a/tests/test_orient_sync_voting.py
+++ b/tests/test_orient_sync_voting.py
@@ -96,12 +96,9 @@ def test_estimate_rotations(source_orientation_objs):
     orient_est.estimate_rotations()
 
     # Register estimates to ground truth rotations and compute the
-    # angular distance between them (in degrees).
-    mean_ang_dist = mean_aligned_angular_distance(orient_est.rotations, src.rotations)
-
-    # Assert that mean angular distance is less than 1 degree (5 degrees with shifts).
-    degree_tol = 1
-    assert mean_ang_dist < degree_tol
+    # mean angular distance between them (in degrees).
+    # Assert that mean angular distance is less than 1 degree.
+    mean_aligned_angular_distance(orient_est.rotations, src.rotations, degree_tol=1)
 
 
 def test_estimate_shifts(source_orientation_objs):
@@ -140,7 +137,9 @@ def test_estimate_rotations_fuzzy_mask():
     orient_est_fuzzy.estimate_rotations()
 
     # Check that fuzzy_mask improves orientation estimation.
-    mean_angle_dist = mean_aligned_angular_distance(orient_est.rotations, noisy_src.rotations)
+    mean_angle_dist = mean_aligned_angular_distance(
+        orient_est.rotations, noisy_src.rotations
+    )
     mean_angle_dist_fuzzy = mean_aligned_angular_distance(
         orient_est_fuzzy.rotations, noisy_src.rotations
     )

--- a/tests/test_orient_sync_voting.py
+++ b/tests/test_orient_sync_voting.py
@@ -10,12 +10,7 @@ from aspire.abinitio import CLOrient3D, CLSyncVoting
 from aspire.commands.orient3d import orient3d
 from aspire.noise import WhiteNoiseAdder
 from aspire.source import Simulation
-from aspire.utils import (
-    Rotation,
-    get_aligned_rotations,
-    register_rotations,
-    rots_to_clmatrix,
-)
+from aspire.utils import Rotation, check_rotations, rots_to_clmatrix
 from aspire.volume import AsymmetricVolume
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "saved_test_data")
@@ -195,13 +190,3 @@ def test_command_line():
         )
         # check that the command completed successfully
         assert result.exit_code == 0
-
-
-def check_rotations(rots_est, rots_gt):
-    # Register estimates to ground truth rotations and compute the
-    # angular distance between them (in degrees).
-    Q_mat, flag = register_rotations(rots_est, rots_gt)
-    regrot = get_aligned_rotations(rots_est, Q_mat, flag)
-    mean_ang_dist = Rotation.mean_angular_distance(regrot, rots_gt) * 180 / np.pi
-
-    return mean_ang_dist

--- a/tests/test_orient_sync_voting.py
+++ b/tests/test_orient_sync_voting.py
@@ -10,7 +10,7 @@ from aspire.abinitio import CLOrient3D, CLSyncVoting
 from aspire.commands.orient3d import orient3d
 from aspire.noise import WhiteNoiseAdder
 from aspire.source import Simulation
-from aspire.utils import check_rotations, rots_to_clmatrix
+from aspire.utils import mean_aligned_angular_distance, rots_to_clmatrix
 from aspire.volume import AsymmetricVolume
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "saved_test_data")
@@ -97,7 +97,7 @@ def test_estimate_rotations(source_orientation_objs):
 
     # Register estimates to ground truth rotations and compute the
     # angular distance between them (in degrees).
-    mean_ang_dist = check_rotations(orient_est.rotations, src.rotations)
+    mean_ang_dist = mean_aligned_angular_distance(orient_est.rotations, src.rotations)
 
     # Assert that mean angular distance is less than 1 degree (5 degrees with shifts).
     degree_tol = 1
@@ -140,8 +140,8 @@ def test_estimate_rotations_fuzzy_mask():
     orient_est_fuzzy.estimate_rotations()
 
     # Check that fuzzy_mask improves orientation estimation.
-    mean_angle_dist = check_rotations(orient_est.rotations, noisy_src.rotations)
-    mean_angle_dist_fuzzy = check_rotations(
+    mean_angle_dist = mean_aligned_angular_distance(orient_est.rotations, noisy_src.rotations)
+    mean_angle_dist_fuzzy = mean_aligned_angular_distance(
         orient_est_fuzzy.rotations, noisy_src.rotations
     )
 

--- a/tests/test_oriented_source.py
+++ b/tests/test_oriented_source.py
@@ -39,7 +39,7 @@ def src_fixture(request):
 
     # Generate an origianl source and an oriented source.
     og_src = Simulation(L=L, n=n, vols=vol, offsets=0)
-    orient_est = estimator(og_src, max_shift=1 / L, **estimator_kwargs)
+    orient_est = estimator(og_src, max_shift=1 / L, mask=False, **estimator_kwargs)
     oriented_src = OrientedSource(og_src, orient_est)
 
     return og_src, oriented_src

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -355,7 +355,7 @@ def test_fuzzy_mask():
 
     # Smoke test for 1D, 2D, and 3D fuzzy_mask.
     for dim in range(1, 4):
-        _ = fuzzy_mask((8,) * dim, np.float32)
+        _ = fuzzy_mask((32,) * dim, np.float32)
 
     # Check that we raise an error for bad dimension.
     with pytest.raises(RuntimeError, match=r"Only 1D, 2D, or 3D fuzzy_mask*"):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -350,8 +350,16 @@ def test_fuzzy_mask():
             ],
         ]
     )
-    fmask = fuzzy_mask((8, 8), dtype=results.dtype, r0=2, risetime=2)
+    fmask = fuzzy_mask((8, 8), results.dtype, r0=2, risetime=2)
     assert np.allclose(results, fmask, atol=1e-7)
+
+    # Smoke test for 1D, 2D, and 3D fuzzy_mask.
+    for dim in range(1, 4):
+        _ = fuzzy_mask((8,) * dim, np.float32)
+
+    # Check that we raise an error for bad dimension.
+    with pytest.raises(RuntimeError, match=r"Only 1D, 2D, or 3D fuzzy_mask*"):
+        _ = fuzzy_mask((8,) * 4, np.float32)
 
 
 def test_multiprocessing_utils():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -351,7 +351,7 @@ def test_fuzzy_mask():
         ]
     )
     fmask = fuzzy_mask((8, 8), results.dtype, r0=2, risetime=2)
-    assert np.allclose(results, fmask, atol=1e-7)
+    np.testing.assert_allclose(results, fmask, atol=1e-7)
 
     # Smoke test for 1D, 2D, and 3D fuzzy_mask.
     for dim in range(1, 4):
@@ -360,6 +360,14 @@ def test_fuzzy_mask():
     # Check that we raise an error for bad dimension.
     with pytest.raises(RuntimeError, match=r"Only 1D, 2D, or 3D fuzzy_mask*"):
         _ = fuzzy_mask((8,) * 4, np.float32)
+
+    # Check we raise for bad 2D shape.
+    with pytest.raises(ValueError, match=r"A 2D fuzzy_mask must be square*"):
+        _ = fuzzy_mask((2, 3), np.float32)
+
+    # Check we raise for bad 3D shape.
+    with pytest.raises(ValueError, match=r"A 3D fuzzy_mask must be cubic*"):
+        _ = fuzzy_mask((2, 3, 3), np.float32)
 
 
 def test_multiprocessing_utils():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -350,7 +350,7 @@ def test_fuzzy_mask():
             ],
         ]
     )
-    fmask = fuzzy_mask((8, 8), 2, 2)
+    fmask = fuzzy_mask((8, 8), 2, 2, dtype=results.dtype)
     assert np.allclose(results, fmask, atol=1e-7)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -350,7 +350,7 @@ def test_fuzzy_mask():
             ],
         ]
     )
-    fmask = fuzzy_mask((8, 8), 2, 2, dtype=results.dtype)
+    fmask = fuzzy_mask((8, 8), dtype=results.dtype, r0=2, risetime=2)
     assert np.allclose(results, fmask, atol=1e-7)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -68,6 +68,7 @@ per-file-ignores =
   __init__.py: F401
  gallery/tutorials/aspire_introduction.py: T201, F401, E402
  gallery/tutorials/configuration.py: T201, E402
+ gallery/tutorials/pipeline_demo.py: T201
  gallery/tutorials/turorials/data_downloader.py: E402
  gallery/tutorials/tutorials/ctf.py: T201, E402
  gallery/tutorials/tutorials/micrograph_source.py: T201, E402


### PR DESCRIPTION
This PR implements an optional use of `fuzzy_mask` to mask projection images prior to common line detection (ie. prior to taking the polar Fourier transform). This appears to improve common line detection for noisy images (see issue https://github.com/ComputationalCryoEM/ASPIRE-Python/issues/861). My guess is that this might not improve common line detection when using class averages since the ears of the images are already masked off.

This implementation currently uses a boolean mask parameter to optionally enable the `fuzzy_mask`. The default is set to True which uses the mask. With the `fuzzy_mask` enabled, the mask uses default parameters found in the Matlab code.

An alternative implementation could be to have a user provide a configured `fuzzy_mask`.

closes https://github.com/ComputationalCryoEM/ASPIRE-Python/issues/861