### PR TITLE
J-sync Bug

### DIFF
--- a/src/aspire/abinitio/commonline_c3_c4.py
+++ b/src/aspire/abinitio/commonline_c3_c4.py
@@ -785,7 +785,7 @@ class CLSymmetryC3C4(CLOrient3D, SyncVotingMixin):
             # Update multiplication of signs times vec
             new_vec[ij] += s_ij_jk * vec[jk] + s_ij_ik * vec[ik]
             new_vec[jk] += s_ij_jk * vec[ij] + s_ik_jk * vec[ik]
-            new_vec[ik] += s_ij_jk * vec[ij] + s_ik_jk * vec[jk]
+            new_vec[ik] += s_ij_ik * vec[ij] + s_ik_jk * vec[jk]
 
         return new_vec
 

--- a/tests/test_orient_symmetric.py
+++ b/tests/test_orient_symmetric.py
@@ -441,11 +441,11 @@ def test_commonlines(n_img, L, order, dtype):
 )
 def test_global_J_sync(n_img, dtype):
     """
-    For this test we build a set of relative rotations, Rijs, and randomly
-    J_conjugate them. We then test that J-synchronization is correct up to
-    conjugation of the entire set. We use n_img = 3 as the smallest possible
-    example to run the algorithm, which computes relative handedness over all
-    triplets of images.
+    For this test we build a set of 3rd row outer products, vijs and viis, and
+    randomly J_conjugate them. We then test that J-synchronization is correct up
+    to conjugation of the entire set. To expose bugs in the implementation, we use
+    n_img = 3 as the smallest possible example to run the algorithm, which computes
+    relative handedness over all triplets of images (in this case 1 triplet).
     """
     L = 16  # test not dependent on L
     order = 3  # test not dependent on order


### PR DESCRIPTION
There was a small bug in part of the J-sync algorithm used for Cn symmetric molecules. In particular, there was an error in this line https://github.com/ComputationalCryoEM/ASPIRE-Python/blob/554601bd5f91d33aab09efe0d80644360f6f3663/src/aspire/abinitio/commonline_c3_c4.py#L788

where the first term should be `s_ij_ik`. The existing test did not catch this bug as the algorithm was still producing correct results since this one term was part of a larger accumulation of terms of which we only take the sign. 

To expose the bug in the new test we use a problem size of n=3, the smallest size for the algorithm to run since it loops over triplets of images. In this case the test fails with the bug still in place.