### PR TITLE
Cov2D denoiser cleanup.

### DIFF
--- a/gallery/experiments/experimental_abinitio_pipeline_10028.py
+++ b/gallery/experiments/experimental_abinitio_pipeline_10028.py
@@ -30,7 +30,7 @@ import numpy as np
 
 from aspire.abinitio import CLSyncVoting
 from aspire.basis import FFBBasis3D
-from aspire.denoising import DefaultClassAvgSource, DenoisedImageSource, DenoiserCov2D
+from aspire.denoising import DefaultClassAvgSource, DenoisedSource, DenoiserCov2D
 from aspire.noise import AnisotropicNoiseEstimator
 from aspire.reconstruction import MeanEstimator
 from aspire.source import OrientedSource, RelionSource
@@ -121,7 +121,7 @@ if do_cov2d:
     # Use CWF denoising
     cwf_denoiser = DenoiserCov2D(src)
     # Use denoised src for classification
-    classification_src = DenoisedImageSource(src, cwf_denoiser)
+    classification_src = DenoisedSource(src, cwf_denoiser)
     # Cache for speedup.  Avoids recomputing.
     classification_src = classification_src.cache()
     # Peek, what do the denoised images look like...

--- a/gallery/experiments/experimental_abinitio_pipeline_10028.py
+++ b/gallery/experiments/experimental_abinitio_pipeline_10028.py
@@ -121,7 +121,7 @@ if do_cov2d:
     # Use CWF denoising
     cwf_denoiser = DenoiserCov2D(src)
     # Use denoised src for classification
-    classification_src = DenoisedSource(src, cwf_denoiser)
+    classification_src = DenoisedSource(cwf_denoiser)
     # Cache for speedup.  Avoids recomputing.
     classification_src = classification_src.cache()
     # Peek, what do the denoised images look like...

--- a/gallery/experiments/experimental_abinitio_pipeline_10028.py
+++ b/gallery/experiments/experimental_abinitio_pipeline_10028.py
@@ -30,7 +30,7 @@ import numpy as np
 
 from aspire.abinitio import CLSyncVoting
 from aspire.basis import FFBBasis3D
-from aspire.denoising import DefaultClassAvgSource, DenoiserCov2D, DenoisedImageSource
+from aspire.denoising import DefaultClassAvgSource, DenoisedImageSource, DenoiserCov2D
 from aspire.noise import AnisotropicNoiseEstimator
 from aspire.reconstruction import MeanEstimator
 from aspire.source import OrientedSource, RelionSource

--- a/gallery/experiments/experimental_abinitio_pipeline_10028.py
+++ b/gallery/experiments/experimental_abinitio_pipeline_10028.py
@@ -30,7 +30,7 @@ import numpy as np
 
 from aspire.abinitio import CLSyncVoting
 from aspire.basis import FFBBasis3D
-from aspire.denoising import DefaultClassAvgSource, DenoiserCov2D
+from aspire.denoising import DefaultClassAvgSource, DenoiserCov2D, DenoisedImageSource
 from aspire.noise import AnisotropicNoiseEstimator
 from aspire.reconstruction import MeanEstimator
 from aspire.source import OrientedSource, RelionSource
@@ -121,7 +121,7 @@ if do_cov2d:
     # Use CWF denoising
     cwf_denoiser = DenoiserCov2D(src)
     # Use denoised src for classification
-    classification_src = cwf_denoiser.denoise()
+    classification_src = DenoisedImageSource(src, cwf_denoiser)
     # Cache for speedup.  Avoids recomputing.
     classification_src = classification_src.cache()
     # Peek, what do the denoised images look like...

--- a/gallery/experiments/experimental_abinitio_pipeline_10028.py
+++ b/gallery/experiments/experimental_abinitio_pipeline_10028.py
@@ -121,7 +121,7 @@ if do_cov2d:
     # Use CWF denoising
     cwf_denoiser = DenoiserCov2D(src)
     # Use denoised src for classification
-    classification_src = DenoisedSource(cwf_denoiser)
+    classification_src = DenoisedSource(src, cwf_denoiser)
     # Cache for speedup.  Avoids recomputing.
     classification_src = classification_src.cache()
     # Peek, what do the denoised images look like...

--- a/gallery/experiments/simulated_abinitio_pipeline.py
+++ b/gallery/experiments/simulated_abinitio_pipeline.py
@@ -22,7 +22,7 @@ import numpy as np
 
 from aspire.abinitio import CLSyncVoting
 from aspire.basis import FFBBasis3D
-from aspire.denoising import DefaultClassAvgSource, DenoiserCov2D
+from aspire.denoising import DefaultClassAvgSource, DenoisedImageSource, DenoiserCov2D
 from aspire.downloader import emdb_2660
 from aspire.noise import AnisotropicNoiseEstimator, CustomNoiseAdder
 from aspire.operators import FunctionFilter, RadialCTFFilter
@@ -145,7 +145,7 @@ if do_cov2d:
     # Use CWF denoising
     cwf_denoiser = DenoiserCov2D(src)
     # Use denoised src for classification
-    classification_src = cwf_denoiser.denoise()
+    classification_src = DenoisedImageSource(src, cwf_denoiser)
     # Peek, what do the denoised images look like...
     if interactive:
         classification_src.images[:10].show()

