### PR TITLE
Ampere CI Fix

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -80,6 +80,7 @@ jobs:
     - name: Set up Conda ${{ matrix.os }} Python ${{ matrix.python-version }}
       uses: conda-incubator/setup-miniconda@v2
       with:
+        miniconda-version: "latest"
         auto-update-conda: true
         python-version: ${{ matrix.python-version }}
         activate-environment: aspire

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -151,7 +151,7 @@ jobs:
       run: |
         ASPIREDIR=${{ env.WORK_DIR }} python -c \
         "import aspire; print(aspire.config['ray']['temp_dir'])"
-        ASPIREDIR=${{ env.WORK_DIR }} pytest --durations=50
+        ASPIREDIR=${{ env.WORK_DIR }} python -m pytest --durations=50
     - name: Cache Data
       run: |
         ASPIREDIR=${{ env.WORK_DIR }} python -c \


### PR DESCRIPTION
CI was failing on our self hosted runner due to some changes in how pytest is bound into path: https://github.com/ComputationalCryoEM/ASPIRE-Python/actions/runs/8838267362/job/24269024633#step:5:11

Letting python handle the paths (ie. use `python -m pytest` to invoke pytest) fixes the problem.