### PR TITLE
add author note and paper to ctf module

### DIFF
--- a/src/aspire/ctf/ctf_estimator.py
+++ b/src/aspire/ctf/ctf_estimator.py
@@ -1,8 +1,26 @@
 """
+Contains code supporting CTF parameter estimation.
+Generally, this is a port of ASPIRE-CTF from MATLAB.
+
+See paper:
+
+  |    "Reducing bias and variance for CTF estimation in single particle cryo-EM"
+  |    Ayelet Heimowitz, Joakim Andén, Amit Singer
+  |    Ultramicroscopy, Volume 212, 2020
+  |    https://doi.org/10.1016/j.ultramic.2020.112950.
+
+Note:
+`CtfEstimator` computes the background as a monotonically decreasing
+function of spatial frequency. This practice may lead to an inaccurate
+background estimation for experimental images produced using a K2
+camera in counting mode, as the background in this case is not
+monotonically decreasing. Despite this, CTF parameters are captured
+successfully in such situations.
+
 Created on Sep 10, 2019
 @author: Ayelet Heimowitz, Amit Moscovich
 
-Integrated into ASPIRE by Garrett Wright Feb 2021.
+Integrated into ASPIRE-Python by Garrett Wright Feb 2021.
 """
 
 import logging

--- a/src/aspire/ctf/ctf_estimator.py
+++ b/src/aspire/ctf/ctf_estimator.py
@@ -10,7 +10,7 @@ See paper:
   |    https://doi.org/10.1016/j.ultramic.2020.112950.
 
 Note:
-`CtfEstimator` computes the background as a monotonically decreasing
+``CtfEstimator`` computes the background as a monotonically decreasing
 function of spatial frequency. This practice may lead to an inaccurate
 background estimation for experimental images produced using a K2
 camera in counting mode, as the background in this case is not


### PR DESCRIPTION
Closes #1036 .  Changed the name of the function to ASPIRE-Python's class and the last sentence.  Otherwise taken from author.

Here is the rendered doc page for `aspire.ctf`:

<img width="668" alt="Screenshot 2023-11-08 at 8 00 08 AM" src="https://github.com/ComputationalCryoEM/ASPIRE-Python/assets/47759732/3707df9f-d1ca-49db-88ed-ed95501eb821">
