### PR TITLE
use magnitude of eigvals in bispect random vector selection

### DIFF
--- a/src/aspire/classification/legacy_implementations.py
+++ b/src/aspire/classification/legacy_implementations.py
@@ -138,7 +138,7 @@ def bispec_2drot_large(coef, freqs, eigval, alpha, sample_n, seed=None):
 
     phase = coef[freqs_not_zero] / np.absolute(coef[freqs_not_zero])
     phase = np.arctan2(np.imag(phase), np.real(phase))
-    eigval = eigval[freqs_not_zero]
+    eigval = np.abs(eigval[freqs_not_zero])
     o1, o2 = bispec_operator_1(freqs[freqs_not_zero])
 
     # GBW, naively handle vanishing eigvals.


### PR DESCRIPTION
It appears that `p_m = m / m.sum()` in `bispec_2drot_large` occasionally returns `(inf+nanj)`.  Trying just the magnitude for eigvals (`p`).  Works for for the example I caught in pdb.