### PR TITLE
Docstring Error tox check

### DIFF
--- a/docs/check_docstrings.py
+++ b/docs/check_docstrings.py
@@ -20,7 +20,10 @@ def check_blank_line_above_param_section(file_path):
     with open(file_path, "r") as file:
         content = file.read()
 
-    regex = r" {4,}\"\"\"\n(?:^[^:]+?[^\n])+\n {4,}:(?:.*\n)+? {4,}\"\"\"| {4,}\"\"\"\n(?:^.*[^\n]\n)+\n\n+ {4,}:(?:.*\n)+? {4,}\"\"\""
+    regex = (
+        r" {4,}\"\"\"\n(?:^[^:]+?[^\n])+\n {4,}(:p|:r)(?:.*\n)+? {4,}\"\"\""
+        r"| {4,}\"\"\"\n(?:^[^:]+?[^\n])+\n\n\n+ {4,}(:p|:r)(?:.*\n)+? {4,}\"\"\""
+    )
 
     bad_docstrings = re.finditer(regex, content, re.MULTILINE)
     for docstring in bad_docstrings:

--- a/docs/check_docstrings.py
+++ b/docs/check_docstrings.py
@@ -1,0 +1,75 @@
+import logging
+import os
+import re
+import sys
+
+logger = logging.getLogger(__name__)
+
+
+def check_blank_line_above_param_section(file_path):
+    """
+    Check that every docstring with both a body section and a parameter
+    section separates the two sections with exactly one blank line. Log
+    errors and return count.
+
+    :param file_path: File path to check for error.
+    :return: Per file error count.
+    """
+    error_count = 0
+    with open(file_path, "r") as file:
+        content = file.read()
+
+    docstrings = re.findall(r"\"\"\"(.*?)\"\"\"", content, re.DOTALL)
+
+    for docstring in docstrings:
+        lines = docstring.split("\n")
+        for i, line in enumerate(lines):
+            if line.strip().startswith(r":param") or line.strip().startswith(
+                r":return"
+            ):
+                body_section = "\n".join(lines[:i])
+                if not body_section:
+                    break
+                elif body_section != body_section.rstrip() + "\n":
+                    # Get line number of error.
+                    # Using `re.escape` to deal with non-alphanumeric characters.
+                    match = re.search(re.escape(body_section), content)
+                    docstring_start = match.start()
+                    line_number = content.count("\n", 0, docstring_start) + i
+
+                    # Log error message.
+                    msg = "Must have exactly 1 blank line between docstring body and parameter sections."
+                    logger.error(f"{file_path}: {line_number}: {msg}")
+                    error_count += 1
+                    break
+                else:
+                    break
+    return error_count
+
+
+def process_directory(directory):
+    """
+    Recursively walk through directories and check for docstring errors.
+    If any errors found, log error count and exit.
+
+    :param directory: Directory path to walk.
+    """
+    error_count = 0
+    for root, _, files in os.walk(directory):
+        for file in files:
+            if file.endswith(".py"):
+                file_path = os.path.join(root, file)
+                logger.info(f"Processing file: {file_path}")
+                error_count += check_blank_line_above_param_section(file_path)
+    if error_count > 0:
+        logger.error(f"Found {error_count} docstring errors.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        logger.warning("Usage: python check_docstrings.py <directory>")
+        sys.exit(1)
+
+    target_directory = sys.argv[1]
+    process_directory(target_directory)

--- a/docs/check_docstrings.py
+++ b/docs/check_docstrings.py
@@ -3,6 +3,8 @@ import os
 import re
 import sys
 
+from glob import glob
+
 logger = logging.getLogger(__name__)
 
 
@@ -55,12 +57,8 @@ def process_directory(directory):
     :param directory: Directory path to walk.
     """
     error_count = 0
-    for root, _, files in os.walk(directory):
-        for file in files:
-            if file.endswith(".py"):
-                file_path = os.path.join(root, file)
-                logger.info(f"Processing file: {file_path}")
-                error_count += check_blank_line_above_param_section(file_path)
+    for file in glob(os.path.join(directory, '**/*.py'), recursive=True):
+        error_count += check_blank_line_above_param_section(file)
     if error_count > 0:
         logger.error(f"Found {error_count} docstring errors.")
         sys.exit(1)

--- a/docs/check_docstrings.py
+++ b/docs/check_docstrings.py
@@ -20,27 +20,16 @@ def check_blank_line_above_param_section(file_path):
     with open(file_path, "r") as file:
         content = file.read()
 
-    docstrings = re.finditer(r"\"\"\"(.*?)\"\"\"", content, re.DOTALL)
-    for docstring in docstrings:
-        lines = docstring[0].split("\n")
+    regex = r" {4,}\"\"\"\n(?:^[^:]+?[^\n])+\n {4,}:(?:.*\n)+? {4,}\"\"\"| {4,}\"\"\"\n(?:^.*[^\n]\n)+\n\n+ {4,}:(?:.*\n)+? {4,}\"\"\""
 
-        # Search for first occurence of either a ':param' or ':return' string.
-        for i, line in enumerate(lines):
-            if line.strip().startswith((r":param", r":return")):
-                # If a body section exists but is not followed by exactly 1
-                # new line log an error message and add to the count.
-                body_section = "\n".join(lines[1:i])
-                if not body_section:
-                    break
-                elif body_section != body_section.rstrip() + "\n":
-                    # Get line number.
-                    line_number = content.count("\n", 0, docstring.start()) + i
+    bad_docstrings = re.finditer(regex, content, re.MULTILINE)
+    for docstring in bad_docstrings:
+        line_number = content.count("\n", 0, docstring.start()) + 1
 
-                    # Log error message.
-                    msg = "Must have exactly 1 blank line between docstring body and parameter sections."
-                    logger.error(f"{file_path}: {line_number}: {msg}")
-                    error_count += 1
-                break
+        # Log error message.
+        msg = "Must have exactly 1 blank line between docstring body and parameter sections."
+        logger.error(f"{file_path}: {line_number}: {msg}")
+        error_count += 1
 
     return error_count
 

--- a/docs/check_docstrings.py
+++ b/docs/check_docstrings.py
@@ -26,9 +26,7 @@ def check_blank_line_above_param_section(file_path):
 
         # Search for first occurence of either a ':param' or ':return' string.
         for i, line in enumerate(lines):
-            if line.strip().startswith(r":param") or line.strip().startswith(
-                r":return"
-            ):
+            if line.strip().startswith((r":param", r":return")):
                 # If a body section exists but is not followed by exactly 1
                 # new line log an error message and add to the count.
                 body_section = "\n".join(lines[1:i])

--- a/docs/check_docstrings.py
+++ b/docs/check_docstrings.py
@@ -66,4 +66,6 @@ if __name__ == "__main__":
         sys.exit(1)
 
     target_directory = sys.argv[1]
+    if not os.path.isdir(target_directory):
+        raise RuntimeError(f"Invalid target directory path: {target_directory}")
     process_directory(target_directory)

--- a/docs/check_docstrings.py
+++ b/docs/check_docstrings.py
@@ -21,8 +21,7 @@ def check_blank_line_above_param_section(file_path):
         content = file.read()
 
     regex = (
-        r" {4,}\"\"\"\n(?:^[^:]+?[^\n])+\n {4,}(:p|:r)(?:.*\n)+? {4,}\"\"\""
-        r"| {4,}\"\"\"\n(?:^[^:]+?[^\n])+\n\n\n+ {4,}(:p|:r)(?:.*\n)+? {4,}\"\"\""
+        r" {4,}\"\"\"\n(?:^[^:]+?[^\n])+(\n|\n\n\n+) {4,}(:p|:r)(?:.*\n)+? {4,}\"\"\""
     )
 
     bad_docstrings = re.finditer(regex, content, re.MULTILINE)

--- a/src/aspire/apple/helper.py
+++ b/src/aspire/apple/helper.py
@@ -6,11 +6,11 @@ from aspire.numeric import fft, xp
 class PickerHelper:
     @classmethod
     def gaussian_filter(cls, size_filter, std):
-        """Computes low-pass filter.
+        """
+        Computes low-pass filter.
 
-        Args:
-            size_filter: Size of filter (size_filter x size_filter).
-            std: sigma value in filter.
+        :param size_filter: Size of filter (size_filter x size_filter).
+        :param std: sigma value in filter.
         """
 
         y, x = xp.mgrid[
@@ -27,15 +27,14 @@ class PickerHelper:
 
     @classmethod
     def extract_windows(cls, img, block_size):
-        """Extracts blocks of size (block_size x block_size) from the micrograph. Blocks are
+        """
+        Extracts blocks of size (block_size x block_size) from the micrograph. Blocks are
         extracted with steps of size (block_size)
 
-        Args:
-            img: Micrograph image.
-            block_size: required block size.
+        :param img: Micrograph image.
+        :param block_size: required block size.
 
-        Returns:
-            3D Matrix of blocks. For example, img[0] is the first block.
+        :return: 3D Matrix of blocks. For example, img[0] is the first block.
         """
 
         # Compute x,y boundary using block_size
@@ -57,15 +56,14 @@ class PickerHelper:
 
     @classmethod
     def extract_query(cls, img, block_size):
-        """Extract all query images from the micrograph. windows are
+        """
+        Extract all query images from the micrograph. windows are
         extracted with steps of size (block_size/2)
 
-        Args:
-            img: Micrograph image.
-            block_size: Query images must be of size (block_size x block_size).
+        :param img: Micrograph image.
+        :param block_size: Query images must be of size (block_size x block_size).
 
-        Returns:
-            4D Matrix of query images.
+        :return: 4D Matrix of query images.
         """
 
         # keep only the portion of the image that can be split into blocks with no remainder
@@ -135,16 +133,15 @@ class PickerHelper:
 
     @classmethod
     def extract_references(cls, img, query_size, container_size):
-        """Chooses and extracts reference images from the micrograph.
+        """
+        Chooses and extracts reference images from the micrograph.
 
-        Args:
-            img: Micrograph image.
-            query_size: Reference images must be of the same size of query images, i.e. (query_size x query_size).
-            container_size: Containers are large regions used to select reference images. The size of each
-                region is (container_size x container_size)
+        :param img: Micrograph image.
+        :param query_size: Reference images must be of the same size of query images, i.e. (query_size x query_size).
+        :param container_size: Containers are large regions used to select reference images. The size of each
+            region is (container_size x container_size)
 
-        Returns:
-            3D Matrix of reference images.  windows[0] is the first reference window.
+        :return: 3D Matrix of reference images.  windows[0] is the first reference window.
         """
 
         img = xp.asarray(img)
@@ -220,16 +217,15 @@ class PickerHelper:
 
     @classmethod
     def get_training_set(cls, micro_img, bw_mask_p, bw_mask_n, n):
-        """Gets training set for the SVM classifier.
+        """
+        Gets training set for the SVM classifier.
 
-        Args:
-            micro_img: Micrograph image.
-            bw_mask_p: Binary image indicating regions from which to extract examples of particles.
-            bw_mask_n: Binary image indicating regions from which to extract examples of noise.
-            n: Size of training windows.
+        :param micro_img: Micrograph image.
+        :param bw_mask_p: Binary image indicating regions from which to extract examples of particles.
+        :param bw_mask_n: Binary image indicating regions from which to extract examples of noise.
+        :param n: Size of training windows.
 
-        Returns:
-            A matrix of features and a vector of labels for the SVM training.
+        :return: A matrix of features and a vector of labels for the SVM training.
         """
 
         non_overlap = cls.extract_windows(micro_img, n)
@@ -260,15 +256,14 @@ class PickerHelper:
 
     @classmethod
     def moments(cls, img, query_size):
-        """Calculates the mean and standard deviation for each window of size (query_size x query_size)
+        """
+        Calculates the mean and standard deviation for each window of size (query_size x query_size)
         in the micrograph.
 
-        Args:
-            img: Micrograph image.
-            query_size: Size of windows for which to compute mean and std.
+        :param img: Micrograph image.
+        :param query_size: Size of windows for which to compute mean and std.
 
-        Returns:
-            A matrix of mean intensity and a matrix of variance, each containing a single
+        :return: A matrix of mean intensity and a matrix of variance, each containing a single
             entry for each possible (query_size x query_size) window in the micrograph.
         """
 

--- a/src/aspire/basis/steerable.py
+++ b/src/aspire/basis/steerable.py
@@ -352,8 +352,6 @@ class SteerableBasis2D(Basis):
             More advanced operations can combine indices attributes.
              `angular=self.angular_indices>=0, radial=r` selects coefficients with non negative angular indices and some radial index `r`.
 
-
-
         :return: Boolen mask of shape (`count`,).
             Intended to be broadcast with `Coef` containers.
         """

--- a/tests/saved_test_data/sample_docstrings.py
+++ b/tests/saved_test_data/sample_docstrings.py
@@ -11,12 +11,14 @@ def good_fun1(frog, dog):
     :return: A frog on a dog
     """
 
+
 def good_fun2():
     """
     This function has only a return.
 
     :return: Just a return.
     """
+
 
 def bad_fun1(cat, hat):
     """
@@ -27,6 +29,7 @@ def bad_fun1(cat, hat):
     :return: A cat in a hat.
     """
 
+
 def bad_fun2(foo):
     """
     This docstring has too many blank lines between
@@ -36,4 +39,3 @@ def bad_fun2(foo):
     :param foo: foo description.
     :return: bar
     """
-    

--- a/tests/saved_test_data/sample_docstrings.py
+++ b/tests/saved_test_data/sample_docstrings.py
@@ -1,0 +1,39 @@
+def good_fun1(frog, dog):
+    """
+    This docstring is properly formatted.
+
+    It has a multi-line, multi-section body
+    followed by exactly one blank line.
+
+    :param frog: This param description is
+        multiline.
+    :param dog: Single line description
+    :return: A frog on a dog
+    """
+
+def good_fun2():
+    """
+    This function has only a return.
+
+    :return: Just a return.
+    """
+
+def bad_fun1(cat, hat):
+    """
+    This docstring is missing a blank line
+    between the body and parameter sections.
+    :param cat: A cat.
+    :param hat: A hat.
+    :return: A cat in a hat.
+    """
+
+def bad_fun2(foo):
+    """
+    This docstring has too many blank lines between
+    the body and parameter sections.
+
+
+    :param foo: foo description.
+    :return: bar
+    """
+    

--- a/tests/saved_test_data/sample_docstrings.py
+++ b/tests/saved_test_data/sample_docstrings.py
@@ -31,6 +31,14 @@ def good_fun3():
         """
 
 
+def good_fun4(bing, bong):
+    """
+    :param bing: This docstring has no body.
+    :param bong: Should not error.
+    :return: Boom.
+    """
+
+
 def bad_fun1(cat, hat):
     """
     This docstring is missing a blank line

--- a/tests/saved_test_data/sample_docstrings.py
+++ b/tests/saved_test_data/sample_docstrings.py
@@ -20,6 +20,17 @@ def good_fun2():
     """
 
 
+def good_fun3():
+    def nested_fun(bip):
+        """
+        This is a properly formatted docstring
+        in a nested function.
+
+        :param bip: A small bip
+        :return: A large bop
+        """
+
+
 def bad_fun1(cat, hat):
     """
     This docstring is missing a blank line
@@ -39,3 +50,13 @@ def bad_fun2(foo):
     :param foo: foo description.
     :return: bar
     """
+
+
+def bad_fun3():
+    def nested_fun(bip):
+        """
+        This is an improperly formatted docstring
+        in a nested function.
+        :param bip: A small bip
+        :return: A large bop
+        """

--- a/tests/test_docstring_checker.py
+++ b/tests/test_docstring_checker.py
@@ -1,22 +1,32 @@
+import os
 import subprocess
 
 
 def test_check_docstrings():
+    DATA_DIR = os.path.join(os.path.dirname(__file__), "saved_test_data")
+    DOCS_CHECKER = os.path.join(
+        os.path.dirname(__file__), "..", "docs", "check_docstrings.py"
+    )
+
     result = subprocess.run(
-        ["python", "docs/check_docstrings.py", "tests/saved_test_data"],
+        ["python", DOCS_CHECKER, DATA_DIR],
         capture_output=True,
         text=True,
     )
 
-    good_doc_1 = "sample_docstrings.py: 2: Must have exactly 1 blank line"
-    good_doc_2 = "sample_docstrings.py: 16: Must have exactly 1 blank line"
-    err_1 = "sample_docstrings.py: 24: Must have exactly 1 blank line"
-    err_2 = "sample_docstrings.py: 34: Must have exactly 1 blank line"
+    good_doc_line_nums = [2, 16, 25]
+    bad_doc_line_nums = [35, 45, 57]
 
     # Check that good docstrings do not log error
-    assert good_doc_1 not in result.stderr
-    assert good_doc_2 not in result.stderr
+    for line_num in good_doc_line_nums:
+        msg = f"sample_docstrings.py: {line_num}: Must have exactly 1 blank line"
+        assert msg not in result.stderr
 
     # Check that bad docstrings log error
-    assert err_1 in result.stderr
-    assert err_2 in result.stderr
+    for line_num in bad_doc_line_nums:
+        msg = f"sample_docstrings.py: {line_num}: Must have exactly 1 blank line"
+        assert msg in result.stderr
+
+    # Check total error count log
+    msg = f"Found {len(bad_doc_line_nums)} docstring errors"
+    assert msg in result.stderr

--- a/tests/test_docstring_checker.py
+++ b/tests/test_docstring_checker.py
@@ -1,7 +1,5 @@
-import sys
-
-import pytest
 import subprocess
+
 
 def test_check_docstrings():
     result = subprocess.run(
@@ -12,7 +10,7 @@ def test_check_docstrings():
 
     err_1 = "sample_docstrings.py: 22"
     err_2 = "sample_docstrings.py: 31"
-    
+
     assert result.stdout == ""
     assert err_1 in result.stderr
-    assert err_2 in result.stderr    
+    assert err_2 in result.stderr

--- a/tests/test_docstring_checker.py
+++ b/tests/test_docstring_checker.py
@@ -14,8 +14,8 @@ def test_check_blank_line(caplog):
     error_count = check_docstrings.check_blank_line_above_param_section(test_string)
 
     # Line numbers of good and bad docstrings in sample_docstrings.py
-    good_doc_line_nums = [2, 16, 25]
-    bad_doc_line_nums = [35, 45, 57]
+    good_doc_line_nums = [2, 16, 25, 35]
+    bad_doc_line_nums = [43, 53, 65]
 
     # Check that good docstrings do not log error
     for line_num in good_doc_line_nums:

--- a/tests/test_docstring_checker.py
+++ b/tests/test_docstring_checker.py
@@ -1,32 +1,31 @@
+import logging
 import os
-import subprocess
+
+from docs import check_docstrings
 
 
-def test_check_docstrings():
-    DATA_DIR = os.path.join(os.path.dirname(__file__), "saved_test_data")
-    DOCS_CHECKER = os.path.join(
-        os.path.dirname(__file__), "..", "docs", "check_docstrings.py"
+def test_check_docstrings_new(caplog):
+    test_string = os.path.join(
+        os.path.dirname(__file__), "saved_test_data", "sample_docstrings.py"
     )
 
-    result = subprocess.run(
-        ["python", DOCS_CHECKER, DATA_DIR],
-        capture_output=True,
-        text=True,
-    )
+    caplog.clear()
+    caplog.set_level(logging.ERROR)
+    error_count = check_docstrings.check_blank_line_above_param_section(test_string)
 
+    # Line numbers of good and bad docstrings in sample_docstrings.py
     good_doc_line_nums = [2, 16, 25]
     bad_doc_line_nums = [35, 45, 57]
 
     # Check that good docstrings do not log error
     for line_num in good_doc_line_nums:
         msg = f"sample_docstrings.py: {line_num}: Must have exactly 1 blank line"
-        assert msg not in result.stderr
+        assert msg not in caplog.text
 
     # Check that bad docstrings log error
     for line_num in bad_doc_line_nums:
         msg = f"sample_docstrings.py: {line_num}: Must have exactly 1 blank line"
-        assert msg in result.stderr
+        assert msg in caplog.text
 
     # Check total error count log
-    msg = f"Found {len(bad_doc_line_nums)} docstring errors"
-    assert msg in result.stderr
+    assert error_count == len(bad_doc_line_nums)

--- a/tests/test_docstring_checker.py
+++ b/tests/test_docstring_checker.py
@@ -4,7 +4,7 @@ import os
 from docs import check_docstrings
 
 
-def test_check_docstrings_new(caplog):
+def test_check_blank_line(caplog):
     test_string = os.path.join(
         os.path.dirname(__file__), "saved_test_data", "sample_docstrings.py"
     )

--- a/tests/test_docstring_checker.py
+++ b/tests/test_docstring_checker.py
@@ -1,0 +1,18 @@
+import sys
+
+import pytest
+import subprocess
+
+def test_check_docstrings():
+    result = subprocess.run(
+        ["python", "docs/check_docstrings.py", "tests/saved_test_data"],
+        capture_output=True,
+        text=True,
+    )
+
+    err_1 = "sample_docstrings.py: 22"
+    err_2 = "sample_docstrings.py: 31"
+    
+    assert result.stdout == ""
+    assert err_1 in result.stderr
+    assert err_2 in result.stderr    

--- a/tests/test_docstring_checker.py
+++ b/tests/test_docstring_checker.py
@@ -8,9 +8,15 @@ def test_check_docstrings():
         text=True,
     )
 
-    err_1 = "sample_docstrings.py: 22"
-    err_2 = "sample_docstrings.py: 31"
+    good_doc_1 = "sample_docstrings.py: 2: Must have exactly 1 blank line"
+    good_doc_2 = "sample_docstrings.py: 16: Must have exactly 1 blank line"
+    err_1 = "sample_docstrings.py: 24: Must have exactly 1 blank line"
+    err_2 = "sample_docstrings.py: 34: Must have exactly 1 blank line"
 
-    assert result.stdout == ""
+    # Check that good docstrings do not log error
+    assert good_doc_1 not in result.stderr
+    assert good_doc_2 not in result.stderr
+
+    # Check that bad docstrings log error
     assert err_1 in result.stderr
     assert err_2 in result.stderr

--- a/tox.ini
+++ b/tox.ini
@@ -55,6 +55,7 @@ commands =
     flake8 .
     isort --check-only --diff .
     black --check --diff .
+    python docs/check_docstrings.py src/aspire
     python -m json.tool .zenodo.json /dev/null
     check-manifest .
     python -m build


### PR DESCRIPTION
This PR adds a docstring checking script and tox check command to check that body and parameter sections of all docstrings are separated by exactly one blank line (This was causing docs to render improperly).

For extensibility purposes the script is separated into a method to check for the specific error on file-by-file basis and a method to recursively walk through all files in a given directory path that calls the error checking method.  This way we can easily add checks for other docstring errors if needed.

This closes #330.