### PR TITLE
SymmetryGroup Pass-through for Volume Transformations

### DIFF
--- a/src/aspire/volume/symmetry_groups.py
+++ b/src/aspire/volume/symmetry_groups.py
@@ -26,6 +26,11 @@ class SymmetryGroup(ABC):
         Method for generating a Rotation object for the symmetry group.
         """
 
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return str(self) == str(other)
+        return False
+
     @property
     def matrices(self):
         return self.rotations.matrices

--- a/src/aspire/volume/volume.py
+++ b/src/aspire/volume/volume.py
@@ -209,7 +209,7 @@ class Volume:
         incompat_syms = (
             isinstance(other, Volume) and self.symmetry_group != other.symmetry_group
         )
-        arbitrary_array = not isinstance(other, Volume) and getattr(other, size, 1) > 1
+        arbitrary_array = not isinstance(other, Volume) and getattr(other, 'size', 1) > 1
 
         if any([self_transformation, incompat_syms, arbitrary_array]):
             self._symmetry_group_warning()
@@ -398,13 +398,15 @@ class Volume:
 
         return cls(data)
 
-    def transpose(self):
+    def transpose(self, symmetry=None):
         """
         Returns a new Volume instance with volume data axes transposed.
 
         :return: Volume instance.
         """
-        symmetry = self._result_symmetry()
+        # Ensures warning stacklevel is the same for `vol.T` and `vol.transpose()`.
+        if symmetry is None:
+            symmetry = self._result_symmetry()
 
         original_stack_shape = self.stack_shape
         v = self._data.reshape(-1, *self._data.shape[-3:])
@@ -419,8 +421,8 @@ class Volume:
 
         :return: Volume instance.
         """
-
-        return self.transpose()
+        symmetry = self._result_symmetry()
+        return self.transpose(symmetry=symmetry)
 
     def flatten(self):
         """

--- a/src/aspire/volume/volume.py
+++ b/src/aspire/volume/volume.py
@@ -206,8 +206,8 @@ class Volume:
 
         # Conditions of incompatibility.
         self_transformation = other is None
-        incompat_syms = isinstance(other, Volume) and str(self.symmetry_group) != str(
-            other.symmetry_group
+        incompat_syms = (
+            isinstance(other, Volume) and self.symmetry_group != other.symmetry_group
         )
         arbitrary_array = not isinstance(other, Volume) and hasattr(other, "__len__")
 

--- a/src/aspire/volume/volume.py
+++ b/src/aspire/volume/volume.py
@@ -198,27 +198,20 @@ class Volume:
         :return: SymmetryGroup instance.
         """
         # No need to check for C1.
-        if str(self.symmetry_group) == "C1":
+        if isinstance(self.symmetry_group, IdentitySymmetryGroup):
             return self.symmetry_group
 
-        # Handle case of transformations of `self`.
-        if other is None:
-            self._symmetry_group_warning()
-            return IdentitySymmetryGroup(dtype=self.dtype)
-
-        # Handle binary operations of `self` and `other`.
+        # Warn and set to IdentitySymmetryGroup if `other` is symmetrically incompatible.
         result_symmetry = self.symmetry_group
 
-        # Warn and set to IdentitySymmetryGroup if `other` is symmetrically incompatible.
-        if isinstance(other, Volume) and str(self.symmetry_group) != str(
+        # Conditions of incompatibility.
+        self_transformation = other is None
+        incompat_syms = isinstance(other, Volume) and str(self.symmetry_group) != str(
             other.symmetry_group
-        ):
-            self._symmetry_group_warning()
-            result_symmetry = IdentitySymmetryGroup(dtype=self.dtype)
+        )
+        arbitrary_array = not isinstance(other, Volume) and hasattr(other, "__len__")
 
-        elif not isinstance(other, Volume) and hasattr(
-            other, "__len__"
-        ):  # ie. is not a scalar
+        if any([self_transformation, incompat_syms, arbitrary_array]):
             self._symmetry_group_warning()
             result_symmetry = IdentitySymmetryGroup(dtype=self.dtype)
 

--- a/src/aspire/volume/volume.py
+++ b/src/aspire/volume/volume.py
@@ -181,27 +181,35 @@ class Volume:
 
     def _symmetry_group_warning(self):
         """
-        Warn when a transformation has the potential to change the symmetry
+        Warn when an operation has the potential to change the symmetry
         of a volume or the alignment of symmetry axes.
         """
