### PR TITLE
Reduce cls avg flakyness for tiny unit tests

### DIFF
--- a/src/aspire/classification/legacy_implementations.py
+++ b/src/aspire/classification/legacy_implementations.py
@@ -154,7 +154,7 @@ def bispec_2drot_large(coef, freqs, eigval, alpha, sample_n, seed=None):
     m = np.exp(o1 * coef_norm + 1j * o2 * phase)
 
     # svd of the reduced bispectrum
-    u, s, v = pca_y(m, 300, seed=seed)
+    u, s, v = pca_y(m, min(300, len(m)), seed=seed)
 
     coef_b = np.einsum("i, ij -> ij", s, np.conjugate(v))
     coef_b_r = np.conjugate(u.T).dot(np.conjugate(m))

--- a/tests/test_class_src.py
+++ b/tests/test_class_src.py
@@ -35,6 +35,8 @@ logger = logging.getLogger(__name__)
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "saved_test_data")
 
+# RNG SEED, should help small class average tests be deterministic.
+SEED = 5552368
 
 IMG_SIZES = [
     16,
@@ -151,6 +153,7 @@ def classifier(class_sim_fixture):
         large_pca_implementation="legacy",
         nn_implementation="legacy",
         bispectrum_implementation="legacy",
+        seed=SEED,
     )
 
 
@@ -223,6 +226,7 @@ def cls_fixture(class_sim_fixture):
         bispectrum_components=101,  # Compressed Features after last PCA stage.
         n_nbor=10,
         nn_implementation="sklearn",
+        seed=SEED,
     )
     # Compute the classification
     # (classes, reflections, distances)


### PR DESCRIPTION
This test was already slowly driving me mad, and making the images smaller (for speed) made it worse.  Hoping this finally resolves.

- Adds small array handling hack used in MATLAB code
- Fixes seed in classifier

