### PR TITLE
Indices cleanup

### DIFF
--- a/src/aspire/basis/basis.py
+++ b/src/aspire/basis/basis.py
@@ -409,12 +409,6 @@ class Basis:
         """
         raise NotImplementedError("subclasses must implement this")
 
-    def indices(self):
-        """
-        Create the indices for each basis function
-        """
-        raise NotImplementedError("subclasses must implement this")
-
     def _precomp(self):
         """
         Precompute the basis functions at defined sample points

--- a/src/aspire/basis/fb_2d.py
+++ b/src/aspire/basis/fb_2d.py
@@ -63,7 +63,6 @@ class FBBasis2D(SteerableBasis2D, FBBasisMixin):
 
         # generate 1D indices for basis functions
         self._compute_indices()
-        self._indices = self.indices()
 
         # get normalized factors
         self.radial_norms, self.angular_norms = self.norms()
@@ -109,16 +108,6 @@ class FBBasis2D(SteerableBasis2D, FBBasisMixin):
         self.angular_indices = indices_ells
         self.radial_indices = indices_ks
         self.signs_indices = indices_sgns
-
-    def indices(self):
-        """
-        Return the precomputed indices for each basis function.
-        """
-        return {
-            "ells": self.angular_indices,
-            "ks": self.radial_indices,
-            "sgns": self.signs_indices,
-        }
 
     def _precomp(self):
         """

--- a/src/aspire/basis/ffb_2d.py
+++ b/src/aspire/basis/ffb_2d.py
@@ -124,7 +124,7 @@ class FFBBasis2D(FBBasis2D):
 
         # include the normalization factor of angular part into radial part
         radial_norm = self._precomp["radial"] / np.expand_dims(self.angular_norms, 1)
-        pf[:, 0, :] = v[:, self._zero_angular_indices] @ radial_norm[idx]
+        pf[:, 0, :] = v[:, self._zero_angular_inds] @ radial_norm[idx]
         ind = ind + np.size(idx)
 
         ind_pos = ind
@@ -217,7 +217,7 @@ class FFBBasis2D(FBBasis2D):
 
         # include the normalization factor of angular part into radial part
         radial_norm = self._precomp["radial"] / np.expand_dims(self.angular_norms, 1)
-        v[:, self._zero_angular_indices] = pf[:, :, 0].real @ radial_norm[idx].T
+        v[:, self._zero_angular_inds] = pf[:, :, 0].real @ radial_norm[idx].T
         ind = ind + np.size(idx)
 
         ind_pos = ind

--- a/src/aspire/basis/ffb_2d.py
+++ b/src/aspire/basis/ffb_2d.py
@@ -51,7 +51,6 @@ class FFBBasis2D(FBBasis2D):
 
         # generate 1D indices for basis functions
         self._compute_indices()
-        self._indices = self.indices()
 
         # get normalized factors
         self.radial_norms, self.angular_norms = self.norms()
@@ -118,7 +117,6 @@ class FFBBasis2D(FBBasis2D):
 
         # go through  each basis function and find corresponding coefficient
         pf = np.zeros((n_data, 2 * n_theta, n_r), dtype=complex_type(self.dtype))
-        mask = self._indices["ells"] == 0
 
         ind = 0
 
@@ -126,7 +124,7 @@ class FFBBasis2D(FBBasis2D):
 
         # include the normalization factor of angular part into radial part
         radial_norm = self._precomp["radial"] / np.expand_dims(self.angular_norms, 1)
-        pf[:, 0, :] = v[:, mask] @ radial_norm[idx]
+        pf[:, 0, :] = v[:, self._zero_angular_indices] @ radial_norm[idx]
         ind = ind + np.size(idx)
 
         ind_pos = ind
@@ -216,11 +214,10 @@ class FFBBasis2D(FBBasis2D):
         # go through each basis function and find the corresponding coefficient
         ind = 0
         idx = ind + np.arange(self.k_max[0])
-        mask = self._indices["ells"] == 0
 
         # include the normalization factor of angular part into radial part
         radial_norm = self._precomp["radial"] / np.expand_dims(self.angular_norms, 1)
-        v[:, mask] = pf[:, :, 0].real @ radial_norm[idx].T
+        v[:, self._zero_angular_indices] = pf[:, :, 0].real @ radial_norm[idx].T
         ind = ind + np.size(idx)
 
         ind_pos = ind

--- a/src/aspire/basis/fle_2d.py
+++ b/src/aspire/basis/fle_2d.py
@@ -143,16 +143,6 @@ class FLEBasis2D(SteerableBasis2D, FBBasisMixin):
 
             ci += len(ks)
 
-    def indices(self):
-        """
-        Return the precomputed indices for each basis function.
-        """
-        return {
-            "ells": self.angular_indices,
-            "ks": self.radial_indices,
-            "sgns": self.signs_indices,
-        }
-
     def _precomp(self):
         """
         Precompute the basis functions and other objects used in the evaluation of