-        if str(self.symmetry_group) != "C1":
-            msg = (
-                f"`symmetry_group` attribute is being set to `C1`. This transformation may"
-                f" effect the symmetry (or symmetric alignment) of the volume. To reset the"
-                f" symmetry group run `self._set_symmetry_group('{self.symmetry_group}')`."
-            )
-            warnings.warn(msg, UserWarning, stacklevel=4)
+        msg = (
+            f"`symmetry_group` attribute is being set to `C1`. This operation may"
+            f" effect the symmetry (or symmetric alignment) of the volume. To reset the"
+            f" symmetry group run `self._set_symmetry_group('{self.symmetry_group}')`."
+        )
+        warnings.warn(msg, UserWarning, stacklevel=4)
 
     def _result_symmetry(self, other=None):
         """
-        Check if `other` will alter symmetry of `self` and return appropriate symmetry_group.
+        Check if `other` will alter symmetry of `self` and return resulting symmetry_group.
+
+        :return: SymmetryGroup instance.
         """
+        # No need to check for C1.
+        if str(self.symmetry_group) == "C1":
+            return self.symmetry_group
+
+        # Handle case of transformations of `self`.
         if other is None:
             self._symmetry_group_warning()
             return IdentitySymmetryGroup(dtype=self.dtype)
 
+        # Handle binary operations of `self` and `other`.
         result_symmetry = self.symmetry_group
-        # Warn and set to IdentitySymmetryGroup if incompatible symmetries or non-scalar.
+
+        # Warn and set to IdentitySymmetryGroup if `other` is symmetrically incompatible.
         if isinstance(other, Volume) and str(self.symmetry_group) != str(
             other.symmetry_group
         ):

--- a/src/aspire/volume/volume.py
+++ b/src/aspire/volume/volume.py
@@ -135,7 +135,9 @@ class Volume:
             Defaults to True.
         :return: Volume instance
         """
-        return self.__class__(self.asnumpy().astype(dtype, copy=copy))
+        return self.__class__(
+            self.asnumpy().astype(dtype, copy=copy), symmetry_group=self.symmetry_group
+        )
 
     def _check_key_dims(self, key):
         if isinstance(key, tuple) and (len(key) > self._data.ndim):
@@ -145,7 +147,7 @@ class Volume:
 
     def __getitem__(self, key):
         self._check_key_dims(key)
-        return self.__class__(self._data[key])
+        return self.__class__(self._data[key], symmetry_group=self.symmetry_group)
 
     def __setitem__(self, key, value):
         self._check_key_dims(key)
@@ -198,7 +200,10 @@ class Volume:
                 f"Number of volumes {self.n_vols} cannot be reshaped to {shape}."
             )
 
-        return self.__class__(self._data.reshape(*shape, *self._data.shape[-3:]))
+        return self.__class__(
+            self._data.reshape(*shape, *self._data.shape[-3:]),
+            symmetry_group=self.symmetry_group,
+        )
 
     def __repr__(self):
         msg = (
@@ -359,7 +364,9 @@ class Volume:
         original_stack_shape = self.stack_shape
         v = self.stack_reshape(-1)
         vt = np.transpose(v._data, (0, -1, -2, -3))
-        return self.__class__(vt).stack_reshape(original_stack_shape)
+        return self.__class__(vt, symmetry_group=self.symmetry_group).stack_reshape(
+            original_stack_shape
+        )
 
     @property
     def T(self):
@@ -400,7 +407,9 @@ class Volume:
                     f"Cannot flip axis {ax}: stack axis. Did you mean {ax-4}?"
                 )
 
-        return self.__class__(np.flip(self._data, axis))
+        return self.__class__(
+            np.flip(self._data, axis), symmetry_group=self.symmetry_group
+        )
 
     def downsample(self, ds_res, mask=None):
         """
@@ -427,7 +436,9 @@ class Volume:
             ds_res**3 / self.resolution**3
         )
         # returns a new Volume object
-        return self.__class__(np.real(out)).stack_reshape(original_stack_shape)
+        return self.__class__(
+            np.real(out), symmetry_group=self.symmetry_group
+        ).stack_reshape(original_stack_shape)
 
     def shift(self):
         raise NotImplementedError
