### PR TITLE
Blk Diag dtypes

### DIFF
--- a/src/aspire/operators/blk_diag_matrix.py
+++ b/src/aspire/operators/blk_diag_matrix.py
@@ -91,7 +91,7 @@ class BlkDiagMatrix:
         :param blk: Block to append (ndarray).
         """
 
-        self.data.append(blk)
+        self.data.append(blk.astype(self.dtype, copy=False))
         self.nblocks += 1
         self.reset_cache()
 
@@ -130,7 +130,7 @@ class BlkDiagMatrix:
         Convenience wrapper, setter on self.data.
         """
 
-        self.data[key] = value
+        self.data[key] = value.astype(self.dtype, copy=False)
         self.reset_cache()
 
     def __len__(self):


### PR DESCRIPTION
Enforce blk diag dtype on assign/insert.

Found its possible for other dtypes to sneak into block diagonals for very large (>=256) resolutions via upcasting.  This should enforce those have dtype consistent with the block diagonal instance.  For most cases the arrays should just pass through as they were.