### PR TITLE
`finufft` 2.2.0 updates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,9 @@ dependencies = [
     "click",
     "confuse >= 2.0.0",
     "cvxpy",
-    "finufft>=2.2.0",
+    # finufft 2.2.0 doesn't seemt to run on GHA Windows CI...    
+    "finufft==2.2.0 ; sys_platform != 'win32'",
+    "finufft==2.1.0 ; sys_platform == 'win32'",
     "gemmi >= 0.4.8",
     "grpcio >= 1.54.2",
     "joblib",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "pydantic<2",  # Workaround for Ray<2.9
     "pyfftw",
     "pymanopt",
-    "pyshtools",
+    "pyshtools<=4.10.4",  # 4.11.7 might have a packaging bug
     "PyWavelets",
     "ray",
     "scipy >= 1.10.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "click",
     "confuse >= 2.0.0",
     "cvxpy",
-    "finufft",
+    "finufft>=2.2.0",
     "gemmi >= 0.4.8",
     "grpcio >= 1.54.2",
     "joblib",

--- a/src/aspire/nufft/finufft.py
+++ b/src/aspire/nufft/finufft.py
@@ -50,7 +50,7 @@ class FinufftPlan(Plan):
             n_modes_or_dim=self.sz,
             eps=self.epsilon,
             n_trans=self.ntransforms,
-            dtype=self.dtype,
+            dtype=self.complex_dtype,
         )
 
         self._adjoint_plan = finufft.Plan(
@@ -58,7 +58,7 @@ class FinufftPlan(Plan):
             n_modes_or_dim=self.sz,
             eps=self.epsilon,
             n_trans=self.ntransforms,
-            dtype=self.dtype,
+            dtype=self.complex_dtype,
         )
 
         self._transform_plan.setpts(*self.fourier_pts)


### PR DESCRIPTION
A change in finufft was causing something like 80k warnings (😂) in fresh environments which picked up their latest package (released over the winter break).

This was part of the performance issue I was seeing during fresh installs on the development machines.