@@ -497,7 +508,7 @@ class Volume:
             np.real(fft.centered_ifftn(xp.asarray(vol_f), axes=(-3, -2, -1)))
         )
 
-        return self.__class__(vol)
+        return self.__class__(vol, symmetry_group=self.symmetry_group)
 
     def denoise(self):
         raise NotImplementedError

--- a/src/aspire/volume/volume.py
+++ b/src/aspire/volume/volume.py
@@ -209,7 +209,7 @@ class Volume:
         incompat_syms = (
             isinstance(other, Volume) and self.symmetry_group != other.symmetry_group
         )
-        arbitrary_array = not isinstance(other, Volume) and hasattr(other, "__len__")
+        arbitrary_array = not isinstance(other, Volume) and getattr(other, size, 1) > 1
 
         if any([self_transformation, incompat_syms, arbitrary_array]):
             self._symmetry_group_warning()

--- a/src/aspire/volume/volume.py
+++ b/src/aspire/volume/volume.py
@@ -232,10 +232,16 @@ class Volume:
         return self.n_vols
 
     def __add__(self, other):
-        self._symmetry_group_warning("add")
         if isinstance(other, Volume):
-            res = self.__class__(self._data + other.asnumpy())
+            if str(self.symmetry_group) == str(other.symmetry_group):
+                res = self.__class__(
+                    self._data + other.asnumpy(), symmetry_group=self.symmetry_group
+                )
+            else:
+                self._symmetry_group_warning("add")
+                res = self.__class__(self._data + other.asnumpy())
         else:
+            self._symmetry_group_warning("add")
             res = self.__class__(self._data + other)
 
         return res
@@ -245,8 +251,15 @@ class Volume:
 
     def __sub__(self, other):
         if isinstance(other, Volume):
-            res = self.__class__(self._data - other.asnumpy())
+            if str(self.symmetry_group) == str(other.symmetry_group):
+                res = self.__class__(
+                    self._data - other.asnumpy(), symmetry_group=self.symmetry_group
+                )
+            else:
+                self._symmetry_group_warning("subtract")
+                res = self.__class__(self._data - other.asnumpy())
         else:
+            self._symmetry_group_warning("subtract")
             res = self.__class__(self._data - other)
 
         return res
@@ -256,8 +269,15 @@ class Volume:
 
     def __mul__(self, other):
         if isinstance(other, Volume):
-            res = self.__class__(self._data * other.asnumpy())
+            if str(self.symmetry_group) == str(other.symmetry_group):
+                res = self.__class__(
+                    self._data * other.asnumpy(), symmetry_group=self.symmetry_group
+                )
+            else:
+                self._symmetry_group_warning("multiply")
+                res = self.__class__(self._data * other.asnumpy())
         else:
+            self._symmetry_group_warning("multiply")
             res = self.__class__(self._data * other)
 
         return res
@@ -270,8 +290,15 @@ class Volume:
         Scalar division, follows numpy semantics.
         """
         if isinstance(other, Volume):
-            res = self.__class__(self._data / other.asnumpy())
+            if str(self.symmetry_group) == str(other.symmetry_group):
+                res = self.__class__(
+                    self._data / other.asnumpy(), symmetry_group=self.symmetry_group
+                )
+            else:
+                self._symmetry_group_warning("divide")
+                res = self.__class__(self._data / other.asnumpy())
         else:
+            self._symmetry_group_warning("divide")
             res = self.__class__(self._data / other)
 
         return res

--- a/src/aspire/volume/volume.py
+++ b/src/aspire/volume/volume.py
@@ -213,7 +213,7 @@ class Volume:
         result_symmetry = self.symmetry_group
 
         # Conditions of incompatibility.
-        self_transformation = other is None
+        axes_altering_transformation = other is None
         incompat_syms = (
             isinstance(other, Volume) and self.symmetry_group != other.symmetry_group
         )
@@ -221,7 +221,7 @@ class Volume:
             not isinstance(other, Volume) and getattr(other, "size", 1) > 1
         )
 
-        if any([self_transformation, incompat_syms, arbitrary_array]):
+        if any([axes_altering_transformation, incompat_syms, arbitrary_array]):
             self._symmetry_group_warning(stacklevel=stacklevel)
             result_symmetry = IdentitySymmetryGroup(dtype=self.dtype)
 

--- a/src/aspire/volume/volume.py
+++ b/src/aspire/volume/volume.py
@@ -209,7 +209,9 @@ class Volume:
         incompat_syms = (
             isinstance(other, Volume) and self.symmetry_group != other.symmetry_group
         )
-        arbitrary_array = not isinstance(other, Volume) and getattr(other, 'size', 1) > 1
+        arbitrary_array = (
+            not isinstance(other, Volume) and getattr(other, "size", 1) > 1
+        )
 
         if any([self_transformation, incompat_syms, arbitrary_array]):
             self._symmetry_group_warning()

--- a/src/aspire/volume/volume.py
+++ b/src/aspire/volume/volume.py
@@ -179,7 +179,7 @@ class Volume:
             )
         self._symmetry_group = value
 
-    def _symmetry_group_warning(self, method):
+    def _symmetry_group_warning(self):
         """
         Warn when a transformation has the potential to change the symmetry
         of a volume or the alignment of symmetry axes.
