### PR TITLE
Allow RelionSource to be double precision

### DIFF
--- a/src/aspire/source/relion.py
+++ b/src/aspire/source/relion.py
@@ -83,7 +83,7 @@ class RelionSource(ImageSource):
 
         mrc_dtype = mrc_dtypes[mode]
         # Potentially over ride the inferred data type.
-        if dtype is not None and dtype != mrc_dtype:
+        if dtype is not None and dtype != np.dtype(mrc_dtype):
             logger.warning(
                 f"Overriding MRC datatype {mrc_dtype} with user supplied {dtype}."
             )

--- a/tests/test_starfile_stack.py
+++ b/tests/test_starfile_stack.py
@@ -14,10 +14,15 @@ DATA_DIR = os.path.join(os.path.dirname(__file__), "saved_test_data")
 
 
 class StarFileTestCase(TestCase):
+    # Default dtype (inferred)
+    _dtype = None
+
     def setUpStarFile(self, starfile_name):
         # set up RelionSource object for tests
         with importlib_path(tests.saved_test_data, starfile_name) as starfile:
-            self.src = RelionSource(starfile, data_folder=DATA_DIR, max_rows=12)
+            self.src = RelionSource(
+                starfile, data_folder=DATA_DIR, max_rows=12, dtype=self._dtype
+            )
 
     def setUp(self):
         # this method is used by StarFileMainCase but overridden by StarFileOneImage
@@ -94,3 +99,30 @@ class StarFileSingleImage(StarFileTestCase):
         # where there is only one image in the mrcs
         single_image = self.src.images[0].asnumpy()[0]
         self.assertEqual(single_image.shape, (200, 200))
+
+
+class StarFileDtypeOverrideCase64(StarFileMainCase):
+    # Override RelionSource dtype
+    _dtype = np.float64
+
+    def testSourceDtype(self):
+        """Test source identifies as _dtype."""
+        self.assertTrue(self.src.dtype == self._dtype)
+
+    def testImageDtype(self):
+        """Test image returned as _dtype."""
+        self.assertTrue(self.src.images[0].dtype == self._dtype)
+
+    def testRotationsDtype(self):
+        """Test image returned as _dtype."""
+        self.assertTrue(self.src.rotations.dtype == self._dtype)
+
+    def testImageDownsampleDtype(self):
+        """Test downsample pipeline operation returns _dtype."""
+        _src = self.src.downsample(16)
+        self.assertTrue(_src.images[0].dtype == self._dtype)
+
+
+class StarFileDtypeOverrideCase32(StarFileMainCase):
+    # Override RelionSource dtype
+    _dtype = np.float32


### PR DESCRIPTION
The `MeanEstimation` fails to converge at higher resolutions for experimental data (189 and higher) in single precision.  I believe this is probably related to the accuracy of the basis in these conditions, but there is more work to be done there at another time.

This small PR allows `RelionSource` to upcast images and supporting data as doubles to be consumed by other components.  It adds some tests checking the dtype override occurs.

This resolved for 189 pixel reconstructions and is currently being tested at 380. Will update, WIP draft for now.