### PR TITLE
Simulation `eval_coords` Bug

### DIFF
--- a/gallery/tutorials/tutorials/cov3d_simulation.py
+++ b/gallery/tutorials/tutorials/cov3d_simulation.py
@@ -33,10 +33,11 @@ num_imgs = 1024  # number of images
 num_eigs = 16  # number of eigen-vectors to keep
 dtype = np.float32
 
-# Generate a ``Volume`` object for use in the simulation. Here we use a ``LegacyVolume`` which
-# by default generates 2 unique random volumes.
+# Generate a ``Volume`` object for use in the simulation. Here we use a ``LegacyVolume`` and
+# set C = 3 to generate 3 unique random volumes.
 vols = LegacyVolume(
     L=img_size,
+    C=3,
     dtype=dtype,
 ).generate()
 
@@ -49,7 +50,7 @@ sim = Simulation(
     dtype=dtype,
 )
 
-# The Simulation object was created using 2 volumes.
+# The Simulation object was created using 3 volumes.
 num_vols = sim.C
 
 # Specify the normal FB basis method for expending the 2D images
@@ -159,6 +160,6 @@ logger.info(f'Coordinates (mean rel. error) = {coords_perf["rel_err"]}')
 logger.info(f'Coordinates (mean correlation) = {np.mean(coords_perf["corr"])}')
 
 # Basic Check
-assert covar_perf["rel_err"] <= 0.60
-assert np.mean(coords_perf["corr"]) >= 0.98
+assert covar_perf["rel_err"] <= 0.80
+assert np.mean(coords_perf["corr"]) >= 0.97
 assert clustering_accuracy >= 0.99

--- a/src/aspire/source/simulation.py
+++ b/src/aspire/source/simulation.py
@@ -477,9 +477,10 @@ class Simulation(ImageSource):
 
         :param mean_vol: A mean volume in the form of a Volume instance.
         :param eig_vols: A set of eigenvolumes in an Volume instance.
-        :param coords_est: The estimated coordinates in the affine space defined centered at `mean_vol` and spanned
-            by `eig_vols`.
-        :return:
+        :param coords_est: The estimated coordinates in the affine space defined centered
+            at `mean_vol` and spanned by `eig_vols`.
+        :return: Dictionary containing error, relative error, and correlation for each set
+            of estimated coordinates.
         """
         assert isinstance(mean_vol, Volume)
         assert isinstance(eig_vols, Volume)

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -515,7 +515,7 @@ class SimTestCase(TestCase):
 
         self.assertTrue(
             np.allclose(
-                result["err"][:10],
+                result["err"][0, :10],
                 [
                     1.58382394,
                     1.58382394,


### PR DESCRIPTION
Resolves #823 

Refactor `Simulation.eval_coords` to handle more than one set of estimated coordinates (ie. when coordinates are estimated for more than 2 volumes). 