### PR TITLE
Whiten Extremal Value

### DIFF
--- a/src/aspire/operators/filters.py
+++ b/src/aspire/operators/filters.py
@@ -207,7 +207,7 @@ class PowerFilter(Filter):
         if self._power < 0:
             eps = np.finfo(filter_vals.dtype).eps
             threshold = eps**self._power
-            ind = np.where(filter_vals > threshold)
+            ind = np.where(abs(filter_vals) > threshold)
             if len(ind[0]) > 0:
                 logger.warning(
                     f"{self} setting {len(ind[0])} extremal filter value(s) to zero."

--- a/src/aspire/operators/filters.py
+++ b/src/aspire/operators/filters.py
@@ -207,6 +207,11 @@ class PowerFilter(Filter):
         if self._power < 0:
             eps = np.finfo(filter_vals.dtype).eps
             threshold = eps**self._power
+            ind = np.where(filter_vals > threshold)
+            if len(ind[0]) > 0:
+                logger.warning(
+                    f"{self} setting {len(ind[0])} extremal filter value(s) to zero."
+                )
             filter_vals[filter_vals > threshold] = 0
 
         return filter_vals

--- a/src/aspire/operators/filters.py
+++ b/src/aspire/operators/filters.py
@@ -199,10 +199,17 @@ class PowerFilter(Filter):
 
         See `Filter.evaluate_grid` for usage.
         """
-
-        return (
+        filter_vals = (
             self._filter.evaluate_grid(L, dtype=dtype, *args, **kwargs) ** self._power
         )
+
+        # Place safeguard on values below machine epsilon.
+        if self._power < 0:
+            eps = np.finfo(filter_vals.dtype).eps
+            threshold = eps**self._power
+            filter_vals[filter_vals > threshold] = 0
+
+        return filter_vals
 
 
 class LambdaFilter(Filter):
@@ -340,7 +347,6 @@ class ArrayFilter(Filter):
 
         See Filter.evaluate_grid for usage.
         """
-
         if all(dim == L for dim in self.xfer_fn_array.shape):
             logger.debug(
                 "Size of transfer function matches evaluate_grid size L exactly,"

--- a/src/aspire/utils/relion_interop.py
+++ b/src/aspire/utils/relion_interop.py
@@ -44,7 +44,7 @@ relion_metadata_fields = {
     "_rlnNrOfSignificantSamples": float,
     "_rlnNrOfFrames": int,
     "_rlnMaxValueProbDistribution": float,
-    "_rlnOpticsGroup": float,
+    "_rlnOpticsGroup": int,
     "_rlnOpticsGroupName": str,
 }
 

--- a/src/aspire/utils/relion_interop.py
+++ b/src/aspire/utils/relion_interop.py
@@ -44,7 +44,7 @@ relion_metadata_fields = {
     "_rlnNrOfSignificantSamples": float,
     "_rlnNrOfFrames": int,
     "_rlnMaxValueProbDistribution": float,
-    "_rlnOpticsGroup": int,
+    "_rlnOpticsGroup": float,
     "_rlnOpticsGroupName": str,
 }
 


### PR DESCRIPTION
Implements a fix for extremal values when using `image.whiten()`. See issue #658 

This first attempt implements a safeguard in `PowerFilter` whenever `self._power` is negative. Sets filter values to zero whenever omega is less than machine epsilon. 

This implementation resolves the issue encountered in the provided users script. 