@@ -188,8 +188,8 @@ class Volume:
         """
         if str(self.symmetry_group) != "C1":
             msg = (
-                f"`symmetry_group` attribute is being set to `C1`. {self.__class__.__name__}.{method}()"
-                f" may effect the symmetry (or symmetric alignment) of the volume. To reset the"
+                f"`symmetry_group` attribute is being set to `C1`. This transformation may"
+                f" effect the symmetry (or symmetric alignment) of the volume. To reset the"
                 f" symmetry group run `self._set_symmetry_group('{self.symmetry_group}')`."
             )
             warnings.warn(msg, UserWarning, stacklevel=3)
@@ -238,10 +238,10 @@ class Volume:
                     self._data + other.asnumpy(), symmetry_group=self.symmetry_group
                 )
             else:
-                self._symmetry_group_warning("add")
+                self._symmetry_group_warning()
                 res = self.__class__(self._data + other.asnumpy())
         else:
-            self._symmetry_group_warning("add")
+            self._symmetry_group_warning()
             res = self.__class__(self._data + other)
 
         return res
@@ -256,10 +256,10 @@ class Volume:
                     self._data - other.asnumpy(), symmetry_group=self.symmetry_group
                 )
             else:
-                self._symmetry_group_warning("subtract")
+                self._symmetry_group_warning()
                 res = self.__class__(self._data - other.asnumpy())
         else:
-            self._symmetry_group_warning("subtract")
+            self._symmetry_group_warning()
             res = self.__class__(self._data - other)
 
         return res
@@ -274,10 +274,10 @@ class Volume:
                     self._data * other.asnumpy(), symmetry_group=self.symmetry_group
                 )
             else:
-                self._symmetry_group_warning("multiply")
+                self._symmetry_group_warning()
                 res = self.__class__(self._data * other.asnumpy())
         else:
-            self._symmetry_group_warning("multiply")
+            self._symmetry_group_warning()
             res = self.__class__(self._data * other)
 
         return res
@@ -295,10 +295,10 @@ class Volume:
                     self._data / other.asnumpy(), symmetry_group=self.symmetry_group
                 )
             else:
-                self._symmetry_group_warning("divide")
+                self._symmetry_group_warning()
                 res = self.__class__(self._data / other.asnumpy())
         else:
-            self._symmetry_group_warning("divide")
+            self._symmetry_group_warning()
             res = self.__class__(self._data / other)
 
         return res

--- a/src/aspire/volume/volume.py
+++ b/src/aspire/volume/volume.py
@@ -179,18 +179,20 @@ class Volume:
             )
         self._symmetry_group = value
 
-    def _symmetry_group_warning(self):
+    def _symmetry_group_warning(self, method):
         """
         Warn when a transformation has the potential to change the symmetry
         of a volume or the alignment of symmetry axes.
+
+        :param method: Name of method (string).
         """
         if str(self.symmetry_group) != "C1":
             msg = (
-                f"`symmetry_group` attribute is being set to `C1`. This transformation may"
-                f" effect the symmetry (or symmetric alignment) of the volume. To reset the"
+                f"`symmetry_group` attribute is being set to `C1`. {self.__class__.__name__}.{method}()"
+                f" may effect the symmetry (or symmetric alignment) of the volume. To reset the"
                 f" symmetry group run `self._set_symmetry_group('{self.symmetry_group}')`."
             )
-            warnings.warn(msg, UserWarning)
+            warnings.warn(msg, UserWarning, stacklevel=3)
 
     def stack_reshape(self, *args):
         """
