### PR TITLE
PSWF/FPSWF 2d grid convention

### DIFF
--- a/src/aspire/basis/fpswf_2d.py
+++ b/src/aspire/basis/fpswf_2d.py
@@ -177,8 +177,8 @@ class FPSWFBasis2D(PSWFBasis2D):
             ]
         )
 
-        pts_x = quad_rule_pts_r * np.cos(quad_rule_pts_theta)
-        pts_y = quad_rule_pts_r * np.sin(quad_rule_pts_theta)
+        pts_x = quad_rule_pts_r * np.sin(quad_rule_pts_theta)
+        pts_y = quad_rule_pts_r * np.cos(quad_rule_pts_theta)
 
         return (
             pts_x,

--- a/src/aspire/basis/fpswf_2d.py
+++ b/src/aspire/basis/fpswf_2d.py
@@ -177,12 +177,12 @@ class FPSWFBasis2D(PSWFBasis2D):
             ]
         )
 
-        pts_x = quad_rule_pts_r * np.sin(quad_rule_pts_theta)
-        pts_y = quad_rule_pts_r * np.cos(quad_rule_pts_theta)
+        pts_x = quad_rule_pts_r * np.cos(quad_rule_pts_theta)
+        pts_y = quad_rule_pts_r * np.sin(quad_rule_pts_theta)
 
         return (
-            pts_x,
             pts_y,
+            pts_x,
             quad_rule_weights,
             radial_quad_points,
             quad_rule_radial_weights,

--- a/src/aspire/basis/pswf_2d.py
+++ b/src/aspire/basis/pswf_2d.py
@@ -83,7 +83,7 @@ class PSWFBasis2D(SteerableBasis2D):
         """
         Generate the 2D sampling grid
         """
-        grid = grid_2d(self.nres, normalized=False, indexing="xy")
+        grid = grid_2d(self.nres, normalized=False, indexing="yx")
         self._disk_mask = grid["r"] <= self.rcut
         self._r_disk = grid["r"][self._disk_mask] / self.rcut
         self._theta_disk = grid["phi"][self._disk_mask]

--- a/src/aspire/basis/pswf_2d.py
+++ b/src/aspire/basis/pswf_2d.py
@@ -403,19 +403,3 @@ class PSWFBasis2D(SteerableBasis2D):
         See `SteerableBasis2D.filter_to_basis_mat`.
         """
         return super().filter_to_basis_mat(*args, **kwargs)
-
-    def rotate(self, coef, radians, refl=None):
-        """
-        See `SteerableBasis2D.rotate`.
-        """
-        # {F}PSWF rotation convention is still CW internally.
-        # This will make things consistent until that is addressed.
-        return super().rotate(coef, -radians, refl=refl)
-
-    def complex_rotate(self, complex_coef, radians, refl=None):
-        """
-        See `SteerableBasis2D.rotate`.
-        """
-        # {F}PSWF rotation convention is still CW internally.
-        # This will make things consistent until that is addressed.
-        return super().complex_rotate(complex_coef, -radians, refl=refl)

--- a/tests/test_FPSWFbasis2D.py
+++ b/tests/test_FPSWFbasis2D.py
@@ -17,12 +17,11 @@ test_bases = [FPSWFBasis2D(L, dtype=dtype) for L, dtype in pswf_params_2d]
 @pytest.mark.parametrize("basis", test_bases, ids=show_basis_params)
 class TestFPSWFBasis2D(UniversalBasisMixin):
     def testFPSWFBasis2DEvaluate_t(self, basis):
-        img_ary = np.load(
-            os.path.join(DATA_DIR, "ffbbasis2d_xcoef_in_8_8.npy")
-        ).T  # RCOPT
+        img_ary = np.load(os.path.join(DATA_DIR, "ffbbasis2d_xcoef_in_8_8.npy"))
         images = Image(img_ary)
 
         result = basis.evaluate_t(images)
+
         # Historically, FPSWF returned complex values.
         # Load and convert them for this hard coded test.
         ccoefs = np.load(os.path.join(DATA_DIR, "pswf2d_vcoefs_out_8_8.npy")).T  # RCOPT
@@ -37,7 +36,9 @@ class TestFPSWFBasis2D(UniversalBasisMixin):
         coefs = ComplexCoef(basis, ccoefs).to_real()
         result = coefs.evaluate()
 
-        result = basis.evaluate(coefs)
-        images = np.load(os.path.join(DATA_DIR, "pswf2d_xcoef_out_8_8.npy")).T  # RCOPT
+        # This hardcoded reference result requires transposing the stack axis.
+        images = np.transpose(
+            np.load(os.path.join(DATA_DIR, "pswf2d_xcoef_out_8_8.npy")), (2, 0, 1)
+        )
 
-        np.testing.assert_allclose(result, images, rtol=1e-05, atol=1e-08)
+        np.testing.assert_allclose(result.asnumpy(), images, rtol=1e-05, atol=1e-08)

--- a/tests/test_PSWFbasis2D.py
+++ b/tests/test_PSWFbasis2D.py
@@ -16,9 +16,7 @@ test_bases = [PSWFBasis2D(L, dtype=dtype) for L, dtype in pswf_params_2d]
 @pytest.mark.parametrize("basis", test_bases, ids=show_basis_params)
 class TestPSWFBasis2D(UniversalBasisMixin):
     def testPSWFBasis2DEvaluate_t(self, basis):
-        img_ary = np.load(
-            os.path.join(DATA_DIR, "ffbbasis2d_xcoef_in_8_8.npy")
-        ).T  # RCOPT
+        img_ary = np.load(os.path.join(DATA_DIR, "ffbbasis2d_xcoef_in_8_8.npy"))
         images = Image(img_ary)
 
         result = basis.evaluate_t(images)
@@ -37,5 +35,10 @@ class TestPSWFBasis2D(UniversalBasisMixin):
         coefs = ComplexCoef(basis, ccoefs).to_real()
 
         result = coefs.evaluate()
-        images = np.load(os.path.join(DATA_DIR, "pswf2d_xcoef_out_8_8.npy")).T  # RCOPT
-        assert np.allclose(result.asnumpy(), images)
+
+        # This hardcoded reference result requires transposing the stack axis.
+        images = np.transpose(
+            np.load(os.path.join(DATA_DIR, "pswf2d_xcoef_out_8_8.npy")), (2, 0, 1)
+        )
+
+        np.testing.assert_allclose(result.asnumpy(), images, rtol=1e-05, atol=1e-08)


### PR DESCRIPTION
Follow up for the 2d prolate basis.  Updates to use the `yx` internally in the basis.  Also should rm the previously required rotation override hack.

This was broken out to avoid commingling changing the unit tests in the middle of the basis interop structural changes.

I will manually run these in a notebook and review the output of cov2d, class avg, and rotate before opening to review.