### PR TITLE
Adding progress bar for CLSync

### DIFF
--- a/src/aspire/abinitio/commonline_base.py
+++ b/src/aspire/abinitio/commonline_base.py
@@ -5,7 +5,7 @@ import numpy as np
 import scipy.sparse as sparse
 
 from aspire.operators import PolarFT
-from aspire.utils import common_line_from_rots, fuzzy_mask
+from aspire.utils import common_line_from_rots, fuzzy_mask, tqdm
 from aspire.utils.random import choice
 
 logger = logging.getLogger(__name__)
@@ -167,6 +167,10 @@ class CLOrient3D:
         # Note that only use half of each ray
         pf = self._apply_filter_and_norm("ijk, k -> ijk", pf, r_max, h)
 
+        # Setup a progress bar
+        _total_pairs_to_test = self.n_check * (self.n_check - 1) // 2
+        pbar = tqdm(desc="Searching over common line pairs", total=_total_pairs_to_test)
+
         # Search for common lines between [i, j] pairs of images.
         # Creating pf and building common lines are different to the Matlab version.
         # The random selection is implemented.
@@ -211,6 +215,8 @@ class CLOrient3D:
                         clmatrix[j, i] = cl2
                         cl_dist[i, j] = sval
                         shifts_1d[i, j] = shifts[shift]
+                pbar.update()
+        pbar.close()
 
         self.clmatrix = clmatrix
         self.shifts_1d = shifts_1d

--- a/src/aspire/abinitio/commonline_base.py
+++ b/src/aspire/abinitio/commonline_base.py
@@ -168,7 +168,7 @@ class CLOrient3D:
         pf = self._apply_filter_and_norm("ijk, k -> ijk", pf, r_max, h)
 
         # Setup a progress bar
-        _total_pairs_to_test = self.n_check * (self.n_check - 1) // 2
+        _total_pairs_to_test = self.n_img * (self.n_check - 1) // 2
         pbar = tqdm(desc="Searching over common line pairs", total=_total_pairs_to_test)
 
         # Search for common lines between [i, j] pairs of images.

--- a/src/aspire/reconstruction/estimator.py
+++ b/src/aspire/reconstruction/estimator.py
@@ -51,7 +51,7 @@ class Estimator:
 
         self.src = src
         if basis is None:
-            logger.info("{self.__class__.__name__} instantiating default basis.")
+            logger.info(f"{self.__class__.__name__} instantiating default basis.")
             basis = FFBBasis3D(src.L, dtype=src.dtype)
         self.basis = basis
         self.dtype = self.src.dtype


### PR DESCRIPTION
Testing this locally now on a few experiments.  Gives me a better estimate of how long this step will take.

```
2024-03-15 11:38:03,223 INFO [aspire.source.image] Attempting to create an Image object from Numpy array.
2024-03-15 11:38:03,224 INFO [aspire.source.image] Creating ArrayImageSource with 3000 images.
2024-03-15 11:38:03,225 INFO [aspire.source.image] Creating OrientedSource with 3000 images.
2024-03-15 11:38:03,225 INFO [aspire.reconstruction.estimator] {self.__class__.__name__} instantiating default basis.
2024-03-15 11:38:03,225 INFO [aspire.basis.ffb_3d] Expanding 3D map in a frequency-domain Fourier–Bessel basis using the fast method.
2024-03-15 11:38:31,230 INFO [aspire.source.image] Estimating rotations for <aspire.source.image.ArrayImageSource object at 0x7fc70d2d3160> using <aspire.abinitio.commonline_sync.CLSyncVoting object at 0x7fc61d8665b0>.
2024-03-15 11:38:31,638 INFO [aspire.operators.polar_ft] Represent 2D image in a polar Fourier grid
Searching over common line pairs:   1%|          | 39088/4498500 [03:06<5:52:55, 210.59it/s]
```

I see one of my log messages has a bug, I'll fix that too while I'm in here.