@@ -230,6 +232,7 @@ class Volume:
         return self.n_vols
 
     def __add__(self, other):
+        self._symmetry_group_warning("add")
         if isinstance(other, Volume):
             res = self.__class__(self._data + other.asnumpy())
         else:
@@ -375,7 +378,7 @@ class Volume:
 
         :return: Volume instance.
         """
-        self._symmetry_group_warning()
+        self._symmetry_group_warning("transpose")
 
         original_stack_shape = self.stack_shape
         v = self._data.reshape(-1, *self._data.shape[-3:])
@@ -411,7 +414,7 @@ class Volume:
 
         :return: Volume instance.
         """
-        self._symmetry_group_warning()
+        self._symmetry_group_warning("flip")
 
         # Convert integer to tuple, so we can always loop.
         if isinstance(axis, int):
@@ -470,7 +473,7 @@ class Volume:
 
         :return: `Volume` instance.
         """
-        self._symmetry_group_warning()
+        self._symmetry_group_warning("rotate")
         if self.stack_ndim > 1:
             raise NotImplementedError(
                 "`rotation` is currently limited to 1D Volume stacks."

--- a/src/aspire/volume/volume_synthesis.py
+++ b/src/aspire/volume/volume_synthesis.py
@@ -8,6 +8,7 @@ from aspire.utils.random import Random, randn
 from aspire.volume import (
     CnSymmetryGroup,
     DnSymmetryGroup,
+    IdentitySymmetryGroup,
     OSymmetryGroup,
     TSymmetryGroup,
     Volume,
@@ -246,6 +247,9 @@ class AsymmetricVolume(CnSymmetricVolume):
             raise ValueError(
                 f"An {self.__class__.__name__} must have order=1. Provided order was {self.order}"
             )
+
+    def _set_symmetry_group(self):
+        self._symmetry_group = IdentitySymmetryGroup(dtype=self.dtype)
 
     def _symmetrize_gaussians(self, Q, D, mu):
         return Q, D, mu

--- a/tests/test_symmetry_groups.py
+++ b/tests/test_symmetry_groups.py
@@ -66,6 +66,14 @@ def test_group_str(group_fixture):
     logger.debug(f"String for {group_fixture}: {sym_string}.")
 
 
+def test_group_equivalence(group_fixture):
+    C2_symmetry_group = CnSymmetryGroup(order=2, dtype=group_fixture.dtype)
+    if str(group_fixture) == "C2":
+        assert C2_symmetry_group == group_fixture
+    else:
+        assert C2_symmetry_group != group_fixture
+
+
 def test_group_rotations(group_fixture):
     rotations = group_fixture.rotations
     assert isinstance(rotations, Rotation)

--- a/tests/test_synthetic_volume.py
+++ b/tests/test_synthetic_volume.py
@@ -119,6 +119,8 @@ def test_compact_support(vol_fixture):
         assert (vol.asnumpy()[0][inside] > 0).all()
 
 
+# Supress expected warnings due to rotation of symmetric volume.
+@pytest.mark.filterwarnings("ignore:`symmetry_group` attribute is being set to `C1`")
 def test_volume_symmetry(vol_fixture):
     """Test that volumes have intended symmetry."""
     vol = vol_fixture.generate()

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -810,6 +810,12 @@ def test_aglebraic_ops_symmetry_warnings(symmetric_vols):
     # Should have 4 warnings on record.
     assert len(record) == 4
 
+    # Check that warning occurs only once per line.
+    with warnings.catch_warnings(record=True) as record:
+        for _ in range(5):
+            vol_c3 + vol_c4
+    assert len(record) == 1
+
 
 def test_volume_load_with_symmetry():
     # Check we can load a Volume with symmetry_group.

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import tempfile
+import warnings
 from itertools import product
 
 import numpy as np
@@ -779,13 +780,15 @@ def test_transformation_symmetry_warnings(symmetric_vols):
 def test_aglebraic_ops_symmetry_warnings(symmetric_vols):
     vol_c3, vol_c4 = symmetric_vols
 
-    # Compatible symmetry should retain symmetry_group.
-    assert (vol_c3 + vol_c3).symmetry_group == vol_c3.symmetry_group
-    assert (vol_c3 - vol_c3).symmetry_group == vol_c3.symmetry_group
-    assert (vol_c3 * vol_c3).symmetry_group == vol_c3.symmetry_group
-    assert (
-        vol_c3 / (vol_c3 + 1)
-    ).symmetry_group == vol_c3.symmetry_group  # plus 1 to avoid division by 0.
+    # Compatible symmetry should retain symmetry_group and emit no warning.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert (vol_c3 + vol_c3).symmetry_group == vol_c3.symmetry_group
+        assert (vol_c3 - vol_c3).symmetry_group == vol_c3.symmetry_group
+        assert (vol_c3 * vol_c3).symmetry_group == vol_c3.symmetry_group
+        assert (
+            vol_c3 / (vol_c3 + 1)
+        ).symmetry_group == vol_c3.symmetry_group  # plus 1 to avoid division by 0.
 
     # Incompatible symmetry should warn and set symmetry_group to C1.
     with pytest.warns(

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -753,13 +753,13 @@ def test_symmetry_group_pass_through(symmetric_vols):
 
 def test_transformation_symmetry_warnings(symmetric_vols):
     """