--- a/src/aspire/basis/fspca.py
+++ b/src/aspire/basis/fspca.py
@@ -71,7 +71,7 @@ class FSPCABasis(SteerableBasis2D):
         self.complex_count = self.basis.complex_count
         self.angular_indices = self.basis.angular_indices
         self.radial_indices = self.basis.radial_indices
-        self.signs_indices = self.basis._indices["sgns"]
+        self.signs_indices = self.basis.signs_indices
         self.complex_angular_indices = self.basis.complex_angular_indices
         self.complex_radial_indices = self.basis.complex_radial_indices
 
@@ -243,7 +243,7 @@ class FSPCABasis(SteerableBasis2D):
         self.mean_coef_zero = self.mean_coef_est.asnumpy()[0][self.angular_indices == 0]
 
         # Define mask for zero angular mode, used in loop below
-        zero_ell_mask = self.basis._indices["ells"] == 0
+        zero_ell_mask = self.basis.angular_indices == 0
 
         # Apply Data matrix batchwise
         num_batches = (self.src.n + self.batch_size - 1) // self.batch_size
@@ -275,9 +275,9 @@ class FSPCABasis(SteerableBasis2D):
             for ell in range(
                 1, self.basis.ell_max + 1
             ):  # `ell` in this code is `k` from paper
-                mask_ell = self.basis._indices["ells"] == ell
-                mask_pos = mask_ell & (self.basis._indices["sgns"] == +1)
-                mask_neg = mask_ell & (self.basis._indices["sgns"] == -1)
+                mask_ell = self.basis.angular_indices == ell
+                mask_pos = mask_ell & (self.basis.signs_indices == +1)
+                mask_neg = mask_ell & (self.basis.signs_indices == -1)
 
                 A.append(batch_coef[:, mask_pos])
                 A.append(batch_coef[:, mask_neg])
@@ -405,8 +405,8 @@ class FSPCABasis(SteerableBasis2D):
         top_components = list(ordered_components)[: self.components]
 
         # Now we need to find the locations of both the + and - sgns.
-        pos_mask = self.basis._indices["sgns"] == 1
-        neg_mask = self.basis._indices["sgns"] == -1
+        pos_mask = self.basis.signs_indices == 1
+        neg_mask = self.basis.signs_indices == -1
         compressed_indices = []
         for k, q in top_components:
             # Compute the locations of coefs we're interested in.

--- a/src/aspire/basis/pswf_2d.py
+++ b/src/aspire/basis/pswf_2d.py
@@ -94,14 +94,6 @@ class PSWFBasis2D(SteerableBasis2D):
         """
         self._generate_samples()
 
-        self.non_neg_freq_inds = slice(0, len(self.complex_angular_indices))
-
-        tmp = np.nonzero(self.complex_angular_indices == 0)[0]
-        self.zero_freq_inds = slice(tmp[0], tmp[-1] + 1)
-
-        tmp = np.nonzero(self.complex_angular_indices > 0)[0]
-        self.pos_freq_inds = slice(tmp[0], tmp[-1] + 1)
-
     def _generate_samples(self):
         """
         Generate sample points for PSWF functions

