### PR TITLE
Volume rotate/project tests with arbitrary rotations

### DIFF
--- a/src/aspire/volume/volume.py
+++ b/src/aspire/volume/volume.py
@@ -454,8 +454,7 @@ class Volume:
         ), f"Argument must be an instance of the Rotation class. {type(rot_matrices)} was supplied."
 
         # Invert the rotations passed to `rotated_grids_3d` and get numpy representation of Rotation object.
-        rots_inverted = rot_matrices.invert()
-        rots_inverted = rots_inverted.matrices
+        rots_inverted = rot_matrices.invert().matrices
 
         K = len(rots_inverted)  # Rotation stack size
         assert K == self.n_vols or K == 1, "Rotation object must be length 1 or n_vols."

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -307,15 +307,14 @@ def test_project(vols_1, dtype):
     assert np.allclose(results, imgs_clean, atol=1e-7)
 
 
-# Parameterize over even and odd resolutions
-@pytest.mark.parametrize("L", RES)
-def test_rotate_axes(L, dtype):
+def test_rotate_axes(res, dtype):
     # In this test we instantiate Volume instance `vol`, containing a single nonzero
     # voxel in the first octant, and rotate it by multiples of pi/2 about each axis.
     # We then compare to reference volumes containing appropriately located nonzero voxel.
 
     # Create a Volume instance to rotate.
     # This volume has a value of 1 in the first octant at (1, 1, 1) and zeros elsewhere.
