### PR TITLE
IdentityFilter for Simulation

### DIFF
--- a/src/aspire/covariance/covar2d.py
+++ b/src/aspire/covariance/covar2d.py
@@ -5,7 +5,7 @@ from numpy.linalg import eig, inv
 from scipy.linalg import solve, sqrtm
 
 from aspire.basis import Coef, FFBBasis2D
-from aspire.operators import BlkDiagMatrix, DiagMatrix
+from aspire.operators import BlkDiagMatrix, DiagMatrix, IdentityFilter
 from aspire.optimization import conj_grad, fill_struct
 from aspire.utils import make_symmat
 from aspire.utils.matlab_compat import m_reshape
@@ -528,7 +528,10 @@ class BatchedRotCov2D(RotCov2D):
         if self.basis is None:
             self.basis = FFBBasis2D((src.L, src.L), dtype=self.dtype)
 
-        if not src.unique_filters:
+        if not src.unique_filters or (
+            len(src.unique_filters) == 1
+            and isinstance(src.unique_filters[0], IdentityFilter)
+        ):
             logger.info("CTF filters are not included in Cov2D denoising")
             # set all CTF filters to an identity filter
             self.ctf_idx = np.zeros(src.n, dtype=int)

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -849,20 +849,23 @@ class ImageSource(ABC):
 
         logger.info("Perform phase flip on source object")
 
-        if len(self.unique_filters) >= 1:
-            unique_xforms = [FilterXform(f.sign) for f in self.unique_filters]
-
-            logger.info("Adding Phase Flip Xform to end of generation pipeline")
-            self.generation_pipeline.add_xform(
-                IndexedXform(unique_xforms, self.filter_indices)
-            )
-
-        else:
+        if self.unique_filters is None or (
+            len(self.unique_filters) == 1
+            and isinstance(self.unique_filters[0], IdentityFilter)
+        ):
             # No CTF filters found
             logger.warning(
                 "No Filters found."
                 "  `phase_flip` is a no-op without Filters."
                 "  Confirm you have correctly populated CTFFilters."
+            )
+
+        else:
+            unique_xforms = [FilterXform(f.sign) for f in self.unique_filters]
+
+            logger.info("Adding Phase Flip Xform to end of generation pipeline")
+            self.generation_pipeline.add_xform(
+                IndexedXform(unique_xforms, self.filter_indices)
             )
 
     @as_copy

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -849,7 +849,7 @@ class ImageSource(ABC):
 
         logger.info("Perform phase flip on source object")
 
-        if self.unique_filters is None or (
+        if not self.unique_filters or (
             len(self.unique_filters) == 1
             and isinstance(self.unique_filters[0], IdentityFilter)
         ):

--- a/src/aspire/source/simulation.py
+++ b/src/aspire/source/simulation.py
@@ -161,13 +161,13 @@ class Simulation(ImageSource):
         self.sim_filters = copy.deepcopy(unique_filters)
 
         # Create filter indices and fill the metadata based on unique filters
-        if unique_filters:
+        if len(unique_filters) == 1 and isinstance(unique_filters[0], IdentityFilter):
+            self.filter_indices = np.zeros(n, dtype=int)
+        else:
             if filter_indices is None:
                 filter_indices = randi(len(unique_filters), n, seed=seed) - 1
             self._populate_ctf_metadata(filter_indices)
             self.filter_indices = filter_indices
-        else:
-            self.filter_indices = np.zeros(n, dtype=int)
 
         self.offsets = offsets
         self.amplitudes = amplitudes

--- a/src/aspire/source/simulation.py
+++ b/src/aspire/source/simulation.py
@@ -7,6 +7,7 @@ from sklearn.metrics import adjusted_rand_score
 
 from aspire.image import Image
 from aspire.noise import NoiseAdder
+from aspire.operators import IdentityFilter
 from aspire.source import ImageSource
 from aspire.source.image import _ImageAccessor
 from aspire.utils import (
@@ -151,7 +152,9 @@ class Simulation(ImageSource):
         self.angles = self._init_angles(angles)
 
         if unique_filters is None:
-            unique_filters = []
+            # Use IdentityFilter to pass unharmed through filter eval code
+            # that is potentially called by other methods later.
+            unique_filters = [IdentityFilter()]
         self.unique_filters = unique_filters
         # sim_filters must be a deep copy so that it is not changed
         # when unique_filters is changed


### PR DESCRIPTION
This PR resolves issue #978, ie. reconstructions from clean Simulations failing for singles. 

The issue was that Simulations, when not provided `unique_filters`, were not defaulting to `IdentityFilter` as the other `ImageSource`'s do. Ultimately, this caused `evaluate_src_filters_on_grid` to return an arbitrary array that was initialized as `np.empty(...)`.

Aside from reconstructions failing for singles, this was also causing inconsistent reconstructions for doubles.

The "Symmetry Boosting" PR #1072 relies on this fix and adds a testing suite that covers clean reconstructions of Simulations with varying symmetries (including an asymmetric case). 