--- a/gallery/experiments/simulated_abinitio_pipeline.py
+++ b/gallery/experiments/simulated_abinitio_pipeline.py
@@ -22,7 +22,7 @@ import numpy as np
 
 from aspire.abinitio import CLSyncVoting
 from aspire.basis import FFBBasis3D
-from aspire.denoising import DefaultClassAvgSource, DenoisedImageSource, DenoiserCov2D
+from aspire.denoising import DefaultClassAvgSource, DenoisedSource, DenoiserCov2D
 from aspire.downloader import emdb_2660
 from aspire.noise import AnisotropicNoiseEstimator, CustomNoiseAdder
 from aspire.operators import FunctionFilter, RadialCTFFilter
@@ -145,7 +145,7 @@ if do_cov2d:
     # Use CWF denoising
     cwf_denoiser = DenoiserCov2D(src)
     # Use denoised src for classification
-    classification_src = DenoisedImageSource(src, cwf_denoiser)
+    classification_src = DenoisedSource(src, cwf_denoiser)
     # Peek, what do the denoised images look like...
     if interactive:
         classification_src.images[:10].show()

--- a/gallery/experiments/simulated_abinitio_pipeline.py
+++ b/gallery/experiments/simulated_abinitio_pipeline.py
@@ -145,7 +145,7 @@ if do_cov2d:
     # Use CWF denoising
     cwf_denoiser = DenoiserCov2D(src)
     # Use denoised src for classification
-    classification_src = DenoisedSource(src, cwf_denoiser)
+    classification_src = DenoisedSource(cwf_denoiser)
     # Peek, what do the denoised images look like...
     if interactive:
         classification_src.images[:10].show()

--- a/gallery/experiments/simulated_abinitio_pipeline.py
+++ b/gallery/experiments/simulated_abinitio_pipeline.py
@@ -145,7 +145,7 @@ if do_cov2d:
     # Use CWF denoising
     cwf_denoiser = DenoiserCov2D(src)
     # Use denoised src for classification
-    classification_src = DenoisedSource(cwf_denoiser)
+    classification_src = DenoisedSource(src, cwf_denoiser)
     # Peek, what do the denoised images look like...
     if interactive:
         classification_src.images[:10].show()

--- a/src/aspire/commands/denoise.py
+++ b/src/aspire/commands/denoise.py
@@ -4,7 +4,7 @@ import click
 
 from aspire.basis import FFBBasis2D
 from aspire.commands import log_level_option
-from aspire.denoising.denoiser_cov2d import DenoiserCov2D
+from aspire.denoising import DenoiserCov2D, DenoisedImageSource
 from aspire.noise import AnisotropicNoiseEstimator, WhiteNoiseEstimator
 from aspire.source.relion import RelionSource
 from aspire.utils.logging import setConsoleLoggingLevel
