### PR TITLE
SymmetryGroup Parsing

### DIFF
--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -516,7 +516,7 @@ class Image:
         ), "Number of rotation matrices must match the number of images"
 
         # Get symmetry rotations from SymmetryGroup.
-        symmetry_rots = SymmetryGroup.parser(symmetry_group, dtype=self.dtype).matrices
+        symmetry_rots = SymmetryGroup.parse(symmetry_group, dtype=self.dtype).matrices
 
         # Compute Fourier transform of images.
         im_f = xp.asnumpy(fft.centered_fft2(xp.asarray(self._data))) / (L**2)

--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -516,18 +516,9 @@ class Image:
         ), "Number of rotation matrices must match the number of images"
 
         # Get symmetry rotations from SymmetryGroup.
-        if symmetry_group is None:
-            symmetry_rots = np.eye(3, dtype=self.dtype)[None]
-        else:
-            if isinstance(symmetry_group, str):
-                symmetry_group = SymmetryGroup.from_string(
-                    symmetry_group, dtype=self.dtype
-                )
-            if not isinstance(symmetry_group, SymmetryGroup):
-                raise TypeError(
-                    f"`symmetry_group` must be a `SymmetryGroup` instance. Found {type(symmetry_group)}."
-                )
-            symmetry_rots = symmetry_group.matrices
+        symmetry_rots = SymmetryGroup.from_string(
+            symmetry_group, dtype=self.dtype
+        ).matrices
 
         # Compute Fourier transform of images.
         im_f = xp.asnumpy(fft.centered_fft2(xp.asarray(self._data))) / (L**2)

--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -516,7 +516,7 @@ class Image:
         ), "Number of rotation matrices must match the number of images"
 
         # Get symmetry rotations from SymmetryGroup.
-        symmetry_rots = SymmetryGroup.from_string(
+        symmetry_rots = SymmetryGroup.parser(
             symmetry_group, dtype=self.dtype
         ).matrices
 

--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -516,9 +516,7 @@ class Image:
         ), "Number of rotation matrices must match the number of images"
 
         # Get symmetry rotations from SymmetryGroup.
-        symmetry_rots = SymmetryGroup.parser(
-            symmetry_group, dtype=self.dtype
-        ).matrices
+        symmetry_rots = SymmetryGroup.parser(symmetry_group, dtype=self.dtype).matrices
 
         # Compute Fourier transform of images.
         im_f = xp.asnumpy(fft.centered_fft2(xp.asarray(self._data))) / (L**2)

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -255,13 +255,8 @@ class ImageSource(ABC):
             raise RuntimeError(
                 f"This source is no longer mutable. Try new_source = source.update(symmetry_group='{value}')."
             )
-        if isinstance(value, str):
-            value = SymmetryGroup.from_string(value, dtype=self.dtype)
-        if not isinstance(value, SymmetryGroup):
-            raise ValueError(
-                "`symmetry_group` must be an instance of the SymmetryGroup class"
-            )
-        self._symmetry_group = value
+
+        self._symmetry_group = SymmetryGroup.from_string(value, dtype=self.dtype)
         self.set_metadata(["_rlnSymmetryGroup"], str(self.symmetry_group))
 
     def _populate_symmetry_group(self, symmetry_group):

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -256,7 +256,7 @@ class ImageSource(ABC):
                 f"This source is no longer mutable. Try new_source = source.update(symmetry_group='{value}')."
             )
 
-        self._symmetry_group = SymmetryGroup.from_string(value, dtype=self.dtype)
+        self._symmetry_group = SymmetryGroup.parser(value, dtype=self.dtype)
         self.set_metadata(["_rlnSymmetryGroup"], str(self.symmetry_group))
 
     def _populate_symmetry_group(self, symmetry_group):
@@ -270,7 +270,7 @@ class ImageSource(ABC):
                     f"Overriding metadata with supplied symmetry group {symmetry_group}"
                 )
             else:
-                symmetry_group = SymmetryGroup.from_string(
+                symmetry_group = SymmetryGroup.parser(
                     symmetry=self.get_metadata(["_rlnSymmetryGroup"])[0],
                     dtype=self.dtype,
                 )

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -256,7 +256,7 @@ class ImageSource(ABC):
                 f"This source is no longer mutable. Try new_source = source.update(symmetry_group='{value}')."
             )
 
