### PR TITLE
update GHA miniconda setup version to ~v3~ v2.3.0

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -78,7 +78,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Conda ${{ matrix.os }} Python ${{ matrix.python-version }}
-      uses: conda-incubator/setup-miniconda@v2.3
+      uses: conda-incubator/setup-miniconda@v2.3.0
       with:
         miniconda-version: "latest"
         auto-update-conda: true

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -78,7 +78,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Conda ${{ matrix.os }} Python ${{ matrix.python-version }}
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         miniconda-version: "latest"
         auto-update-conda: true

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -78,7 +78,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Conda ${{ matrix.os }} Python ${{ matrix.python-version }}
-      uses: conda-incubator/setup-miniconda@v3
+      uses: conda-incubator/setup-miniconda@v2.3
       with:
         miniconda-version: "latest"
         auto-update-conda: true


### PR DESCRIPTION
Closes #1121 

`conda-incubator/setup-miniconda@v3` is using Node 20.  Should resolve (Node 16) deprecation message.

Because this only occurs on the Conda CI, I'm just going to kick off the full pull request now instead of our usual two step process.