-    A warning should be emitted (once) for transpose, flip, rotate, add, sub, mult, div.
+    A warning should be emitted for transpose, flip, and rotate.
     """
     vol_c3, _ = symmetric_vols
     sym_group = str(vol_c3.symmetry_group)
     assert sym_group == "C3"
 
-    # Check we get warning on first transformation.
+    # Check we get warning for each transformation.
     with pytest.warns(
         UserWarning, match=r".*`symmetry_group` attribute is being set to `C1`.*"
     ) as record:
@@ -778,6 +778,9 @@ def test_transformation_symmetry_warnings(symmetric_vols):
 
 
 def test_aglebraic_ops_symmetry_warnings(symmetric_vols):
+    """
+    A warning should be emitted for  add, sub, mult, and div.
+    """
     vol_c3, vol_c4 = symmetric_vols
 
     # Compatible symmetry should retain symmetry_group and emit no warning.

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -771,7 +771,7 @@ def test_symmetry_group_reset_warning():
         _ = vol_r.rotate(Rotation.about_axis("x", np.pi, dtype=vol.dtype))
 
         # Throw single test warning.
-        warnings.warn("test", Warning)
+        warnings.warn("test", Warning, stacklevel=2)
 
     # Should only have test warning
     assert len(record) == 1

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -772,10 +772,6 @@ def test_transformation_symmetry_warnings(symmetric_vols):
     assert str(vol_f.symmetry_group) == "C1"
     assert str(vol_r.symmetry_group) == "C1"
 
-    # Should only have test warning
-    assert len(record) == 1
-    assert str(record[0].message) == "test"
-
     # Check original volume has retained C3 symmetry.
     assert str(vol_c3.symmetry_group) == "C3"
 

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -726,6 +726,28 @@ def test_symmetry_group_set_get(sym_group, sym_string):
         _ = Volume(data, symmetry_group=123, dtype=dtype)
 
 
+def test_symmetry_group_pass_through():
+    sym_group = "C5"
+    vol = Volume(
+        np.load(os.path.join(DATA_DIR, "clean70SRibosome_vol_down8.npy")),
+        symmetry_group=sym_group,
+    )
+
+    # Chack symmetry_group pass-through for various transformations.
+    assert str(vol.astype(np.float64).symmetry_group) == sym_group  # astype
+    assert str(vol[0].symmetry_group) == sym_group  # getitem
+    assert str(vol.stack_reshape((1, 1)).symmetry_group) == sym_group  # stack_reshape
+    assert str(vol.T.symmetry_group) == sym_group  # transpose
+    assert str(vol.flip().symmetry_group) == sym_group  # flip
+    assert (
+        str(vol.downsample(vol.resolution // 2).symmetry_group) == sym_group
+    )  # downsample
+    assert (
+        str(vol.rotate(Rotation.about_axis("x", np.pi, dtype=vol.dtype)).symmetry_group)
+        == sym_group
+    )  # rotate
+
+
 def test_volume_load_with_symmetry():
     # Check we can load a Volume with symmetry_group.
     vol = Volume(

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import tempfile
-import warnings
 from itertools import product
 
 import numpy as np


### PR DESCRIPTION
Checks whether operations on symmetric volumes should retain symmetry group. If not, the symmetry group is downgraded to C1 and warning is emitted.

Will close #1081.