### PR TITLE
update cufinufft

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ gpu_102 = ["pycuda", "cupy-cuda102", "cufinufft==1.3"]
 gpu_110 = ["pycuda", "cupy-cuda110", "cufinufft==1.3"]
 gpu_111 = ["pycuda", "cupy-cuda111", "cufinufft==1.3"]
 gpu_11x = ["pycuda", "cupy-cuda11x", "cufinufft==1.3"]
-gpu_12x = ["pycuda", "cupy-cuda12x", "cufinufft==1.3"]
+gpu_12x = ["pycuda", "cupy-cuda12x", "cufinufft==2.2.0"]
 dev = [
     "black",
     "bumpversion",

--- a/src/aspire/nufft/cufinufft.py
+++ b/src/aspire/nufft/cufinufft.py
@@ -96,9 +96,7 @@ class CufinufftPlan(Plan):
         `(ntransforms, num_pts)`.
         """
 
-        # Check we're not forcing a dtype workaround for ASPIRE-Python/703,
-        #   then check if we have a dtype mismatch.
-        # This avoids false positive complaint for the workaround.
+        # Check dtype mismatch.
         if not (signal.dtype == self.dtype or signal.dtype == self.complex_dtype):
             logger.warning(
                 "Incorrect dtypes passed to (a)nufft."


### PR DESCRIPTION
Updates cufinufft to 2.2.0.

Reverts one of the outstanding workarounds.

WIP.  While this appears to work, I still need to review what actually changed between versions.  Also should have some additional manual testing.