+    L = res
     data = np.zeros((L, L, L), dtype=dtype)
     data[L // 2 + 1, L // 2 + 1, L // 2 + 1] = 1
     vol = Volume(data)
@@ -358,13 +357,12 @@ def test_rotate_axes(L, dtype):
         assert np.allclose(ref_vol, rot_vol, atol=utest_tolerance(dtype))
 
 
-@pytest.mark.parametrize("dtype", [np.float32, np.float64])
-@pytest.mark.parametrize("L", [32, 33])
-def test_rotate(L, dtype):
+def test_rotate(res, dtype):
     """
     We rotate Volumes containing random hot/cold spots by random rotations and check that
     hot/cold spots in the rotated Volumes are in the expected locations.
     """
+    L = res
     n_vols = 5
 
     # Generate random locations for hot/cold spots, each at a distance of approximately

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -320,20 +320,20 @@ def test_rotate_axes(L, dtype):
     data[L // 2 + 1, L // 2 + 1, L // 2 + 1] = 1
     vol = Volume(data)
 
-    # Create a dict with map from axis and angle of rotation to new location of nonzero voxel.
+    # Create a dict with map from axis and angle of rotation to new location (z, y, x) of nonzero voxel.
     ref_pts = {
         ("x", 0): (1, 1, 1),
-        ("x", pi / 2): (-1, 1, 1),
+        ("x", pi / 2): (1, -1, 1),
         ("x", pi): (-1, -1, 1),
-        ("x", 3 * pi / 2): (1, -1, 1),
+        ("x", 3 * pi / 2): (-1, 1, 1),
         ("y", 0): (1, 1, 1),
-        ("y", pi / 2): (1, 1, -1),
+        ("y", pi / 2): (-1, 1, 1),
         ("y", pi): (-1, 1, -1),
-        ("y", 3 * pi / 2): (-1, 1, 1),
+        ("y", 3 * pi / 2): (1, 1, -1),
         ("z", 0): (1, 1, 1),
-        ("z", pi / 2): (1, -1, 1),
+        ("z", pi / 2): (1, 1, -1),
         ("z", pi): (1, -1, -1),
-        ("z", 3 * pi / 2): (1, 1, -1),
+        ("z", 3 * pi / 2): (1, -1, 1),
     }
 
     center = np.array([L // 2] * 3)
@@ -402,8 +402,8 @@ def test_rotate(L, dtype):
     for i in range(n_vols):
         new_hot_loc = np.unravel_index(np.argmax(rotated_vols.asnumpy()[i]), (L, L, L))
         new_cold_loc = np.unravel_index(np.argmin(rotated_vols.asnumpy()[i]), (L, L, L))
-        np.testing.assert_allclose(new_hot_spot, expected_locs[i, 0])
-        np.testing.assert_allclose(new_cold_spot, expected_locs[i, 1])
+        np.testing.assert_allclose(new_hot_loc, expected_locs[i, 0])
+        np.testing.assert_allclose(new_cold_loc, expected_locs[i, 1])
 
 
 def test_rotate_broadcast_unicast(asym_vols):

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -313,8 +313,9 @@ def test_project(vols_hot_cold):
 
     # Check that new hot/cold spots are within 1 pixel of expectecd locations.
     for i in range(vols.n_vols):
-        new_hot_loc = np.unravel_index(np.argmax(projections.asnumpy()[i]), (L, L))
-        new_cold_loc = np.unravel_index(np.argmin(projections.asnumpy()[i]), (L, L))
+        p = projections.asnumpy()[i]
+        new_hot_loc = np.unravel_index(np.argmax(p), (L, L))
+        new_cold_loc = np.unravel_index(np.argmin(p), (L, L))
         np.testing.assert_allclose(new_hot_loc, expected_locs[i, 0], atol=1)
         np.testing.assert_allclose(new_cold_loc, expected_locs[i, 1], atol=1)
 
@@ -439,8 +440,9 @@ def test_rotate(vols_hot_cold):
 
     # Check that new hot/cold spots are in expectecd locations.
     for i in range(vols.n_vols):
-        new_hot_loc = np.unravel_index(np.argmax(rotated_vols.asnumpy()[i]), (L, L, L))
-        new_cold_loc = np.unravel_index(np.argmin(rotated_vols.asnumpy()[i]), (L, L, L))
+        v = rotated_vols.asnumpy()[i]
+        new_hot_loc = np.unravel_index(np.argmax(v), (L, L, L))
+        new_cold_loc = np.unravel_index(np.argmin(v), (L, L, L))
         np.testing.assert_allclose(new_hot_loc, expected_locs[i, 0])
         np.testing.assert_allclose(new_cold_loc, expected_locs[i, 1])
 

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -301,10 +301,8 @@ def test_project(vols_hot_cold):
     # produced by rotating the underlying grid) and then project along the z-axis.
 
     # Expected location of hot/cold spots relative to (0, 0, 0) origin in (x, y, z) order.
-    expected_hot_cold = np.transpose(
-        rots.invert().matrices @ np.transpose(hot_cold_locs[..., ::-1], axes=(0, 2, 1)),
-        axes=(0, 2, 1),
-    )
+    # Note, we write the simpler `(x, y, z) @ rots` in place of `(rots.T @ (x, y, z).T).T`
+    expected_hot_cold = hot_cold_locs[..., ::-1] @ rots.matrices
 
     # Expected location of hot/cold spots relative to center (L/2, L/2, L/2) in (z, y, x) order.
     # Then projected along z-axis by dropping the z component.
@@ -428,13 +426,10 @@ def test_rotate(vols_hot_cold):
 
     # Generate random rotations.
     rots = Rotation.generate_random_rotations(n=vols.n_vols, dtype=dtype)
-    rots_mat = rots.matrices
 
     # Expected location of hot/cold spots relative to (0, 0, 0) origin in (x, y, z) order.
-    expected_hot_cold = np.transpose(
-        rots_mat @ np.transpose(hot_cold_locs[..., ::-1], axes=(0, 2, 1)),
-        axes=(0, 2, 1),
-    )
+    # Note, we write the simpler `(x, y, z) @ rots.T` in place of `(rots @ (x, y, z).T).T`
+    expected_hot_cold = hot_cold_locs[..., ::-1] @ rots.invert().matrices
 
     # Expected location of hot/cold spots relative to Volume center (L/2, L/2, L/2) in (z, y, x) order.
     expected_locs = np.round(expected_hot_cold[..., ::-1] + vol_center)

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -295,7 +295,6 @@ def test_project(vols_hot_cold):
 
     # Generate random rotations.
     rots = Rotation.generate_random_rotations(n=vols.n_vols, dtype=dtype)
-    rots_mat = rots.matrices
 
     # To find the expected location of hot/cold spots in the projections we rotate the 3D
     # vector of locations by the transpose, ie. rots.invert(), (since our projections are

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -438,13 +438,13 @@ def test_rotate(vols_hot_cold):
     # Rotate Volumes.
     rotated_vols = vols.rotate(rots)
 
-    # Check that new hot/cold spots are in expectecd locations.
+    # Check that new hot/cold spots are within 1 pixel of expectecd locations.
     for i in range(vols.n_vols):
         v = rotated_vols.asnumpy()[i]
         new_hot_loc = np.unravel_index(np.argmax(v), (L, L, L))
         new_cold_loc = np.unravel_index(np.argmin(v), (L, L, L))
-        np.testing.assert_allclose(new_hot_loc, expected_locs[i, 0])
-        np.testing.assert_allclose(new_cold_loc, expected_locs[i, 1])
+        np.testing.assert_allclose(new_hot_loc, expected_locs[i, 0], atol=1)
+        np.testing.assert_allclose(new_cold_loc, expected_locs[i, 1], atol=1)
 
 
 def test_rotate_broadcast_unicast(asym_vols):


### PR DESCRIPTION
Closes #941 

This PR enforces the convention of `Volume.rotate()` to rotate the volume (not the underlying grid). Also we add a testing for `Volume.project` and `Volume.rotate` that use arbitrary rotations. 