### PR TITLE
cufinufft v2.2.0 migration

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -128,7 +128,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install dependencies
       run: |
-        pip install -e ".[dev,gpu_12x]"
+        pip install -e ".[dev,gpu-12x]"
     - name: Customize config
       run: |
         echo "Setup tmp dirs and chmod so others can cleanup."

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -141,24 +141,26 @@ driver version, run ``nvidia-smi`` on the intended system.
    * - CUDA Version
      - ASPIRE Extension
    * - 10.2
-     - gpu_102
+     - gpu-102
    * - 11.0
-     - gpu_110
+     - gpu-110
    * - 11.1
-     - gpu_111
+     - gpu-111
    * - >=11.2
-     - gpu_11x
+     - gpu-11x
+   * - >=12
+     - gpu-12x
 
-For example, if you have CUDA 11.7 installed on your system,
+For example, if you have CUDA 12.3 installed on your system,
 the command below would install GPU packages required for ASPIRE.
 
 ::
 
     # From a local git repo
-    pip install -e ".[gpu_11x]"
+    pip install -e ".[gpu-12x]"
 
     # From PyPI
-    pip install "aspire[gpu_11x]"
+    pip install "aspire[gpu-12x]"
 
     
 By default if the required GPU extensions are correctly installed,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,11 +63,11 @@ dependencies = [
 "Source" = "https://github.com/ComputationalCryoEM/ASPIRE-Python"
 
 [project.optional-dependencies]
-gpu_102 = ["pycuda", "cupy-cuda102", "cufinufft==1.3"]
-gpu_110 = ["pycuda", "cupy-cuda110", "cufinufft==1.3"]
-gpu_111 = ["pycuda", "cupy-cuda111", "cufinufft==1.3"]
-gpu_11x = ["pycuda", "cupy-cuda11x", "cufinufft==1.3"]
-gpu_12x = ["pycuda", "cupy-cuda12x", "cufinufft==2.2.0"]
+gpu-102 = ["pycuda", "cupy-cuda102", "cufinufft==1.3"]
+gpu-110 = ["pycuda", "cupy-cuda110", "cufinufft==1.3"]
+gpu-111 = ["pycuda", "cupy-cuda111", "cufinufft==1.3"]
+gpu-11x = ["pycuda", "cupy-cuda11x", "cufinufft==1.3"]
+gpu-12x = ["pycuda", "cupy-cuda12x", "cufinufft==2.2.0"]
 dev = [
     "black",
     "bumpversion",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ gpu_102 = ["pycuda", "cupy-cuda102", "cufinufft==1.3"]
 gpu_110 = ["pycuda", "cupy-cuda110", "cufinufft==1.3"]
 gpu_111 = ["pycuda", "cupy-cuda111", "cufinufft==1.3"]
 gpu_11x = ["pycuda", "cupy-cuda11x", "cufinufft==1.3"]
-gpu_12x = ["pycuda", "cupy-cuda12x", "cufinufft==1.3"]
+gpu_12x = ["pycuda", "cupy-cuda12x", "cufinufft==2.2.0"]
 dev = [
     "black",
     "bumpversion",


### PR DESCRIPTION
This updates our `pyproject.toml` towards CUDA 12 with cufinufft v2.2.0.

For cufinufft v2.2.0, the changes described in the python migration guide were applied.

I was expecting this release to solve the float/double bug originally reported in the legacy cufinufft repo, but it seems like that bug (or one with the same symptoms) is still there in the pypi package.  I will look into this just a little and potentially create a bug report in the main finufft repo.

I'm not sure why this seg faulted in the CI.  I ran into this locally, but it went away after some (system) package changes.  Perhaps I need to restart the runner service.  Will look into that.