### PR TITLE
tmp extend develop timeout to 12 hours

### DIFF
--- a/.github/workflows/long_workflow.yml
+++ b/.github/workflows/long_workflow.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   expensive_tests:
     runs-on: self-hosted
+    timeout-minutes: 720
     steps:
     - uses: actions/checkout@v3
     - name: Install dependencies


### PR DESCRIPTION
Pushing this in to restore CI.

See #1039 