--- a/src/aspire/basis/pswf_2d.py
+++ b/src/aspire/basis/pswf_2d.py
@@ -181,18 +181,6 @@ class PSWFBasis2D(SteerableBasis2D):
 
             ci += len(ks)
 
-    # Added for compatibility.
-    # Probably can remove `indices` dict wholesale later (MATLAB holdover).
-    def indices(self):
-        """
-        Return the precomputed indices for each basis function.
-        """
-        return {
-            "ells": self.angular_indices,
-            "ks": self.radial_indices,
-            "sgns": self.signs_indices,
-        }
-
     def _evaluate_t(self, images):
         """
         Evaluate coefficient vectors in PSWF basis using the direct method

--- a/src/aspire/basis/steerable.py
+++ b/src/aspire/basis/steerable.py
@@ -33,7 +33,6 @@ class SteerableBasis2D(Basis, abc.ABC):
         self._blk_diag_cov_shape = None
 
         # Centralize indices attributes between FB/PSWF/FLE in SteerableBasis2D
-        self._indices = self.indices()
         self.complex_count = self.count - sum(self._neg_angular_inds)
         self.complex_angular_indices = self.angular_indices[self._non_neg_angular_inds]
         self.complex_radial_indices = self.radial_indices[self._non_neg_angular_inds]

--- a/src/aspire/covariance/covar2d.py
+++ b/src/aspire/covariance/covar2d.py
@@ -123,9 +123,10 @@ class RotCov2D:
         if coefs.size == 0:
             raise RuntimeError("The coefficients need to be calculated first!")
 
-        mask = self.basis._indices["ells"] == 0
         mean_coef = np.zeros(self.basis.count, dtype=coefs.dtype)
-        mean_coef[mask] = np.mean(coefs[..., mask], axis=0)
+        mean_coef[self.basis._zero_angular_inds] = np.mean(
+            coefs[..., self.basis._zero_angular_inds], axis=0
+        )
 
         return mean_coef
 
@@ -147,16 +148,16 @@ class RotCov2D:
         covar_coef = BlkDiagMatrix.empty(0, dtype=coefs.dtype)
         ell = 0
 
-        mask = self.basis._indices["ells"] == ell
+        mask = self.basis.angular_indices == ell
 
         coef_ell = coefs[..., mask] - mean_coef[mask]
         covar_ell = np.array(coef_ell.T @ coef_ell / coefs.shape[0])
         covar_coef.append(covar_ell)
 
         for ell in range(1, self.basis.ell_max + 1):
-            mask_ell = self.basis._indices["ells"] == ell
-            mask_pos = mask_ell & (self.basis._indices["sgns"] == +1)
-            mask_neg = mask_ell & (self.basis._indices["sgns"] == -1)
+            mask_ell = self.basis.angular_indices == ell
+            mask_pos = mask_ell & (self.basis.signs_indices == +1)
+            mask_neg = mask_ell & (self.basis.signs_indices == -1)
 
             covar_ell_diag = np.array(
                 coefs[:, mask_pos].T @ coefs[:, mask_pos]

--- a/src/aspire/ctf/ctf_estimator.py
+++ b/src/aspire/ctf/ctf_estimator.py
@@ -287,13 +287,13 @@ class CtfEstimator:
         coefs_s = ffbbasis.evaluate_t(amplitude_spectrum).asnumpy().copy().T
         coefs_n = coefs_s.copy()
 
-        coefs_s[np.argwhere(ffbbasis._indices["ells"] == 1)] = 0
+        coefs_s[np.argwhere(ffbbasis.angular_indices == 1)] = 0
         if circular:
-            coefs_s[np.argwhere(ffbbasis._indices["ells"] == 2)] = 0
+            coefs_s[np.argwhere(ffbbasis.angular_indices == 2)] = 0
             noise = amplitude_spectrum
         else:
-            coefs_n[np.argwhere(ffbbasis._indices["ells"] == 0)] = 0
-            coefs_n[np.argwhere(ffbbasis._indices["ells"] == 2)] = 0
+            coefs_n[np.argwhere(ffbbasis.angular_indices == 0)] = 0
+            coefs_n[np.argwhere(ffbbasis.angular_indices == 2)] = 0
             noise = Coef(ffbbasis, coefs_n.T).evaluate()
 
         psd = Coef(ffbbasis, coefs_s.T).evaluate()

--- a/tests/_basis_util.py
+++ b/tests/_basis_util.py
@@ -45,8 +45,6 @@ class Steerable2DMixin:
         ell_max = basis.ell_max
         k_max = basis.k_max
 
-        indices = basis.indices()
-
         i = 0
 
         for ell in range(ell_max + 1):
@@ -57,9 +55,9 @@ class Steerable2DMixin:
 
             for sgn in sgns:
                 for k in range(k_max[ell]):
-                    assert indices["ells"][i] == ell
-                    assert indices["sgns"][i] == sgn
-                    assert indices["ks"][i] == k
+                    assert basis.angular_indices[i] == ell
+                    assert basis.signs_indices[i] == sgn
+                    assert basis.radial_indices[i] == k
 
                     i += 1
 
@@ -99,7 +97,7 @@ class Steerable2DMixin:
 
         coef_np = basis.expand(im).asnumpy()
 
-        ells = basis.indices()["ells"]
+        ells = basis.angular_indices
 
         energy_outside = np.sum(np.abs(coef_np[..., ells != 0]) ** 2)
         energy_total = np.sum(np.abs(coef_np) ** 2)
@@ -125,7 +123,7 @@ class Steerable2DMixin:
 
             coef_np = basis.expand(im1).asnumpy()
 
-            ells = basis.indices()["ells"]
+            ells = basis.angular_indices
 
             energy_outside = np.sum(np.abs(coef_np[..., ells != ell]) ** 2)
             energy_total = np.sum(np.abs(coef_np) ** 2)

--- a/tests/test_FBbasis2D.py
+++ b/tests/test_FBbasis2D.py
@@ -33,10 +33,9 @@ class TestFBBasis2D(UniversalBasisMixin, Steerable2DMixin):
         # This is covered by the isotropic test.
         assert ell > 0
 
-        indices = basis.indices()
-        ells = indices["ells"]
-        sgns = indices["sgns"]
-        ks = indices["ks"]
+        ells = basis.angular_indices
+        sgns = basis.signs_indices
+        ks = basis.radial_indices
 
         g2d = grid_2d(basis.nres, dtype=basis.dtype)
         mask = g2d["r"] < 1

--- a/tests/test_FFBbasis2D.py
+++ b/tests/test_FFBbasis2D.py
@@ -31,10 +31,9 @@ class TestFFBBasis2D(Steerable2DMixin, UniversalBasisMixin):
     seed = 9161341
 
     def _testElement(self, basis, ell, k, sgn):
-        indices = basis.indices()
-        ells = indices["ells"]
-        sgns = indices["sgns"]
-        ks = indices["ks"]
+        ells = basis.angular_indices
+        sgns = basis.signs_indices
+        ks = basis.radial_indices
 
         g2d = grid_2d(basis.nres, dtype=basis.dtype)
         mask = g2d["r"] < 1


### PR DESCRIPTION
Removes deprecated `indices()` method and `_indices` attribute which returned a dictionary.  That implementation originated from porting the legacy MATLAB code which returned a cell array.

Now code base should be using class attributes such as `angular_indices`, `radial_indices`, `signs_indices`, `complex_angular_indices`, etc.

Closes #446 , which was partially addressed across several PRs.