### PR TITLE
Long Running Class avg test patches

### DIFF
--- a/.github/workflows/long_workflow.yml
+++ b/.github/workflows/long_workflow.yml
@@ -2,6 +2,9 @@ name: ASPIRE Python Long Running Test Suite
 
 on:
   push:
+    branches:
+      - 'main'
+      - 'develop'
 
 jobs:
   expensive_tests:

--- a/.github/workflows/long_workflow.yml
+++ b/.github/workflows/long_workflow.yml
@@ -2,9 +2,6 @@ name: ASPIRE Python Long Running Test Suite
 
 on:
   push:
-    branches:
-      - 'main'
-      - 'develop'
 
 jobs:
   expensive_tests:

--- a/tests/test_class_src.py
+++ b/tests/test_class_src.py
@@ -137,7 +137,9 @@ def class_sim_fixture(dtype, img_size):
 
 
 @pytest.fixture(
-    params=CLS_SRCS, ids=lambda param: f"ClassSource={param.__class__.__name__}", scope="module"
+    params=CLS_SRCS,
+    ids=lambda param: f"ClassSource={param.__class__.__name__}",
+    scope="module",
 )
 def test_src_cls(request):
     return request.param
@@ -147,8 +149,8 @@ def test_src_cls(request):
 def classifier(class_sim_fixture):
     return RIRClass2D(
         class_sim_fixture,
-        fspca_components=123,
-        bispectrum_components=101,  # Compressed Features after last PCA stage.
+        fspca_components=63,
+        bispectrum_components=51,  # Compressed Features after last PCA stage.
         n_nbor=10,
         sample_n=50000,
         large_pca_implementation="legacy",
@@ -223,8 +225,8 @@ def cls_fixture(class_sim_fixture):
     # Create the classifier
     c2d = RIRClass2D(
         class_sim_fixture,
-        fspca_components=123,
-        bispectrum_components=101,  # Compressed Features after last PCA stage.
+        fspca_components=63,
+        bispectrum_components=51,  # Compressed Features after last PCA stage.
         n_nbor=10,
         sample_n=50000,
         nn_implementation="sklearn",

--- a/tests/test_class_src.py
+++ b/tests/test_class_src.py
@@ -137,7 +137,7 @@ def class_sim_fixture(dtype, img_size):
 
 
 @pytest.fixture(
-    params=CLS_SRCS, ids=lambda param: f"ClassSource={param.__class__}", scope="module"
+    params=CLS_SRCS, ids=lambda param: f"ClassSource={param.__class__.__name__}", scope="module"
 )
 def test_src_cls(request):
     return request.param


### PR DESCRIPTION
Another attempt at settling down the class average tests that became increasingly flaky as the image size was reduced (for timing reasons).

This PR does two things.  Fixes a diagnostic fixture log message and scales down the compressed bispectrum components by about the same factor I previously scaled the image size.

I have run this patched `Long Running Test Suite` over 15 times in the GHA CI on `decaf` with no failures.  Hoping this finally resolves it for a while.

<img width="305" alt="Screenshot 2023-11-27 at 8 11 03 AM" src="https://github.com/ComputationalCryoEM/ASPIRE-Python/assets/47759732/be0396b5-e136-4f67-8e08-c2893c943aa7">
<img width="303" alt="Screenshot 2023-11-27 at 8 11 09 AM" src="https://github.com/ComputationalCryoEM/ASPIRE-Python/assets/47759732/1d02be85-d920-4f36-890b-705e1b3b5aa2">

Had to rebase PR this morning due to #1054 .
