### PR TITLE
sklearn API change

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "PyWavelets",
     "ray >= 2.9.2",
     "scipy >= 1.10.0",
-    "scikit-learn >= 1.5",
+    "scikit-learn <= 1.4.2",
     "scikit-image",
     "setuptools >= 0.41",
     "tqdm",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "PyWavelets",
     "ray >= 2.9.2",
     "scipy >= 1.10.0",
-    "scikit-learn",
+    "scikit-learn >= 1.5",
     "scikit-image",
     "setuptools >= 0.41",
     "tqdm",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "PyWavelets",
     "ray >= 2.9.2",
     "scipy >= 1.10.0",
-    "scikit-learn <= 1.4.2",
+    "scikit-learn",
     "scikit-image",
     "setuptools >= 0.41",
     "tqdm",

--- a/src/aspire/numeric/complex_pca/complex_pca.py
+++ b/src/aspire/numeric/complex_pca/complex_pca.py
@@ -14,6 +14,7 @@ Unfortunately we need a complex valued PCA, so we wrap theirs for now.
 import numpy as np
 import scipy.sparse as sp
 from sklearn.decomposition import PCA
+from sklearn.utils._array_api import get_namespace
 
 from .validation import check_array
 
@@ -45,6 +46,8 @@ class ComplexPCA(PCA):
             allow_complex=True,
         )
 
+        xp, is_array_api_compliant = get_namespace(X)
+
         # Handle n_components==None
         if self.n_components is None:
             if self.svd_solver != "arpack":
@@ -68,9 +71,9 @@ class ComplexPCA(PCA):
 
         # Call different fits for either full or truncated SVD
         if self._fit_svd_solver == "full":
-            return self._fit_full(X, n_components)
+            return self._fit_full(X, n_components, xp, is_array_api_compliant)
         elif self._fit_svd_solver in ["arpack", "randomized"]:
-            return self._fit_truncated(X, n_components, self._fit_svd_solver)
+            return self._fit_truncated(X, n_components, xp)
         else:
             raise ValueError(
                 "Unrecognized svd_solver='{0}'" "".format(self._fit_svd_solver)

--- a/src/aspire/numeric/complex_pca/complex_pca.py
+++ b/src/aspire/numeric/complex_pca/complex_pca.py
@@ -14,7 +14,6 @@ Unfortunately we need a complex valued PCA, so we wrap theirs for now.
 import numpy as np
 import scipy.sparse as sp
 from sklearn.decomposition import PCA
-from sklearn.utils._array_api import get_namespace
 
 from .validation import check_array
 
@@ -46,8 +45,6 @@ class ComplexPCA(PCA):
             allow_complex=True,
         )
 
-        xp, is_array_api_compliant = get_namespace(X)
-
         # Handle n_components==None
         if self.n_components is None:
             if self.svd_solver != "arpack":
@@ -71,9 +68,9 @@ class ComplexPCA(PCA):
 
         # Call different fits for either full or truncated SVD
         if self._fit_svd_solver == "full":
-            return self._fit_full(X, n_components, xp, is_array_api_compliant)
+            return self._fit_full(X, n_components)
         elif self._fit_svd_solver in ["arpack", "randomized"]:
-            return self._fit_truncated(X, n_components, xp)
+            return self._fit_truncated(X, n_components, self._fit_svd_solver)
         else:
             raise ValueError(
                 "Unrecognized svd_solver='{0}'" "".format(self._fit_svd_solver)

--- a/src/aspire/numeric/complex_pca/complex_pca.py
+++ b/src/aspire/numeric/complex_pca/complex_pca.py
@@ -11,8 +11,6 @@ a few places and not supporting it/crashing in other areas of code.
 Unfortunately we need a complex valued PCA, so we wrap theirs for now.
 """
 
-import sys
-
 import numpy as np
 import scipy.sparse as sp
 import sklearn

--- a/src/aspire/numeric/complex_pca/complex_pca.py
+++ b/src/aspire/numeric/complex_pca/complex_pca.py
@@ -15,6 +15,8 @@ import sys
 
 import numpy as np
 import scipy.sparse as sp
+import sklearn
+from packaging.version import Version
 from sklearn.decomposition import PCA
 from sklearn.utils._array_api import get_namespace
 
@@ -74,17 +76,16 @@ class ComplexPCA(PCA):
         # sci-kit changed `_fit_*()` API in latest release v1.5.0
         # which supports Python 3.9 - 3.12. This can be removed after
         # our minimal support is Python 3.9.
-        py_version = sys.version_info
-        py_dep = py_version.major == 3 and py_version.minor < 9
+        API_dep = Version(sklearn.__version__) < Version("1.5.0")
 
         # Call different fits for either full or truncated SVD
         if self._fit_svd_solver == "full":
-            if py_dep:
+            if API_dep:
                 return self._fit_full(X, n_components)
             else:
                 return self._fit_full(X, n_components, xp, is_array_api_compliant)
         elif self._fit_svd_solver in ["arpack", "randomized"]:
-            if py_dep:
+            if API_dep:
                 return self._fit_truncated(X, n_components, self._fit_svd_solver)
             else:
                 return self._fit_truncated(X, n_components, xp)


### PR DESCRIPTION
In a recent release `sklearn` altered the API of the PCA class methods `_fit_full()` and `_fit_truncated()`. Formerly, the namespace of the data was determined within these methods. Now, the namespace is determined in the method `_fit()` which calls the above methods and passes the namespace as an argument.

This API changed caused our subclass, `ComplexPCA`, of `sklearn`'s PCA class to be broken.

In this PR I've made a similar change to our subclass `ComplexPCA`. 