### PR TITLE
increase sample_n for small class averaging problems

### DIFF
--- a/tests/test_class_src.py
+++ b/tests/test_class_src.py
@@ -150,6 +150,7 @@ def classifier(class_sim_fixture):
         fspca_components=123,
         bispectrum_components=101,  # Compressed Features after last PCA stage.
         n_nbor=10,
+        sample_n=50000,
         large_pca_implementation="legacy",
         nn_implementation="legacy",
         bispectrum_implementation="legacy",
@@ -225,6 +226,7 @@ def cls_fixture(class_sim_fixture):
         fspca_components=123,
         bispectrum_components=101,  # Compressed Features after last PCA stage.
         n_nbor=10,
+        sample_n=50000,
         nn_implementation="sklearn",
         seed=SEED,
     )


### PR DESCRIPTION
Another flaky class averaging small unit test update.  Going to merge this one in once CI clears.

This value (50000) is the one recommended by Yoel, but the paper original recommended 4000 as published in our code.  It seems to be working better on `caf` with 50000 at the tiny smoke test resolution.