### PR TITLE
Symmetry Boosting

### DIFF
--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -491,11 +491,15 @@ class Image:
 
     def backproject(self, rot_matrices, symmetry_group=None):
         """
-        Backproject images along rotation
+        Backproject images along rotation. If a symmetry group is provided, images
+        used in back-projection are duplicated (boosted) for symmetric viewing directions.
+        Note, it is assumed that a main axis of symmetry aligns with the z-axis.
 
         :param im: An Image (stack) to backproject.
-        :param rot_matrices: An n-by-3-by-3 array of rotation matrices \
-        corresponding to viewing directions.
+        :param rot_matrices: An n-by-3-by-3 array of rotation matrices
+            corresponding to viewing directions.
+        :param symmetry_group: A SymmetryGroup instance. If supplied,
+            uses symmetry to increase number of images used in back-projeciton.
 
         :return: Volume instance corresonding to the backprojected images.
         """

--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -519,6 +519,9 @@ class Image:
 
         n_sym = len(symmetry_rots)
         boosted_rot_mats = np.zeros((n_sym * self.shape[0], 3, 3), dtype=self.dtype)
+        import pdb
+
+        pdb.set_trace()
         for i, sym_rot in enumerate(symmetry_rots):
             boosted_rot_mats[i * self.shape[0] : (i + 1) * self.shape[0]] = (
                 sym_rot @ rot_matrices

--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -552,7 +552,7 @@ class Image:
 
         vol = anufft(im_f, pts_rot[::-1], (L, L, L), real=True) / L
 
-        return aspire.volume.Volume(vol)
+        return aspire.volume.Volume(vol, symmetry_group=symmetry_group)
 
     def show(self, columns=5, figsize=(20, 10), colorbar=True):
         """

--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -499,7 +499,7 @@ class Image:
         :param rot_matrices: An n-by-3-by-3 array of rotation matrices
             corresponding to viewing directions.
         :param symmetry_group: A SymmetryGroup instance or string indicating symmetry, ie. "C3".
-            If supplied, uses symmetry to increase number of images used in back-projeciton.
+            If supplied, uses symmetry to increase number of images used in back-projection.
 
         :return: Volume instance corresonding to the backprojected images.
         """

--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -12,6 +12,7 @@ import aspire.volume
 from aspire.nufft import anufft
 from aspire.numeric import fft, xp
 from aspire.utils import FourierRingCorrelation, anorm, crop_pad_2d, grid_2d
+from aspire.volume import SymmetryGroup
 
 logger = logging.getLogger(__name__)
 
@@ -519,6 +520,10 @@ class Image:
         if symmetry_group is None:
             symmetry_rots = np.eye(3, dtype=self.dtype)[None]
         else:
+            if not isinstance(symmetry_group, SymmetryGroup):
+                raise TypeError(
+                    f"`symmetry_group` must be a `SymmetryGroup` instance. Found {type(symmetry_group)}."
+                )
             symmetry_rots = symmetry_group.matrices
 
         sym_order = len(symmetry_rots)

--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -517,11 +517,8 @@ class Image:
         else:
             symmetry_rots = symmetry_group.matrices
 
-        n_sym = len(symmetry_rots)
-        boosted_rot_mats = np.zeros((n_sym * self.shape[0], 3, 3), dtype=self.dtype)
-        import pdb
-
-        pdb.set_trace()
+        sym_order = len(symmetry_rots)
+        boosted_rot_mats = np.zeros((sym_order * self.shape[0], 3, 3), dtype=self.dtype)
         for i, sym_rot in enumerate(symmetry_rots):
             boosted_rot_mats[i * self.shape[0] : (i + 1) * self.shape[0]] = (
                 sym_rot @ rot_matrices
@@ -539,7 +536,7 @@ class Image:
             im_f[:, :, 0] = 0
 
         # Apply boosting to images.
-        im_f = np.concatenate((im_f.flatten(),) * n_sym)
+        im_f = np.concatenate((im_f.flatten(),) * sym_order)
 
         vol = anufft(im_f, pts_rot[::-1], (L, L, L), real=True) / L
 

--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -548,7 +548,7 @@ class Image:
             im_f[:, :, 0] = 0
 
         # Apply boosting to images.
-        im_f = np.concatenate((im_f.flatten(),) * sym_order)
+        im_f = np.tile(im_f.flatten(), sym_order)
 
         vol = anufft(im_f, pts_rot[::-1], (L, L, L), real=True) / L
 

--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -492,15 +492,14 @@ class Image:
 
     def backproject(self, rot_matrices, symmetry_group=None):
         """
-        Backproject images along rotation. If a symmetry group is provided, images
+        Backproject images along rotations. If a symmetry group is provided, images
         used in back-projection are duplicated (boosted) for symmetric viewing directions.
         Note, it is assumed that a main axis of symmetry aligns with the z-axis.
 
-        :param im: An Image (stack) to backproject.
         :param rot_matrices: An n-by-3-by-3 array of rotation matrices
             corresponding to viewing directions.
-        :param symmetry_group: A SymmetryGroup instance. If supplied,
-            uses symmetry to increase number of images used in back-projeciton.
+        :param symmetry_group: A SymmetryGroup instance or string indicating symmetry, ie. "C3".
+            If supplied, uses symmetry to increase number of images used in back-projeciton.
 
         :return: Volume instance corresonding to the backprojected images.
         """
@@ -520,6 +519,10 @@ class Image:
         if symmetry_group is None:
             symmetry_rots = np.eye(3, dtype=self.dtype)[None]
         else:
+            if isinstance(symmetry_group, str):
+                symmetry_group = SymmetryGroup.from_string(
+                    symmetry_group, dtype=self.dtype
+                )
             if not isinstance(symmetry_group, SymmetryGroup):
                 raise TypeError(
                     f"`symmetry_group` must be a `SymmetryGroup` instance. Found {type(symmetry_group)}."

--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -538,7 +538,6 @@ class Image:
         im_f = im_f.flatten()
 
         # Backproject. Apply boosting by looping over symmetry rotations.
-        sym_order = len(symmetry_rots)
         vol = np.zeros((L, L, L), dtype=self.dtype)
         for sym_rot in symmetry_rots:
             rotations = sym_rot @ rot_matrices

--- a/src/aspire/reconstruction/estimator.py
+++ b/src/aspire/reconstruction/estimator.py
@@ -18,6 +18,7 @@ class Estimator:
         checkpoint_iterations=10,
         checkpoint_prefix="volume_checkpoint",
         maxiter=100,
+        boost=True,
     ):
         """
         An object representing a 2*L-by-2*L-by-2*L array containing the non-centered Fourier transform of the mean
@@ -51,6 +52,7 @@ class Estimator:
         self.dtype = self.src.dtype
         self.batch_size = batch_size
         self.preconditioner = preconditioner
+        self.boost = boost
 
         # dtype configuration
         if not self.dtype == self.basis.dtype:

--- a/src/aspire/reconstruction/estimator.py
+++ b/src/aspire/reconstruction/estimator.py
@@ -45,6 +45,8 @@ class Estimator:
             before returning.  This should be used in conjunction with
             `checkpoint_iterations` to prevent excessive disk usage.
             `None` disables.
+        :param boost: Option to use `src` symmetry to boost number of images used for mean estimation (Boolean).
+            Default of `True` employs symmetry boosting.
         """
 
         self.src = src

--- a/src/aspire/reconstruction/mean.py
+++ b/src/aspire/reconstruction/mean.py
@@ -308,7 +308,9 @@ class MeanEstimator(WeightedVolumesEstimator):
 
     def __init__(self, src, basis, **kwargs):
         # Note, Handle boosting by adjusting weights based on symmetric order.
-        weights = np.ones((src.n, 1)) / np.sqrt(src.n * len(src.symmetry_group.matrices))
+        weights = np.ones((src.n, 1)) / np.sqrt(
+            src.n * len(src.symmetry_group.matrices)
+        )
         super().__init__(weights, src, basis, **kwargs)
 
     def __getattr__(self, name):

--- a/src/aspire/reconstruction/mean.py
+++ b/src/aspire/reconstruction/mean.py
@@ -153,6 +153,9 @@ class WeightedVolumesEstimator(Estimator):
         :return: The adjoint mapping applied to the images, averaged over the whole dataset and expressed
             as coefficients of `basis`.
         """
+        symmetry_group = None
+        if self.boost:
+            symmetry_group = self.src.symmetry_group
 
         # src_vols_wt_backward
         vol_rhs = Volume(
@@ -168,7 +171,7 @@ class WeightedVolumesEstimator(Estimator):
                         im,
                         i,
                         self.weights[:, k],
-                        symmetry_group=self.src.symmetry_group,
+                        symmetry_group=symmetry_group,
                     )
                     / self.src.n
                 )

--- a/src/aspire/reconstruction/mean.py
+++ b/src/aspire/reconstruction/mean.py
@@ -307,7 +307,8 @@ class MeanEstimator(WeightedVolumesEstimator):
     """
 
     def __init__(self, src, basis, **kwargs):
-        weights = np.ones((src.n, 1)) / np.sqrt(src.n)
+        # Note, Handle boosting by adjusting weights based on symmetric order.
+        weights = np.ones((src.n, 1)) / np.sqrt(src.n * len(src.symmetry_group.matrices))
         super().__init__(weights, src, basis, **kwargs)
 
     def __getattr__(self, name):

--- a/src/aspire/reconstruction/mean.py
+++ b/src/aspire/reconstruction/mean.py
@@ -164,7 +164,13 @@ class WeightedVolumesEstimator(Estimator):
                 im = self.src.images[i : i + self.batch_size]
 
                 batch_vol_rhs = (
-                    self.src.im_backward(im, i, self.weights[:, k]) / self.src.n
+                    self.src.im_backward(
+                        im,
+                        i,
+                        self.weights[:, k],
+                        symmetry_group=self.src.symmetry_group,
+                    )
+                    / self.src.n
                 )
                 vol_rhs[k] += batch_vol_rhs.astype(self.dtype)
 

--- a/src/aspire/reconstruction/mean.py
+++ b/src/aspire/reconstruction/mean.py
@@ -132,7 +132,7 @@ class WeightedVolumesEstimator(Estimator):
                     weights = np.transpose(weights, (2, 0, 1)).flatten()
 
                     # Apply boosting to weights.
-                    weights = np.concatenate((weights,) * sym_order)
+                    weights = np.tile(weights, sym_order)
 
                     batch_kernel = (
                         1

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -947,7 +947,9 @@ class ImageSource(ABC):
         :param im: An Image instance to which we wish to apply the adjoint of the forward model.
         :param start: Start index of image to consider
         :param weights: Optional vector of weights to apply to images.
-        Weights should be length `self.n`.
+            Weights should be length `self.n`.
+        :param symmetry_group: A SymmetryGroup instance. If supplied, uses symmetry to increase
+             number of images used in back-projectioon.
         :return: An L-by-L-by-L volume containing the sum of the adjoint mappings applied to the start+num-1 images.
         """
         num = im.n_images

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -940,7 +940,7 @@ class ImageSource(ABC):
             LambdaXform(normalize_bg, bg_radius=bg_radius, do_ramp=do_ramp)
         )
 
-    def im_backward(self, im, start, weights=None):
+    def im_backward(self, im, start, weights=None, symmetry_group=None):
         """
         Apply adjoint mapping to set of images
 
@@ -960,7 +960,9 @@ class ImageSource(ABC):
         if weights is not None:
             im *= weights[all_idx, np.newaxis, np.newaxis]
 
-        vol = im.backproject(self.rotations[start : start + num, :, :])[0]
+        vol = im.backproject(
+            self.rotations[start : start + num, :, :], symmetry_group=symmetry_group
+        )[0]
 
         return vol
 

--- a/src/aspire/source/simulation.py
+++ b/src/aspire/source/simulation.py
@@ -7,7 +7,6 @@ from sklearn.metrics import adjusted_rand_score
 
 from aspire.image import Image
 from aspire.noise import NoiseAdder
-from aspire.operators import IdentityFilter
 from aspire.source import ImageSource
 from aspire.source.image import _ImageAccessor
 from aspire.utils import (
@@ -152,9 +151,7 @@ class Simulation(ImageSource):
         self.angles = self._init_angles(angles)
 
         if unique_filters is None:
-            # Use IdentityFilter to pass unharmed through filter eval code
-            # that is potentially called by other methods later.
-            unique_filters = [IdentityFilter()]
+            unique_filters = []
         self.unique_filters = unique_filters
         # sim_filters must be a deep copy so that it is not changed
         # when unique_filters is changed

--- a/src/aspire/source/simulation.py
+++ b/src/aspire/source/simulation.py
@@ -7,6 +7,7 @@ from sklearn.metrics import adjusted_rand_score
 
 from aspire.image import Image
 from aspire.noise import NoiseAdder
+from aspire.operators import IdentityFilter
 from aspire.source import ImageSource
 from aspire.source.image import _ImageAccessor
 from aspire.utils import (
@@ -151,7 +152,9 @@ class Simulation(ImageSource):
         self.angles = self._init_angles(angles)
 
         if unique_filters is None:
-            unique_filters = []
+            # Use IdentityFilter to pass unharmed through filter eval code
+            # that is potentially called by other methods later.
+            unique_filters = [IdentityFilter()]
         self.unique_filters = unique_filters
         # sim_filters must be a deep copy so that it is not changed
         # when unique_filters is changed

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -303,10 +303,11 @@ def test_backproject_symmetry_group_error():
     ary = np.random.random((3, 8, 8))
     im = Image(ary)
     rots = np.random.random((3, 3, 3))
+    not_a_symmetry_group = []
 
     # Attempt backproject.
     with raises(TypeError, match=r"`symmetry_group` must be a `SymmetryGroup`*"):
-        _ = im.backproject(rots, symmetry_group="Junk")
+        _ = im.backproject(rots, symmetry_group=not_a_symmetry_group)
 
 
 def test_asnumpy_readonly():

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -299,7 +299,7 @@ def testShow():
 
 def test_backproject_symmetry_group():
     """
-    Providing non-SymmetryGroup instance to backproject should raise an error.
+    Test backproject SymmetryGroup pass through and error message.
     """
     ary = np.random.random((5, 8, 8))
     im = Image(ary)

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -307,7 +307,7 @@ def test_backproject_symmetry_group():
 
     # Attempt backproject with bad symmetry group.
     not_a_symmetry_group = []
-    with raises(TypeError, match=r"`symmetry_group` must be a `SymmetryGroup`*"):
+    with raises(TypeError, match=r"`symmetry_group` must be a `SymmetryGroup`"):
         _ = im.backproject(rots, symmetry_group=not_a_symmetry_group)
 
     # Symmetry from string.

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -296,6 +296,19 @@ def testShow():
     im.show()
 
 
+def test_backproject_symmetry_group_error():
+    """
+    Providing non-SymmetryGroup instance to backproject should raise an error.
+    """
+    ary = np.random.random((3, 8, 8))
+    im = Image(ary)
+    rots = np.random.random((3, 3, 3))
+
+    # Attempt backproject.
+    with raises(TypeError, match=r"`symmetry_group` must be a `SymmetryGroup`*"):
+        _ = im.backproject(rots, symmetry_group="Junk")
+
+
 def test_asnumpy_readonly():
     """
     Attempting assignment should raise an error.

--- a/tests/test_mean_estimator_boosting.py
+++ b/tests/test_mean_estimator_boosting.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from aspire.basis import FFBBasis3D
+from aspire.operators import IdentityFilter
 from aspire.reconstruction import MeanEstimator
 from aspire.source import Simulation
 from aspire.volume import (
@@ -70,6 +71,7 @@ def source(volume):
         amplitudes=1,
         seed=SEED,
         dtype=volume.dtype,
+        unique_filters=[IdentityFilter()],  # Can remove after PR 1076
     )
 
     return src

--- a/tests/test_mean_estimator_boosting.py
+++ b/tests/test_mean_estimator_boosting.py
@@ -174,6 +174,9 @@ def test_boost_flag(source, estimated_volume):
 
 # WeightVolumesEstimator Tests.
 def test_weighted_volumes(weighted_source):
+    """
+    Test WeightedVolumeEstimator reconstructs multiple volumes using symmetry boosting.
+    """
     src = weighted_source
 
     # Use source states to assign weights to volumes.

--- a/tests/test_mean_estimator_boosting.py
+++ b/tests/test_mean_estimator_boosting.py
@@ -74,7 +74,6 @@ def source(volume):
         amplitudes=1,
         seed=SEED,
         dtype=volume.dtype,
-        unique_filters=[IdentityFilter()],  # Can remove after PR 1076
     )
 
     return src
@@ -116,7 +115,6 @@ def weighted_source(weighted_volume):
         amplitudes=1,
         seed=SEED,
         dtype=weighted_volume.dtype,
-        unique_filters=[IdentityFilter(), IdentityFilter()],  # Can remove after PR 1076
     )
 
     return src

--- a/tests/test_mean_estimator_boosting.py
+++ b/tests/test_mean_estimator_boosting.py
@@ -183,11 +183,11 @@ def test_weighted_volumes(weighted_source):
     # Use source states to assign weights to volumes.
     weights = np.zeros((src.n, src.C), dtype=src.dtype)
     weights[:, 0] = abs(src.states - 1.99)  # sends states [1, 2] to weights [.99, .01]
-    weights[:, 1] = abs(-src.states + 1.01)  # sends states [1, 2] to weights [.01, .99]
+    weights[:, 1] = 1 - weights[:, 0]  # sets weights for states [1, 2] as [.01, .99]
 
     # Scale weights
-    n0 = (-src.states + 2).sum()  # number of images from vol[0]
-    n1 = (src.states - 1).sum()  # number of images from vol[1]
+    n0 = np.count_nonzero(src.states == 1)  # number of images from vol[0]
+    n1 = np.count_nonzero(src.states == 2)  # number of images from vol[1]
     weights[:, 0] = weights[:, 0] / weights[:, 0].sum() * np.sqrt(n0)
     weights[:, 1] = weights[:, 1] / weights[:, 1].sum() * np.sqrt(n1)
 

--- a/tests/test_mean_estimator_boosting.py
+++ b/tests/test_mean_estimator_boosting.py
@@ -1,0 +1,104 @@
+import numpy as np
+import pytest
+
+from aspire.basis import FFBBasis3D
+from aspire.reconstruction import MeanEstimator
+from aspire.source import Simulation
+from aspire.volume import (
+    AsymmetricVolume,
+    CnSymmetricVolume,
+    DnSymmetricVolume,
+    OSymmetricVolume,
+    TSymmetricVolume,
+)
+
+SEED = 23
+
+RESOLUTION = [
+    32,
+    33,
+]
+
+DTYPE = [
+    np.float32,
+    pytest.param(np.float64, marks=pytest.mark.expensive),
+]
+
+# Symmetric volume parameters, (volume_type, symmetric_order).
+VOL_PARAMS = [
+    (AsymmetricVolume, None),
+    (CnSymmetricVolume, 4),
+    (CnSymmetricVolume, 5),
+    (DnSymmetricVolume, 2),
+    pytest.param((TSymmetricVolume, None), marks=pytest.mark.expensive),
+    pytest.param((OSymmetricVolume, None), marks=pytest.mark.expensive),
+]
+
+
+# Fixtures.
+@pytest.fixture(params=RESOLUTION, ids=lambda x: f"resolution={x}", scope="module")
+def resolution(request):
+    return request.param
+
+
+@pytest.fixture(params=DTYPE, ids=lambda x: f"dtype={x}", scope="module")
+def dtype(request):
+    return request.param
+
+
+@pytest.fixture(params=VOL_PARAMS, ids=lambda x: f"volume={x[0]}", scope="module")
+def volume(request, resolution, dtype):
+    Volume, order = request.param
+    vol_kwargs = dict(
+        L=resolution,
+        C=1,
+        seed=SEED,
+        dtype=dtype,
+    )
+    if order:
+        vol_kwargs["order"] = order
+
+    return Volume(**vol_kwargs).generate()
+
+
+@pytest.fixture(scope="module")
+def source(volume):
+    src = Simulation(
+        n=200,
+        vols=volume,
+        offsets=0,
+        amplitudes=1,
+        seed=SEED,
+        dtype=volume.dtype,
+    )
+
+    return src
+
+
+@pytest.fixture(scope="module")
+def estimated_volume(source):
+    basis = FFBBasis3D(source.L, dtype=source.dtype)
+    estimator = MeanEstimator(source, basis)
+    estimated_volume = estimator.estimate()
+
+    return estimated_volume
+
+
+# MeanEstimator Tests.
+def test_mean_estimator_boosting(source, estimated_volume):
+    """Test MeanEstimator with boosting."""
+    # Fourier Shell Correlation
+    fsc_resolution, fsc = source.vols.fsc(estimated_volume, pixel_size=1, cutoff=0.5)
+
+    # Check that resolution is less than 2.1 pixels.
+    np.testing.assert_array_less(fsc_resolution, 2.1)
+
+    # Check that second to last correlation value is high (>.90).
+    np.testing.assert_array_less(0.90, fsc[0, -2])
+
+
+def test_total_energy(source, estimated_volume):
+    """Test that energy is preserved in reconstructed volume."""
+    og_total_energy = np.sum(source.vols)
+    recon_total_energy = np.sum(estimated_volume)
+    np.testing.assert_allclose(og_total_energy, recon_total_energy, rtol=1e-3)

--- a/tests/test_mean_estimator_boosting.py
+++ b/tests/test_mean_estimator_boosting.py
@@ -101,10 +101,7 @@ def test_fsc(source, estimated_volume):
 
 def test_mse(source, estimated_volume):
     """Check the mean-squared error between source and estimated volumes."""
-    mse = (
-        np.sum((source.vols.asnumpy() - estimated_volume.asnumpy()) ** 2)
-        / source.L**3
-    )
+    mse = np.mean((source.vols.asnumpy() - estimated_volume.asnumpy()) ** 2)
     np.testing.assert_allclose(mse, 0, atol=1e-3)
 
 

--- a/tests/test_mean_estimator_boosting.py
+++ b/tests/test_mean_estimator_boosting.py
@@ -74,6 +74,7 @@ def source(volume):
         seed=SEED,
         dtype=volume.dtype,
     )
+    src = src.cache()  # precompute images
 
     return src
 

--- a/tests/test_mean_estimator_boosting.py
+++ b/tests/test_mean_estimator_boosting.py
@@ -87,8 +87,8 @@ def estimated_volume(source):
 
 
 # MeanEstimator Tests.
-def test_mean_estimator_boosting(source, estimated_volume):
-    """Test MeanEstimator with boosting."""
+def test_fsc(source, estimated_volume):
+    """Compare estimated volume to source volume with FSC."""
     # Fourier Shell Correlation
     fsc_resolution, fsc = source.vols.fsc(estimated_volume, pixel_size=1, cutoff=0.5)
 
@@ -97,6 +97,15 @@ def test_mean_estimator_boosting(source, estimated_volume):
 
     # Check that second to last correlation value is high (>.90).
     np.testing.assert_array_less(0.90, fsc[0, -2])
+
+
+def test_mse(source, estimated_volume):
+    """Check the mean-squared error between source and estimated volumes."""
+    mse = (
+        np.sum((source.vols.asnumpy() - estimated_volume.asnumpy()) ** 2)
+        / source.L**3
+    )
+    np.testing.assert_allclose(mse, 0, atol=1e-3)
 
 
 def test_total_energy(source, estimated_volume):

--- a/tests/test_mean_estimator_boosting.py
+++ b/tests/test_mean_estimator_boosting.py
@@ -89,9 +89,9 @@ def estimated_volume(source):
     return estimated_volume
 
 
-# Weighted volume fixture.
+# Weighted volume fixture. Only tesing C1, C4, and C5.
 @pytest.fixture(
-    params=VOL_PARAMS, ids=lambda x: f"volume={x[0]}, order={x[1]}", scope="module"
+    params=VOL_PARAMS[:3], ids=lambda x: f"volume={x[0]}, order={x[1]}", scope="module"
 )
 def weighted_volume(request, resolution, dtype):
     Volume, order = request.param
@@ -197,4 +197,4 @@ def test_weighted_volumes(weighted_source):
 
     # Check FSC (scaling may not be close enough to match mse)
     _, corr = src.vols.fsc(est_vols)
-    np.testing.assert_array_less(0.95, corr[:, -2])
+    np.testing.assert_array_less(0.91, corr[:, -2])

--- a/tests/test_mean_estimator_boosting.py
+++ b/tests/test_mean_estimator_boosting.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 
 from aspire.basis import FFBBasis3D
-from aspire.operators import IdentityFilter
 from aspire.reconstruction import MeanEstimator, WeightedVolumesEstimator
 from aspire.source import ArrayImageSource, Simulation
 from aspire.utils import Rotation, utest_tolerance


### PR DESCRIPTION
This PR adds symmetry boosting to `MeanEstimator` and `WeightedVolumesEstimator`. 

Boosting is controlled by a flag in the `*Estimator`'s init, which is `True` (on) by default. Then a `symmetry_group` is obtained from the provided `ImageSource` and passed through `*Estimator.src_backward()` to `source.image.im_backward()` and finally to `image.image.backproject()` where boosting of the images and rotations occurs. 

Additionally, boosting takes place when computing the Fourier kernel used in mean estimation.