### PR TITLE
Nearest Rotation SVD Method

### DIFF
--- a/src/aspire/abinitio/commonline_sdp.py
+++ b/src/aspire/abinitio/commonline_sdp.py
@@ -5,6 +5,7 @@ import numpy as np
 from scipy.sparse import csr_array
 
 from aspire.abinitio import CLOrient3D
+from aspire.utils import nearest_rotations
 from aspire.utils.matlab_compat import stable_eigsh
 
 logger = logging.getLogger(__name__)
@@ -192,8 +193,7 @@ class CommonlineSDP(CLOrient3D):
 
         # Make sure that we got rotations by enforcing R to be
         # a rotation (in case the error is large)
-        u, _, v = np.linalg.svd(rotations)
-        np.einsum("ijk, ikl -> ijl", u, v, out=rotations)
+        rotations = nearest_rotations(rotations)
 
         return rotations
 

--- a/src/aspire/abinitio/commonline_sync.py
+++ b/src/aspire/abinitio/commonline_sync.py
@@ -3,6 +3,7 @@ import logging
 import numpy as np
 
 from aspire.abinitio import CLOrient3D, SyncVotingMixin
+from aspire.utils import nearest_rotations
 from aspire.utils.matlab_compat import stable_eigsh
 
 logger = logging.getLogger(__name__)
@@ -138,8 +139,7 @@ class CLSyncVoting(CLOrient3D, SyncVotingMixin):
         rotations[:, :, 2] = r3.T
         # Make sure that we got rotations by enforcing R to be
         # a rotation (in case the error is large)
-        u, _, v = np.linalg.svd(rotations)
-        np.einsum("ijk, ikl -> ijl", u, v, out=rotations)
+        rotations = nearest_rotations(rotations)
 
         self.rotations = rotations
 

--- a/src/aspire/utils/__init__.py
+++ b/src/aspire/utils/__init__.py
@@ -46,6 +46,7 @@ from .matrix import (
     make_symmat,
     mat_to_vec,
     mdim_mat_fun_conj,
+    nearest_rotations,
     roll_dim,
     symmat_to_vec,
     symmat_to_vec_iso,

--- a/src/aspire/utils/matrix.py
+++ b/src/aspire/utils/matrix.py
@@ -457,7 +457,7 @@ def nearest_rotations(A):
     U, _, V = np.linalg.svd(A)
     neg_det_idx = np.linalg.det(U) * np.linalg.det(V) < 0
     U[neg_det_idx] = U[neg_det_idx] @ np.diag((1, 1, -1)).astype(dtype, copy=False)
-    rots = np.einsum("ijk, ikl -> ijl", U, V)
+    rots = U @ V
 
     return rots.reshape(og_shape)
 

--- a/src/aspire/utils/matrix.py
+++ b/src/aspire/utils/matrix.py
@@ -452,10 +452,11 @@ def nearest_rotations(A):
         )
 
     # For the singular value decomposition A = U @ S @ V, we compute the nearest rotation
-    # matrices R = U @ V, ensuring first that det(U)*det(V) = 1.
+    # matrices R = U @ V. If det(U)*det(V) = -1, we negate the third singular value to ensure
+    # we have a rotation.
     U, _, V = np.linalg.svd(A)
-    neg_det = np.linalg.det(U) * np.linalg.det(V) < 0
-    U[neg_det] = U[neg_det] @ np.diag((1, 1, -1)).astype(dtype, copy=False)
+    neg_det_idx = np.linalg.det(U) * np.linalg.det(V) < 0
+    U[neg_det_idx] = U[neg_det_idx] @ np.diag((1, 1, -1)).astype(dtype, copy=False)
     rots = np.einsum("ijk, ikl -> ijl", U, V)
 
     return rots.reshape(og_shape)

--- a/src/aspire/utils/matrix.py
+++ b/src/aspire/utils/matrix.py
@@ -458,7 +458,7 @@ def nearest_rotations(A):
     U[neg_det] = U[neg_det] @ np.diag((1, 1, -1)).astype(dtype, copy=False)
     rots = np.einsum("ijk, ikl -> ijl", U, V)
 
-    return rots
+    return rots.reshape(og_shape)
 
 
 def fix_signs(u):

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -419,7 +419,7 @@ def _is_rotation(R, dtype):
         R = R[np.newaxis]
 
     n_rots = len(R)