-        self._symmetry_group = SymmetryGroup.parser(value, dtype=self.dtype)
+        self._symmetry_group = SymmetryGroup.parse(value, dtype=self.dtype)
         self.set_metadata(["_rlnSymmetryGroup"], str(self.symmetry_group))
 
     def _populate_symmetry_group(self, symmetry_group):
@@ -270,7 +270,7 @@ class ImageSource(ABC):
                     f"Overriding metadata with supplied symmetry group {symmetry_group}"
                 )
             else:
-                symmetry_group = SymmetryGroup.parser(
+                symmetry_group = SymmetryGroup.parse(
                     symmetry=self.get_metadata(["_rlnSymmetryGroup"])[0],
                     dtype=self.dtype,
                 )

--- a/src/aspire/volume/symmetry_groups.py
+++ b/src/aspire/volume/symmetry_groups.py
@@ -46,7 +46,7 @@ class SymmetryGroup(ABC):
         return f"{self.to_string}"
 
     @staticmethod
-    def parser(symmetry, dtype):
+    def parse(symmetry, dtype):
         """
         Takes a SymmetryGroup instance or a string, ie. 'C1', 'C7', 'D3', 'T', 'O', and returns a concrete
         SymmetryGroup object with the specified dtype.

--- a/src/aspire/volume/symmetry_groups.py
+++ b/src/aspire/volume/symmetry_groups.py
@@ -48,10 +48,10 @@ class SymmetryGroup(ABC):
     @staticmethod
     def parser(symmetry, dtype):
         """
-        Takes a string, ie. 'C1', 'C7', 'D3', 'T', 'O', and returns a concrete
-        SymmetryGroup object.
+        Takes a SymmetryGroup instance or a string, ie. 'C1', 'C7', 'D3', 'T', 'O', and returns a concrete
+        SymmetryGroup object with the specified dtype.
 
-        :param symmetry: A string indicating the symmetry of a molecule.
+        :param symmetry: A string (or SymmetryGroup instance) indicating the symmetry of a molecule.
         :param dtype: dtype for rotation matrices.
         :return: Concrete SymmetryGroup object.
         """

--- a/src/aspire/volume/symmetry_groups.py
+++ b/src/aspire/volume/symmetry_groups.py
@@ -74,6 +74,9 @@ class SymmetryGroup(ABC):
             )
 
         symmetry = symmetry.upper()
+        if symmetry == "C1":
+            return IdentitySymmetryGroup(dtype=dtype)
+
         symmetry_type = symmetry[0]
         symmetric_order = symmetry[1:]
 

--- a/src/aspire/volume/symmetry_groups.py
+++ b/src/aspire/volume/symmetry_groups.py
@@ -46,7 +46,7 @@ class SymmetryGroup(ABC):
         return f"{self.to_string}"
 
     @staticmethod
-    def from_string(symmetry, dtype):
+    def parser(symmetry, dtype):
         """
         Takes a string, ie. 'C1', 'C7', 'D3', 'T', 'O', and returns a concrete
         SymmetryGroup object.

--- a/src/aspire/volume/symmetry_groups.py
+++ b/src/aspire/volume/symmetry_groups.py
@@ -56,6 +56,23 @@ class SymmetryGroup(ABC):
         :return: Concrete SymmetryGroup object.
         """
 
+        if symmetry is None:
+            return IdentitySymmetryGroup(dtype=dtype)
+
+        if isinstance(symmetry, SymmetryGroup):
+            if symmetry.dtype != dtype:
+                logger.warning(f"Recasting SymmetryGroup with dtype {dtype}.")
+                group_kwargs = dict(dtype=dtype)
+                if getattr(symmetry, "order", False) and symmetry.order > 1:
+                    group_kwargs["order"] = symmetry.order
+                symmetry = symmetry.__class__(**group_kwargs)
+            return symmetry
+
+        if not isinstance(symmetry, str):
+            raise TypeError(
+                f"`symmetry` must be a string or `SymmetryGroup` instance. Found {type(symmetry)}"
+            )
+
         symmetry = symmetry.upper()
         symmetry_type = symmetry[0]
         symmetric_order = symmetry[1:]

--- a/src/aspire/volume/volume.py
+++ b/src/aspire/volume/volume.py
@@ -171,16 +171,7 @@ class Volume:
 
         :param value: A `SymmetryGroup` instance or string indicating symmetry, ie. "C5", "D7", "T", etc.
         """
-        # If value not provided set symmetry to the `IdentitySymmetryGroup`.
-        value = value or IdentitySymmetryGroup(dtype=self.dtype)
-        if isinstance(value, str):
-            value = SymmetryGroup.from_string(value, dtype=self.dtype)
-        if not isinstance(value, SymmetryGroup):
-            raise ValueError(
-                "`symmetry_group` must be an instance of the SymmetryGroup class"
-                " or a string indicating the symmetry, ie. 'C5', 'D7', 'T', etc."
-            )
-        self._symmetry_group = value
+        self._symmetry_group = SymmetryGroup.from_string(value, dtype=self.dtype)
 
     def _symmetry_group_warning(self, stacklevel):
         """

--- a/src/aspire/volume/volume.py
+++ b/src/aspire/volume/volume.py
@@ -171,7 +171,7 @@ class Volume:
 
         :param value: A `SymmetryGroup` instance or string indicating symmetry, ie. "C5", "D7", "T", etc.
         """
-        self._symmetry_group = SymmetryGroup.parser(value, dtype=self.dtype)
+        self._symmetry_group = SymmetryGroup.parse(value, dtype=self.dtype)
 
     def _symmetry_group_warning(self, stacklevel):
         """

--- a/src/aspire/volume/volume.py
+++ b/src/aspire/volume/volume.py
@@ -171,7 +171,7 @@ class Volume:
 
         :param value: A `SymmetryGroup` instance or string indicating symmetry, ie. "C5", "D7", "T", etc.
         """
-        self._symmetry_group = SymmetryGroup.from_string(value, dtype=self.dtype)
+        self._symmetry_group = SymmetryGroup.parser(value, dtype=self.dtype)
 
     def _symmetry_group_warning(self, stacklevel):
         """

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -307,7 +307,7 @@ def test_backproject_symmetry_group():
 
     # Attempt backproject with bad symmetry group.
     not_a_symmetry_group = []
-    with raises(TypeError, match=r"`symmetry_group` must be a `SymmetryGroup`"):
+    with raises(TypeError, match=r"`symmetry` must be a string or `SymmetryGroup`"):
         _ = im.backproject(rots, symmetry_group=not_a_symmetry_group)
 
     # Symmetry from string.

--- a/tests/test_symmetry_groups.py
+++ b/tests/test_symmetry_groups.py
@@ -8,6 +8,7 @@ from aspire.utils import Rotation
 from aspire.volume import (
     CnSymmetryGroup,
     DnSymmetryGroup,
+    IdentitySymmetryGroup,
     OSymmetryGroup,
     SymmetryGroup,
     TSymmetryGroup,
@@ -77,6 +78,30 @@ def test_group_equivalence(group_fixture):
 def test_group_rotations(group_fixture):
     rotations = group_fixture.rotations
     assert isinstance(rotations, Rotation)
+
+
+def test_from_string_identity():
+    result = SymmetryGroup.from_string("C1", dtype=np.float32)
+    assert isinstance(result, IdentitySymmetryGroup)
+
+
+def test_from_string_with_group(group_fixture):
+    """Test SymmetryGroup instance are parsed correctly."""
+    result = SymmetryGroup.from_string(group_fixture, group_fixture.dtype)
+    assert result == group_fixture
+    assert result.dtype == group_fixture.dtype
+
+
+def test_from_string_dtype_casting(group_fixture, caplog):
+    """Test that dtype gets re-cast and warns."""
+    dtype = np.float32
+    if group_fixture.dtype == np.float32:
+        dtype = np.float64
+
+    caplog.clear()
+    msg = f"Recasting SymmetryGroup with dtype {dtype}."
+    result = SymmetryGroup.from_string(group_fixture, dtype)
+    assert msg in caplog.text
 
 
 def test_from_string_error():

--- a/tests/test_symmetry_groups.py
+++ b/tests/test_symmetry_groups.py
@@ -100,7 +100,7 @@ def test_from_string_dtype_casting(group_fixture, caplog):
 
     caplog.clear()
     msg = f"Recasting SymmetryGroup with dtype {dtype}."
-    result = SymmetryGroup.from_string(group_fixture, dtype)
+    _ = SymmetryGroup.from_string(group_fixture, dtype)
     assert msg in caplog.text
 
 

--- a/tests/test_symmetry_groups.py
+++ b/tests/test_symmetry_groups.py
@@ -80,19 +80,19 @@ def test_group_rotations(group_fixture):
     assert isinstance(rotations, Rotation)
 
 
-def test_from_string_identity():
-    result = SymmetryGroup.from_string("C1", dtype=np.float32)
+def test_parser_identity():
+    result = SymmetryGroup.parser("C1", dtype=np.float32)
     assert isinstance(result, IdentitySymmetryGroup)
 
 
-def test_from_string_with_group(group_fixture):
+def test_parser_with_group(group_fixture):
     """Test SymmetryGroup instance are parsed correctly."""
-    result = SymmetryGroup.from_string(group_fixture, group_fixture.dtype)
+    result = SymmetryGroup.parser(group_fixture, group_fixture.dtype)
     assert result == group_fixture
     assert result.dtype == group_fixture.dtype
 
 
-def test_from_string_dtype_casting(group_fixture, caplog):
+def test_parser_dtype_casting(group_fixture, caplog):
     """Test that dtype gets re-cast and warns."""
     dtype = np.float32
     if group_fixture.dtype == np.float32:
@@ -100,13 +100,13 @@ def test_from_string_dtype_casting(group_fixture, caplog):
 
     caplog.clear()
     msg = f"Recasting SymmetryGroup with dtype {dtype}."
-    _ = SymmetryGroup.from_string(group_fixture, dtype)
+    _ = SymmetryGroup.parser(group_fixture, dtype)
     assert msg in caplog.text
 
 
-def test_from_string_error():
+def test_parser_error():
     junk_symmetry = "P12"
     with pytest.raises(
         ValueError, match=f"Symmetry type {junk_symmetry[0]} not supported.*"
     ):
-        _ = SymmetryGroup.from_string(junk_symmetry, dtype=np.float32)
+        _ = SymmetryGroup.parser(junk_symmetry, dtype=np.float32)

--- a/tests/test_symmetry_groups.py
+++ b/tests/test_symmetry_groups.py
@@ -81,13 +81,13 @@ def test_group_rotations(group_fixture):
 
 
 def test_parser_identity():
-    result = SymmetryGroup.parser("C1", dtype=np.float32)
+    result = SymmetryGroup.parse("C1", dtype=np.float32)
     assert isinstance(result, IdentitySymmetryGroup)
 
 
 def test_parser_with_group(group_fixture):
     """Test SymmetryGroup instance are parsed correctly."""
-    result = SymmetryGroup.parser(group_fixture, group_fixture.dtype)
+    result = SymmetryGroup.parse(group_fixture, group_fixture.dtype)
     assert result == group_fixture
     assert result.dtype == group_fixture.dtype
 
@@ -100,7 +100,7 @@ def test_parser_dtype_casting(group_fixture, caplog):
 
     caplog.clear()
     msg = f"Recasting SymmetryGroup with dtype {dtype}."
-    _ = SymmetryGroup.parser(group_fixture, dtype)
+    _ = SymmetryGroup.parse(group_fixture, dtype)
     assert msg in caplog.text
 
 
@@ -109,4 +109,4 @@ def test_parser_error():
     with pytest.raises(
         ValueError, match=f"Symmetry type {junk_symmetry[0]} not supported.*"
     ):
-        _ = SymmetryGroup.parser(junk_symmetry, dtype=np.float32)
+        _ = SymmetryGroup.parse(junk_symmetry, dtype=np.float32)

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -727,13 +727,6 @@ def test_symmetry_group_set_get(sym_group, sym_string):
     assert isinstance(vol.symmetry_group, SymmetryGroup)
     assert str(vol.symmetry_group) == sym_string
 
-    # Check for expected error when symmetry_group is not a SymmetryGroup object.
-    with raises(
-        ValueError,
-        match=r"`symmetry_group` must be an instance of the SymmetryGroup class.*",
-    ):
-        _ = Volume(data, symmetry_group=123, dtype=dtype)
-
 
 def test_symmetry_group_pass_through(symmetric_vols):
     vol_c3, _ = symmetric_vols


### PR DESCRIPTION
This PR adds some extra parsing logic to `SymmetryGroup.from_string()` to handle being passed a `SymmetryGroup` instance or `None`.

Closes #1083 