### PR TITLE
Reduce class_avg_src test time

### DIFF
--- a/.github/workflows/long_workflow.yml
+++ b/.github/workflows/long_workflow.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   expensive_tests:
     runs-on: self-hosted
-    timeout-minutes: 720
+    timeout-minutes: 360
     steps:
     - uses: actions/checkout@v3
     - name: Install dependencies


### PR DESCRIPTION
This reduces the long running test time of the `class_avg_src.py` group of tests.  This is accomplished by i) reducing the problem size ii) computing less class averages iii) fixture re-use.