@@ -101,7 +101,7 @@ def denoise(
     if denoise_method == "CWF":
         logger.info("Denoise the images using CWF cov2D method.")
         denoiser = DenoiserCov2D(source, basis)
-        denoised_src = denoiser.denoise(batch_size=512)
+        denoised_src = DenoisedImageSource(source, denoiser)
         denoised_src.save(
             starfile_out, batch_size=512, save_mode="single", overwrite=False
         )

--- a/src/aspire/commands/denoise.py
+++ b/src/aspire/commands/denoise.py
@@ -4,7 +4,7 @@ import click
 
 from aspire.basis import FFBBasis2D
 from aspire.commands import log_level_option
-from aspire.denoising import DenoisedImageSource, DenoiserCov2D
+from aspire.denoising import DenoisedSource, DenoiserCov2D
 from aspire.noise import AnisotropicNoiseEstimator, WhiteNoiseEstimator
 from aspire.source.relion import RelionSource
 from aspire.utils.logging import setConsoleLoggingLevel
@@ -101,7 +101,7 @@ def denoise(
     if denoise_method == "CWF":
         logger.info("Denoise the images using CWF cov2D method.")
         denoiser = DenoiserCov2D(source, basis)
-        denoised_src = DenoisedImageSource(source, denoiser)
+        denoised_src = DenoisedSource(source, denoiser)
         denoised_src.save(
             starfile_out, batch_size=512, save_mode="single", overwrite=False
         )

--- a/src/aspire/commands/denoise.py
+++ b/src/aspire/commands/denoise.py
@@ -101,7 +101,7 @@ def denoise(
     if denoise_method == "CWF":
         logger.info("Denoise the images using CWF cov2D method.")
         denoiser = DenoiserCov2D(source, basis)
-        denoised_src = DenoisedSource(denoiser)
+        denoised_src = DenoisedSource(source, denoiser)
         denoised_src.save(
             starfile_out, batch_size=512, save_mode="single", overwrite=False
         )

--- a/src/aspire/commands/denoise.py
+++ b/src/aspire/commands/denoise.py
@@ -4,7 +4,7 @@ import click
 
 from aspire.basis import FFBBasis2D
 from aspire.commands import log_level_option
-from aspire.denoising import DenoiserCov2D, DenoisedImageSource
+from aspire.denoising import DenoisedImageSource, DenoiserCov2D
 from aspire.noise import AnisotropicNoiseEstimator, WhiteNoiseEstimator
 from aspire.source.relion import RelionSource
 from aspire.utils.logging import setConsoleLoggingLevel

--- a/src/aspire/commands/denoise.py
+++ b/src/aspire/commands/denoise.py
@@ -101,7 +101,7 @@ def denoise(
     if denoise_method == "CWF":
         logger.info("Denoise the images using CWF cov2D method.")
         denoiser = DenoiserCov2D(source, basis)
-        denoised_src = DenoisedSource(source, denoiser)
+        denoised_src = DenoisedSource(denoiser)
         denoised_src.save(
             starfile_out, batch_size=512, save_mode="single", overwrite=False
         )

--- a/src/aspire/denoising/__init__.py
+++ b/src/aspire/denoising/__init__.py
@@ -4,6 +4,6 @@ from .class_avg import ClassAvgSource, DebugClassAvgSource, DefaultClassAvgSourc
 # isort: off
 from .denoiser import Denoiser
 from .denoiser_cov2d import DenoiserCov2D, src_wiener_coords
-from .denoised_src import DenoisedImageSource
+from .denoised_src import DenoisedSource
 
 # isort: on

--- a/src/aspire/denoising/__init__.py
+++ b/src/aspire/denoising/__init__.py
@@ -1,5 +1,9 @@
 from .adaptive_support import adaptive_support
 from .class_avg import ClassAvgSource, DebugClassAvgSource, DefaultClassAvgSource
-from .denoised_src import DenoisedImageSource
+
+# isort: off
 from .denoiser import Denoiser
 from .denoiser_cov2d import DenoiserCov2D, src_wiener_coords
+from .denoised_src import DenoisedImageSource
+
+# isort: on

--- a/src/aspire/denoising/denoised_src.py
+++ b/src/aspire/denoising/denoised_src.py
@@ -6,7 +6,7 @@ from aspire.source import ImageSource
 logger = logging.getLogger(__name__)
 
 
-class DenoisedImageSource(ImageSource):
+class DenoisedSource(ImageSource):
     """
     `ImageSource` class serving denoised 2D images.
     """

--- a/src/aspire/denoising/denoised_src.py
+++ b/src/aspire/denoising/denoised_src.py
@@ -1,8 +1,6 @@
 import logging
 
-import numpy as np
-
-from aspire.image import Image
+from aspire.denoising import Denoiser
 from aspire.source import ImageSource
 
 logger = logging.getLogger(__name__)
@@ -10,22 +8,22 @@ logger = logging.getLogger(__name__)
 
 class DenoisedImageSource(ImageSource):
     """
-    Define a derived ImageSource class to perform operations for denoised 2D images
+    ImageSource class serving denoised 2D images.
     """
 
-    def __init__(self, src, denoiser, batch_size=512):
+    def __init__(self, src, denoiser):
         """
-        Initialize a denoised ImageSource object from original ImageSource of noisy images
+        Initialize a denoised ImageSource object from an ImageSource.
 
         :param src: Original ImageSource object storing noisy images
         :param denoiser: A Denoiser object for specifying a method for denoising
-        :param batch_size: Batch size for loading denoised images.
         """
 
         super().__init__(src.L, src.n, dtype=src.dtype, metadata=src._metadata.copy())
-        self._im = None
+        # TODO, we can probably setup a reasonable default here.
         self.denoiser = denoiser
-        self.batch_size = batch_size
+        if not isinstance(denoiser, Denoiser):
+            raise TypeError("`denoiser` must be subclass of `Denoiser`")
 
         # Any further operations should not mutate this instance.
         self._mutable = False
@@ -36,8 +34,9 @@ class DenoisedImageSource(ImageSource):
         `ImageSource.images` property.
 
         :param indices: The indices of images to return as a 1-D NumPy array.
-        :return: an `Image` object after denoisng.
+        :return: an `Image` object after denoising.
         """
+
         # check for cached images first
         if self._cached_im is not None:
             logger.info("Loading images from cache")
@@ -45,23 +44,7 @@ class DenoisedImageSource(ImageSource):
                 self._cached_im[indices, :, :], indices
             )
 
-        # start and end (and indices) refer to the indices in the DenoisedImageSource
-        # that are being denoised and returned in batches
-        start = indices.min()
-        end = indices.max()
-
-        nimgs = len(indices)
-        im = np.empty((nimgs, self.L, self.L), self.dtype)
-
-        # If we request less than a whole batch, don't crash
-        batch_size = min(nimgs, self.batch_size)
-
-        logger.info(f"Loading {nimgs} images complete")
-        for batch_start in range(start, end + 1, batch_size):
-            imgs_denoised = self.denoiser.images(batch_start, batch_size)
-            batch_end = min(batch_start + batch_size, end + 1)
-            # we subtract start here to correct for any offset in the indices
-            im[batch_start - start : batch_end - start] = imgs_denoised.asnumpy()
+        imgs_denoised = self.denoiser.denoise[indices]
 
         # Finally, apply transforms to resulting Image
-        return self.generation_pipeline.forward(Image(im), indices)
+        return self.generation_pipeline.forward(imgs_denoised, indices)

--- a/src/aspire/denoising/denoised_src.py
+++ b/src/aspire/denoising/denoised_src.py
@@ -25,6 +25,13 @@ class DenoisedSource(ImageSource):
         if not isinstance(denoiser, Denoiser):
             raise TypeError("`denoiser` must be subclass of `Denoiser`")
 
+        # Safety check src and self.denoiser.src are the same.
+        # See #1020
+        if src != self.denoiser.src:
+            raise NotImplementedError(
+                "Denoiser `src` and noisy image `src` must match."
+            )
+
         # Any further operations should not mutate this instance.
         self._mutable = False
 

--- a/src/aspire/denoising/denoised_src.py
+++ b/src/aspire/denoising/denoised_src.py
@@ -11,16 +11,19 @@ class DenoisedSource(ImageSource):
     `ImageSource` class serving denoised 2D images.
     """
 
-    def __init__(self, src, denoiser):
+    def __init__(self, denoiser):
         """
         Initialize a denoised `ImageSource` object from an `ImageSource`.
 
-        :param src: Original `ImageSource` object storing noisy images
         :param denoiser: A `Denoiser` object for specifying a method for denoising
         """
-
-        super().__init__(src.L, src.n, dtype=src.dtype, metadata=src._metadata.copy())
-        # TODO, we can probably setup a reasonable default here.
+        self.src = denoiser.src
+        super().__init__(
+            self.src.L,
+            self.src.n,
+            dtype=self.src.dtype,
+            metadata=self.src._metadata.copy(),
+        )
         self.denoiser = denoiser
         if not isinstance(denoiser, Denoiser):
             raise TypeError("`denoiser` must be subclass of `Denoiser`")

--- a/src/aspire/denoising/denoised_src.py
+++ b/src/aspire/denoising/denoised_src.py
@@ -8,15 +8,15 @@ logger = logging.getLogger(__name__)
 
 class DenoisedImageSource(ImageSource):
     """
-    ImageSource class serving denoised 2D images.
+    `ImageSource` class serving denoised 2D images.
     """
 
     def __init__(self, src, denoiser):
         """
-        Initialize a denoised ImageSource object from an ImageSource.
+        Initialize a denoised `ImageSource` object from an `ImageSource`.
 
-        :param src: Original ImageSource object storing noisy images
-        :param denoiser: A Denoiser object for specifying a method for denoising
+        :param src: Original `ImageSource` object storing noisy images
+        :param denoiser: A `Denoiser` object for specifying a method for denoising
         """
 
         super().__init__(src.L, src.n, dtype=src.dtype, metadata=src._metadata.copy())
@@ -33,7 +33,7 @@ class DenoisedImageSource(ImageSource):
         Internal function to return a set of images after denoising, when accessed via the
         `ImageSource.images` property.
 
-        :param indices: The indices of images to return as a 1-D NumPy array.
+        :param indices: The indices of images to return as a 1-D Numpy array.
         :return: an `Image` object after denoising.
         """
 

--- a/src/aspire/denoising/denoised_src.py
+++ b/src/aspire/denoising/denoised_src.py
@@ -11,19 +11,16 @@ class DenoisedSource(ImageSource):
     `ImageSource` class serving denoised 2D images.
     """
 
-    def __init__(self, denoiser):
+    def __init__(self, src, denoiser):
         """
         Initialize a denoised `ImageSource` object from an `ImageSource`.
 
+        :param src: Original `ImageSource` object storing noisy images
         :param denoiser: A `Denoiser` object for specifying a method for denoising
         """
-        self.src = denoiser.src
-        super().__init__(
-            self.src.L,
-            self.src.n,
-            dtype=self.src.dtype,
-            metadata=self.src._metadata.copy(),
-        )
+
+        super().__init__(src.L, src.n, dtype=src.dtype, metadata=src._metadata.copy())
+        # TODO, we can probably setup a reasonable default here.
         self.denoiser = denoiser
         if not isinstance(denoiser, Denoiser):
             raise TypeError("`denoiser` must be subclass of `Denoiser`")

--- a/src/aspire/denoising/denoiser.py
+++ b/src/aspire/denoising/denoiser.py
@@ -1,5 +1,5 @@
 import logging
-from abc import ABC, abstractproperty
+from abc import ABC, abstractmethod
 
 from aspire.source.image import _ImageAccessor
 
@@ -32,7 +32,7 @@ class Denoiser(ABC):
         """
         return self._img_accessor
 
-    @abstractproperty
+    @abstractmethod
     def _denoise(self, indices):
         """
         Subclasses must implement a private `_denoise` method accepting `indices`.

--- a/src/aspire/denoising/denoiser.py
+++ b/src/aspire/denoising/denoiser.py
@@ -1,31 +1,42 @@
 import logging
+from abc import ABC, abstractproperty
+
+from aspire.source.image import _ImageAccessor
 
 logger = logging.getLogger(__name__)
 
 
-class Denoiser:
+class Denoiser(ABC):
     """
-    Define a base class for denoising 2D images
+    Base class for 2D image denoisers.
     """
 
     def __init__(self, src):
         """
-        Initialize an object for denoising 2D images from the image source
+        Initialize an object for denoising 2D images from `src`.
 
-        :param src: The source object of 2D images with metadata
+        :param src: `ImageSource` providing noisy images.
         """
+
         self.src = src
         self.dtype = src.dtype
-        self.nimg = src.n
+        self.n = src.n
+        self._img_accessor = _ImageAccessor(self._denoise, self.n)
 
+    @property
     def denoise(self):
         """
-        Precompute for Denoiser and DenoisedImageSource for 2D images
-        """
-        raise NotImplementedError("subclasses must implement this")
+        Subscriptable property returning 2D images after denoising.
 
-    def image(self, istart=0, batch_size=512):
+        See `_ImageAccessor`.
         """
-        Obtain a batch size of 2D images after denosing by a specified method
+        self._img_accessor
+
+    @abstractproperty
+    def _denoise(self, indices):
         """
-        raise NotImplementedError("subclasses must implement this")
+        Subclasses must implement a private `_denoise` method accepting `indices`.
+        Subclasses handle any caching as well as denoising.
+
+        See `_ImageAccessor`.
+        """

--- a/src/aspire/denoising/denoiser.py
+++ b/src/aspire/denoising/denoiser.py
@@ -30,7 +30,7 @@ class Denoiser(ABC):
 
         See `_ImageAccessor`.
         """
-        self._img_accessor
+        return self._img_accessor
 
     @abstractproperty
     def _denoise(self, indices):

--- a/src/aspire/denoising/denoiser_cov2d.py
+++ b/src/aspire/denoising/denoiser_cov2d.py
@@ -1,4 +1,5 @@
 import logging
+from copy import deepcopy
 
 import numpy as np
 from numpy.linalg import solve
@@ -103,6 +104,16 @@ class DenoiserCov2D(Denoiser):
     Define a derived class for denoising 2D images using Cov2D method
     """
 
+    # Default options for cov2d configuration.
+    default_opt = {
+        "shrinker": "frobenius_norm",
+        "verbose": 0,
+        "max_iter": 250,
+        "iter_callback": [],
+        "store_iterates": False,
+        "rel_tolerance": 1e-12,
+    }
+
     def __init__(self, src, basis=None, var_noise=None, batch_size=512, covar_opt=None):
         """
         Initialize an object for denoising 2D images using Cov2D method
@@ -110,8 +121,10 @@ class DenoiserCov2D(Denoiser):
         :param src: The source object of 2D images with metadata
         :param basis: The basis method to expand 2D images
         :param var_noise: The estimated variance of noise
-        :param batch_size: The batch size for processing images
-        :param covar_opt: The option list for building Cov2D matrix
+        :param batch_size: Integer batch size for processing images.
+            Defaults to 512.
+        :param covar_opt: Optional dictionary of option overides for Cov2D.
+            Provided options will supersede defaults in `DenoiserCov2D.default_opt`.
         """
 
         super().__init__(src)
@@ -137,16 +150,11 @@ class DenoiserCov2D(Denoiser):
         self.mean_est = None
         self.covar_est = None
 
-        default_opt = {
-            "shrinker": "frobenius_norm",
-            "verbose": 0,
-            "max_iter": 250,
-            "iter_callback": [],
-            "store_iterates": False,
-            "rel_tolerance": 1e-12,
-            "precision": self.dtype,
-        }
-
+        # Create a local copy of the default options.
+        default_opt = deepcopy(self.default_opt)
+        # Assign the dtype corresponding to this instance.
+        default_opt["precision"] = self.dtype
+        # Apply any overrides provided by the user.
         self.covar_opt = fill_struct(covar_opt, default_opt)
 
         # Initialize the rotationally invariant covariance matrix of 2D images

--- a/src/aspire/denoising/denoiser_cov2d.py
+++ b/src/aspire/denoising/denoiser_cov2d.py
@@ -6,7 +6,6 @@ from numpy.linalg import solve
 from aspire.basis import FFBBasis2D
 from aspire.covariance import BatchedRotCov2D
 from aspire.denoising import Denoiser
-from aspire.denoising.denoised_src import DenoisedImageSource
 from aspire.noise import WhiteNoiseEstimator
 from aspire.optimization import fill_struct
 from aspire.utils import mat_to_vec
@@ -104,15 +103,19 @@ class DenoiserCov2D(Denoiser):
     Define a derived class for denoising 2D images using Cov2D method
     """
 
-    def __init__(self, src, basis=None, var_noise=None):
+    def __init__(self, src, basis=None, var_noise=None, batch_size=512, covar_opt=None):
         """
         Initialize an object for denoising 2D images using Cov2D method
 
         :param src: The source object of 2D images with metadata
         :param basis: The basis method to expand 2D images
         :param var_noise: The estimated variance of noise
+        :param batch_size: The batch size for processing images
+        :param covar_opt: The option list for building Cov2D matrix
         """
+
         super().__init__(src)
+        self.batch_size = int(batch_size)
 
         # When var_noise is not specfically over-ridden,
         #   recompute it now. See #496.
@@ -134,19 +137,6 @@ class DenoiserCov2D(Denoiser):
         self.mean_est = None
         self.covar_est = None
 
-    def denoise(self, covar_opt=None, batch_size=512):
-        """
-         Build covariance matrix of 2D images and return a new ImageSource object
-
-        :param covar_opt: The option list for building Cov2D matrix
-        :param batch_size: The batch size for processing images
-        :return: A `DenoisedImageSource` object with the specified denoising object
-        """
-
-        # Initialize the rotationally invariant covariance matrix of 2D images
-        # A fixed batch size is used to go through each image
-        self.cov2d = BatchedRotCov2D(self.src, self.basis, batch_size=batch_size)
-
         default_opt = {
             "shrinker": "frobenius_norm",
             "verbose": 0,
@@ -157,38 +147,51 @@ class DenoiserCov2D(Denoiser):
             "precision": self.dtype,
         }
 
-        covar_opt = fill_struct(covar_opt, default_opt)
-        # Calculate the mean and covariance for the rotationally invariant covariance matrix of 2D images
+        self.covar_opt = fill_struct(covar_opt, default_opt)
+
+        # Initialize the rotationally invariant covariance matrix of 2D images
+        # A fixed batch_size is used to loop through image stack.
+        self.cov2d = BatchedRotCov2D(self.src, self.basis, batch_size=batch_size)
+
+    def build_denoiser(self):
+        """
+        Build estimated mean and covariance matrix of 2D images.
+
+        This method should be computed once, on first `images` access.
+        """
+
+        if self.cov2d_est is not None:
+            return
+
+        logger.info(f"Building mean estimate for {len(self.src)} images.")
         self.mean_est = self.cov2d.get_mean()
 
+        logger.info(f"Building covariance estimates for {len(self.src)} images.")
         self.covar_est = self.cov2d.get_covar(
-            noise_var=self.var_noise, mean_coef=self.mean_est, covar_est_opt=covar_opt
+            noise_var=self.var_noise,
+            mean_coef=self.mean_est,
+            covar_est_opt=self.covar_opt,
         )
 
-        return DenoisedImageSource(self.src, self)
-
-    def images(self, istart=0, batch_size=512):
+    def _denoise(self, indices):
         """
-        Obtain a batch size of 2D images after denosing by Cov2D method
+        Compute denoised 2D images corresponding to `indices`.
 
-        :param istart: the index of starting image
-        :param batch_size: The batch size for processing images
-        :return: an `Image` object with denoised images
+        :return: `Image` object containing denoised images.
         """
-        src = self.src
 
-        # Denoise one batch size of 2D images using the SPCAs from the rotationally invariant covariance matrix
-        img_start = istart
-        img_end = min(istart + batch_size, src.n)
-        imgs_noise = src.images[img_start : img_start + batch_size]
+        # Lazy evaluate estimates on access.
+        # `build_denoiser` internally guards to compute once.
+        self.build_denoiser()
+
+        # Denoise requested `indices` selection of 2D images.
+        imgs_noise = self.src.images[indices]
         coefs_noise = self.basis.evaluate_t(imgs_noise)
-        logger.info(
-            f"Estimating Cov2D coefficients for images from {img_start} to {img_end-1}"
-        )
+        logger.debug(f"Estimating Cov2D coefficients for {len(imgs_noise)} images.")
         coefs_estim = self.cov2d.get_cwf_coefs(
             coefs_noise,
-            self.cov2d.ctf_basis,
-            self.cov2d.ctf_idx[img_start:img_end],
+            self.cov2d.ctf_fb,
+            self.cov2d.ctf_idx[indices],
             mean_coef=self.mean_est,
             covar_coef=self.covar_est,
             noise_var=self.var_noise,

--- a/src/aspire/denoising/denoiser_cov2d.py
+++ b/src/aspire/denoising/denoiser_cov2d.py
@@ -160,7 +160,7 @@ class DenoiserCov2D(Denoiser):
         This method should be computed once, on first `images` access.
         """
 
-        if self.cov2d_est is not None:
+        if self.covar_est is not None:
             return
 
         logger.info(f"Building mean estimate for {len(self.src)} images.")
@@ -186,8 +186,9 @@ class DenoiserCov2D(Denoiser):
 
         # Denoise requested `indices` selection of 2D images.
         imgs_noise = self.src.images[indices]
+
         coefs_noise = self.basis.evaluate_t(imgs_noise)
-        logger.debug(f"Estimating Cov2D coefficients for {len(imgs_noise)} images.")
+        logger.debug(f"Estimating Cov2D coefficients for {imgs_noise.n_images} images.")
         coefs_estim = self.cov2d.get_cwf_coefs(
             coefs_noise,
             self.cov2d.ctf_fb,

--- a/src/aspire/denoising/denoiser_cov2d.py
+++ b/src/aspire/denoising/denoiser_cov2d.py
@@ -199,7 +199,7 @@ class DenoiserCov2D(Denoiser):
         logger.debug(f"Estimating Cov2D coefficients for {imgs_noise.n_images} images.")
         coefs_estim = self.cov2d.get_cwf_coefs(
             coefs_noise,
-            self.cov2d.ctf_fb,
+            self.cov2d.ctf_basis,
             self.cov2d.ctf_idx[indices],
             mean_coef=self.mean_est,
             covar_coef=self.covar_est,

--- a/tests/test_covar2d_denoiser.py
+++ b/tests/test_covar2d_denoiser.py
@@ -22,7 +22,7 @@ basis = FFBBasis2D((img_size, img_size), dtype=dtype)
 
 @pytest.fixture(scope="module")
 def sim():
-    """Simulation source."""
+    """Create a reusable Simulation source."""
     return Simulation(
         L=img_size,
         n=num_imgs,
@@ -35,6 +35,9 @@ def sim():
 
 
 def test_batched_rotcov2d_MSE(sim):
+    """
+    Check calling `DenoiserCov2D` via `DenoiserSource` framework yields acceptable error.
+    """
     # need larger numbers of images and higher resolution for good MSE
     imgs_clean = sim.projections[:]
 
@@ -44,7 +47,6 @@ def test_batched_rotcov2d_MSE(sim):
 
     # Calculate the normalized RMSE of the estimated images.
     nrmse_ims = (imgs_denoised - imgs_clean).norm() / imgs_clean.norm()
-
     np.testing.assert_array_less(nrmse_ims, 0.25)
 
     # Additionally test the `DenoisedSource` and lazy-eval-cache
@@ -54,10 +56,9 @@ def test_batched_rotcov2d_MSE(sim):
 
 
 def test_source_mismatch(sim):
-    """ "
+    """
     Assert mismatched sources raises an error.
     """
-
     # Create a denoiser.
     denoiser = DenoiserCov2D(sim, basis, noise_var)
 

--- a/tests/test_covar2d_denoiser.py
+++ b/tests/test_covar2d_denoiser.py
@@ -36,8 +36,8 @@ class BatchedRotCov2DTestCase(TestCase):
         # Specify the fast FB basis method for expending the 2D images
         ffbbasis = FFBBasis2D((img_size, img_size), dtype=dtype)
         denoiser = DenoiserCov2D(sim, ffbbasis, noise_var)
-        denoised_src = denoiser.denoise(batch_size=64)
-        imgs_denoised = denoised_src.images[:]
+        imgs_denoised = denoiser.denoise[:]
+
         # Calculate the normalized RMSE of the estimated images.
         nrmse_ims = (imgs_denoised - imgs_clean).norm() / imgs_clean.norm()
 

--- a/tests/test_covar2d_denoiser.py
+++ b/tests/test_covar2d_denoiser.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 import numpy as np
 
 from aspire.basis.ffb_2d import FFBBasis2D
-from aspire.denoising.denoiser_cov2d import DenoiserCov2D
+from aspire.denoising import DenoisedImageSource, DenoiserCov2D
 from aspire.noise import WhiteNoiseAdder
 from aspire.operators.filters import RadialCTFFilter
 from aspire.source.simulation import Simulation
@@ -42,3 +42,8 @@ class BatchedRotCov2DTestCase(TestCase):
         nrmse_ims = (imgs_denoised - imgs_clean).norm() / imgs_clean.norm()
 
         self.assertTrue(nrmse_ims < 0.25)
+
+        # Additionally test the `DenoisedImageSource` and lazy-eval-cache
+        # of the cov2d estimator.
+        src = DenoisedImageSource(sim, denoiser)
+        self.assertTrue(np.allclose(src.images[:], imgs_denoised))

--- a/tests/test_covar2d_denoiser.py
+++ b/tests/test_covar2d_denoiser.py
@@ -45,5 +45,5 @@ class BatchedRotCov2DTestCase(TestCase):
 
         # Additionally test the `DenoisedSource` and lazy-eval-cache
         # of the cov2d estimator.
-        src = DenoisedSource(sim, denoiser)
+        src = DenoisedSource(denoiser)
         self.assertTrue(np.allclose(src.images[:], imgs_denoised))

--- a/tests/test_covar2d_denoiser.py
+++ b/tests/test_covar2d_denoiser.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 import numpy as np
 
 from aspire.basis.ffb_2d import FFBBasis2D
-from aspire.denoising import DenoisedImageSource, DenoiserCov2D
+from aspire.denoising import DenoisedSource, DenoiserCov2D
 from aspire.noise import WhiteNoiseAdder
 from aspire.operators.filters import RadialCTFFilter
 from aspire.source.simulation import Simulation
@@ -43,7 +43,7 @@ class BatchedRotCov2DTestCase(TestCase):
 
         self.assertTrue(nrmse_ims < 0.25)
 
-        # Additionally test the `DenoisedImageSource` and lazy-eval-cache
+        # Additionally test the `DenoisedSource` and lazy-eval-cache
         # of the cov2d estimator.
-        src = DenoisedImageSource(sim, denoiser)
+        src = DenoisedSource(sim, denoiser)
         self.assertTrue(np.allclose(src.images[:], imgs_denoised))

--- a/tests/test_covar2d_denoiser.py
+++ b/tests/test_covar2d_denoiser.py
@@ -52,7 +52,7 @@ def test_batched_rotcov2d_MSE(sim):
     # Additionally test the `DenoisedSource` and lazy-eval-cache
     # of the cov2d estimator.
     src = DenoisedSource(sim, denoiser)
-    np.testing.assert_allclose(imgs_denoised, src.images[:])
+    np.testing.assert_allclose(imgs_denoised, src.images[:], rtol=1e-05, atol=1e-08)
 
 
 def test_source_mismatch(sim):

--- a/tests/test_covar2d_denoiser.py
+++ b/tests/test_covar2d_denoiser.py
@@ -45,5 +45,5 @@ class BatchedRotCov2DTestCase(TestCase):
 
         # Additionally test the `DenoisedSource` and lazy-eval-cache
         # of the cov2d estimator.
-        src = DenoisedSource(denoiser)
+        src = DenoisedSource(sim, denoiser)
         self.assertTrue(np.allclose(src.images[:], imgs_denoised))

--- a/tests/test_covar2d_denoiser.py
+++ b/tests/test_covar2d_denoiser.py
@@ -1,6 +1,5 @@
-from unittest import TestCase
-
 import numpy as np
+import pytest
 
 from aspire.basis.ffb_2d import FFBBasis2D
 from aspire.denoising import DenoisedSource, DenoiserCov2D
@@ -8,42 +7,63 @@ from aspire.noise import WhiteNoiseAdder
 from aspire.operators.filters import RadialCTFFilter
 from aspire.source.simulation import Simulation
 
+# TODO, parameterize these further.
+dtype = np.float32
+img_size = 64
+num_imgs = 1024
+noise_var = 0.1848
+noise_adder = WhiteNoiseAdder(var=noise_var)
+filters = [
+    RadialCTFFilter(5, 200, defocus=d, Cs=2.0, alpha=0.1)
+    for d in np.linspace(1.5e4, 2.5e4, 7)
+]
+basis = FFBBasis2D((img_size, img_size), dtype=dtype)
 
-class BatchedRotCov2DTestCase(TestCase):
-    def testMSE(self):
-        # need larger numbers of images and higher resolution for good MSE
-        dtype = np.float32
-        img_size = 64
-        num_imgs = 1024
-        noise_var = 0.1848
-        noise_adder = WhiteNoiseAdder(var=noise_var)
-        filters = [
-            RadialCTFFilter(5, 200, defocus=d, Cs=2.0, alpha=0.1)
-            for d in np.linspace(1.5e4, 2.5e4, 7)
-        ]
-        # set simulation object
-        sim = Simulation(
-            L=img_size,
-            n=num_imgs,
-            unique_filters=filters,
-            offsets=0.0,
-            amplitudes=1.0,
-            dtype=dtype,
-            noise_adder=noise_adder,
-        )
-        imgs_clean = sim.projections[:]
 
-        # Specify the fast FB basis method for expending the 2D images
-        ffbbasis = FFBBasis2D((img_size, img_size), dtype=dtype)
-        denoiser = DenoiserCov2D(sim, ffbbasis, noise_var)
-        imgs_denoised = denoiser.denoise[:]
+@pytest.fixture(scope="module")
+def sim():
+    """Simulation source."""
+    return Simulation(
+        L=img_size,
+        n=num_imgs,
+        unique_filters=filters,
+        offsets=0.0,
+        amplitudes=1.0,
+        dtype=dtype,
+        noise_adder=noise_adder,
+    )
 
-        # Calculate the normalized RMSE of the estimated images.
-        nrmse_ims = (imgs_denoised - imgs_clean).norm() / imgs_clean.norm()
 
-        self.assertTrue(nrmse_ims < 0.25)
+def test_batched_rotcov2d_MSE(sim):
+    # need larger numbers of images and higher resolution for good MSE
+    imgs_clean = sim.projections[:]
 
-        # Additionally test the `DenoisedSource` and lazy-eval-cache
-        # of the cov2d estimator.
-        src = DenoisedSource(sim, denoiser)
-        self.assertTrue(np.allclose(src.images[:], imgs_denoised))
+    # Specify the fast FB basis method for expending the 2D images
+    denoiser = DenoiserCov2D(sim, basis, noise_var)
+    imgs_denoised = denoiser.denoise[:]
+
+    # Calculate the normalized RMSE of the estimated images.
+    nrmse_ims = (imgs_denoised - imgs_clean).norm() / imgs_clean.norm()
+
+    np.testing.assert_array_less(nrmse_ims, 0.25)
+
+    # Additionally test the `DenoisedSource` and lazy-eval-cache
+    # of the cov2d estimator.
+    src = DenoisedSource(sim, denoiser)
+    np.testing.assert_allclose(imgs_denoised, src.images[:])
+
+
+def test_source_mismatch(sim):
+    """ "
+    Assert mismatched sources raises an error.
+    """
+
+    # Create a denoiser.
+    denoiser = DenoiserCov2D(sim, basis, noise_var)
+
+    # Create a different source.
+    src2 = sim[: sim.n - 1]
+
+    # Raise because src2 not identical to denoiser.src (sim)
+    with pytest.raises(NotImplementedError, match=r".*must match.*"):
+        _ = DenoisedSource(src2, denoiser)


### PR DESCRIPTION
Stash initial attempt at #897  and #904.  This converts the `DenoiserCov2D` to be lazily built (minimal init, builds estimates on first access to `denoise` attribute or call to `build_denoiser`).  Also cleans up the mishmash of batching code to just use `indices` and the accessor across the board.

~First commit is just a rough draft of the code changes, haven't updated any calling code or tests.~

Also fixes bunch of issues with the documentation.