### PR TITLE
Flaky Sync Voting Test

### DIFF
--- a/tests/test_orient_sync_voting.py
+++ b/tests/test_orient_sync_voting.py
@@ -87,6 +87,9 @@ def test_build_clmatrix(source_orientation_objs):
 
     # Check that at least 98% of estimates are within 5 degrees.
     tol = 0.98
+    if src.offsets.all() != 0:
+        # Set tolerance to 95% when using nonzero offsets.
+        tol = 0.95
     assert within_5 / angle_diffs.size > tol
 
 


### PR DESCRIPTION
Closes #1049.

This PR loosens the testing tolerance for `test_build_clmatrix` when testing on a simulation with nonzero shifts. Changes from 98% to 95% "good" common line indices.