### PR TITLE
Importlib unhack

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -155,7 +155,7 @@ jobs:
     - name: Cache Data
       run: |
         ASPIREDIR=${{ env.WORK_DIR }} python -c \
-        "import aspire; print(aspire.config['common']['cache_dir']); aspire.downloader.emdb_2660()"
+        "import aspire; print(aspire.config['common']['cache_dir']); import aspire.downloader; aspire.downloader.emdb_2660()"
     - name: Cleanup
       run: rm -rf ${{ env.WORK_DIR }}
 

--- a/src/aspire/__init__.py
+++ b/src/aspire/__init__.py
@@ -83,4 +83,4 @@ def __getattr__(attr):
     if attr in _modules:
         return importlib.import_module(f"aspire.{attr}")
     else:
-        raise AttributeError(f"module {__name__} has no attribute {attr}.")
+        raise AttributeError(f"module `{__name__}` has no attribute `{attr}`.")

--- a/src/aspire/__init__.py
+++ b/src/aspire/__init__.py
@@ -1,3 +1,4 @@
+import importlib
 import logging.config
 import os
 import pkgutil
@@ -68,7 +69,18 @@ if config["logging"]["log_exceptions"].get(int):
 
     sys.excepthook = handle_exception
 
+# Collect set of all module names in package
+_modules = set(item[1] for item in pkgutil.iter_modules(aspire.__path__))
 
+# Automatically add modules
 __all__ = []
-for _, modname, _ in pkgutil.iter_modules(aspire.__path__):
+for modname in _modules:
     __all__.append(modname)  # Add module to __all_
+
+
+# Dynamically load and return attributes
+def __getattr__(attr):
+    if attr in _modules:
+        return importlib.import_module(f"aspire.{attr}")
+    else:
+        raise AttributeError(f"module {__name__} has no attribute {attr}.")

--- a/src/aspire/__init__.py
+++ b/src/aspire/__init__.py
@@ -1,4 +1,3 @@
-import importlib
 import logging.config
 import os
 import pkgutil
@@ -73,4 +72,3 @@ if config["logging"]["log_exceptions"].get(int):
 __all__ = []
 for _, modname, _ in pkgutil.iter_modules(aspire.__path__):
     __all__.append(modname)  # Add module to __all_
-    importlib.import_module(f"aspire.{modname}")  # Import the module

--- a/src/aspire/utils/bot_align.py
+++ b/src/aspire/utils/bot_align.py
@@ -11,7 +11,6 @@ import pymanopt
 from numpy.linalg import norm
 from scipy.optimize import minimize
 
-from aspire.operators import wemd_embed
 from aspire.utils.rotation import Rotation
 
 # Store parameters specific to each loss_type.
@@ -64,6 +63,9 @@ def align_BO(
         Default `None` infers dtype from `vol_ref`.
     :return: Rotation matrix R_init (without refinement) or (R_init, R_est) (with refinement).
     """
+    # Avoid utils/operators/utils circular import
+    from aspire.operators import wemd_embed
+
     # Infer dtype
     dtype = np.dtype(dtype or vol_ref.dtype)
 


### PR DESCRIPTION
This top level import (which I put in a long time ago for potential convenience) seems to be causing increased memory usage.

I don't think anyone uses the feature. Its also most of what makes the first import of `aspire` slow.

Tentatively suggesting we remove it.  Running some large experiments now to see if improves the resource utilization.