-    RTR = np.transpose(R, axes=(0,2,1)) @ R
+    RTR = np.transpose(R, axes=(0, 2, 1)) @ R
     atol = utest_tolerance(dtype)
     np.testing.assert_allclose(
         RTR, np.broadcast_to(np.eye(3), (n_rots, 3, 3)), atol=atol

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -376,18 +376,22 @@ def test_nearest_rotations(dtype):
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_nearest_rotations_reflection(dtype):
-    rots = Rotation.generate_random_rotations(1, seed=0, dtype=dtype).matrices
+    # Generate singleton rotation.
+    rot = Rotation.generate_random_rotations(1, seed=0, dtype=dtype).matrices[0]
 
     # Add a reflection and some noise to the rotation.
-    refl = rots @ np.diag((1, -1, 1)).astype(dtype)
+    refl = rot @ np.diag((1, -1, 1)).astype(dtype)
     noise = 1e-3 * randn(9, seed=0).astype(dtype, copy=False).reshape(3, 3)
     noisy_refl = refl + noise
 
-    # Find nearest rotations
+    # Find nearest rotation.
     nearest_rot = nearest_rotations(noisy_refl)
 
     # Check that estimates are rotation matrices.
     _is_rotation(nearest_rot, dtype)
+
+    # Check that we retain singleton shape.
+    assert nearest_rot.shape == rot.shape
 
 
 def _is_rotation(R, dtype):

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -396,12 +396,12 @@ def test_nearest_rotations_reflection(dtype):
 
 def test_nearest_rotations_error():
     # Check error for bad ndim.
-    A = randn(2 * 5 * 3 * 3, seed=0).reshape(2, 5, 3, 3)
+    A = np.empty((2, 5, 3, 3))
     with pytest.raises(ValueError, match="Array must be of shape"):
         _ = nearest_rotations(A)
 
     # Check error for bad shape.
-    A = randn(5 * 3 * 2, seed=0).reshape(5, 3, 2)
+    A = np.empty((5, 3, 2))
     with pytest.raises(ValueError, match="Array must be of shape"):
         _ = nearest_rotations(A)
 
@@ -419,7 +419,7 @@ def _is_rotation(R, dtype):
         R = R[np.newaxis]
 
     n_rots = len(R)
-    RTR = np.einsum("ikj,ikl->ijl", R, R)
+    RTR = np.transpose(R, axes=(0,2,1)) @ R
     atol = utest_tolerance(dtype)
     np.testing.assert_allclose(
         RTR, np.broadcast_to(np.eye(3), (n_rots, 3, 3)), atol=atol

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -355,7 +355,7 @@ def test_nearest_rotations(dtype):
     n_rots = 5
     rots = Rotation.generate_random_rotations(n_rots, seed=0, dtype=dtype).matrices
 
-    # Add some noise to the rotation.
+    # Add some noise to the rotations.
     noise = 1e-3 * randn(n_rots * 9, seed=0).astype(dtype, copy=False).reshape(
         n_rots, 3, 3
     )
@@ -387,7 +387,7 @@ def test_nearest_rotations_reflection(dtype):
     # Find nearest rotation.
     nearest_rot = nearest_rotations(noisy_refl)
 
-    # Check that estimates are rotation matrices.
+    # Check that estimate is a rotation.
     _is_rotation(nearest_rot, dtype)
 
     # Check that we retain singleton shape.

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -394,6 +394,18 @@ def test_nearest_rotations_reflection(dtype):
     assert nearest_rot.shape == rot.shape
 
 
+def test_nearest_rotations_error():
+    # Check error for bad ndim.
+    A = randn(2 * 5 * 3 * 3, seed=0).reshape(2, 5, 3, 3)
+    with pytest.raises(ValueError, match="Array must be of shape"):
+        _ = nearest_rotations(A)
+
+    # Check error for bad shape.
+    A = randn(5 * 3 * 2, seed=0).reshape(5, 3, 2)
+    with pytest.raises(ValueError, match="Array must be of shape"):
+        _ = nearest_rotations(A)
+
+
 def _is_rotation(R, dtype):
     """
     Helper function to check if a set of 3x3 matrices are rotations


### PR DESCRIPTION
This PR adds a utility function to find the set of nearest rotations for a 3x3 or nx3x3 array.

In the case of the nearest orthogonal matrix being a reflection, this method negates the third singular value to produce a rotation.

Closes #1023 