### PR TITLE
Hack24 nufft updates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,11 +62,11 @@ dependencies = [
 "Source" = "https://github.com/ComputationalCryoEM/ASPIRE-Python"
 
 [project.optional-dependencies]
-gpu-102 = ["pycuda", "cupy-cuda102", "cufinufft==1.3"]
-gpu-110 = ["pycuda", "cupy-cuda110", "cufinufft==1.3"]
-gpu-111 = ["pycuda", "cupy-cuda111", "cufinufft==1.3"]
-gpu-11x = ["pycuda", "cupy-cuda11x", "cufinufft==1.3"]
-gpu-12x = ["pycuda", "cupy-cuda12x", "cufinufft==2.2.0"]
+gpu-102 = ["cupy-cuda102", "cufinufft==1.3"]
+gpu-110 = ["cupy-cuda110", "cufinufft==1.3"]
+gpu-111 = ["cupy-cuda111", "cufinufft==1.3"]
+gpu-11x = ["cupy-cuda11x", "cufinufft==1.3"]
+gpu-12x = ["cupy-cuda12x", "cufinufft==2.2.0"]
 dev = [
     "black",
     "bumpversion",


### PR DESCRIPTION
Add code so `anufft` and `nufft` will detect if signal provided on GPU.  When signal is on GPU (via CuPY ndarray), keep the result on the GPU.

Allows use of `cufinufft` backend when provided host arrays.  In this case should copy signal to and result from GPU.