### PR TITLE
Hack24 sparse

### DIFF
--- a/bbenchmark/bbenchmark.py
+++ b/bbenchmark/bbenchmark.py
@@ -5,6 +5,7 @@ from time import perf_counter, time
 
 import matplotlib.pyplot as plt
 import numpy as np
+
 from aspire.basis import FFBBasis2D, FLEBasis2D
 from aspire.downloader import emdb_2660
 from aspire.noise import WhiteNoiseAdder

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,11 +62,11 @@ dependencies = [
 "Source" = "https://github.com/ComputationalCryoEM/ASPIRE-Python"
 
 [project.optional-dependencies]
-gpu-102 = ["pycuda", "cupy-cuda102", "cufinufft==1.3"]
-gpu-110 = ["pycuda", "cupy-cuda110", "cufinufft==1.3"]
-gpu-111 = ["pycuda", "cupy-cuda111", "cufinufft==1.3"]
-gpu-11x = ["pycuda", "cupy-cuda11x", "cufinufft==1.3"]
-gpu-12x = ["pycuda", "cupy-cuda12x", "cufinufft==2.2.0"]
+gpu-102 = ["cupy-cuda102", "cufinufft==1.3"]
+gpu-110 = ["cupy-cuda110", "cufinufft==1.3"]
+gpu-111 = ["cupy-cuda111", "cufinufft==1.3"]
+gpu-11x = ["cupy-cuda11x", "cufinufft==1.3"]
+gpu-12x = ["cupy-cuda12x", "cufinufft==2.2.0"]
 dev = [
     "black",
     "bumpversion",

--- a/src/aspire/basis/fle_2d.py
+++ b/src/aspire/basis/fle_2d.py
@@ -1,7 +1,6 @@
 import logging
 
 import numpy as np
-from scipy.fft import dct, idct
 from scipy.special import jv
 
 from aspire.basis import Coef, FBBasisMixin, SteerableBasis2D
@@ -555,10 +554,10 @@ class FLEBasis2D(SteerableBasis2D, FBBasisMixin):
         num_img = betas.shape[0]
         if self.num_interp > self.num_radial_nodes:
             betas = xp.asnumpy(betas)
-            betas = dct(betas, axis=1, type=2) / (2 * self.num_radial_nodes)
+            betas = fft.dct(betas, axis=1, type=2) / (2 * self.num_radial_nodes)
             zeros = np.zeros(betas.shape)
             betas = np.concatenate((betas, zeros), axis=1)
-            betas = idct(betas, axis=1, type=2) * 2 * betas.shape[1]
+            betas = fft.idct(betas, axis=1, type=2) * 2 * betas.shape[1]
             betas = xp.asarray(betas)
         betas = xp.moveaxis(betas, 0, -1)
 
@@ -590,9 +589,9 @@ class FLEBasis2D(SteerableBasis2D, FBBasisMixin):
         out = xp.moveaxis(out, -1, 0)
         if self.num_interp > self.num_radial_nodes:
             out = xp.asnumpy(out)  # RM
-            out = dct(out, axis=1, type=2)
+            out = fft.dct(out, axis=1, type=2)
             out = out[:, : self.num_radial_nodes, :]
-            out = idct(out, axis=1, type=2)
+            out = fft.idct(out, axis=1, type=2)
 
         return out
 
@@ -736,10 +735,10 @@ class FLEBasis2D(SteerableBasis2D, FBBasisMixin):
         b = np.squeeze(b)
         b = np.array(b)
         if self.num_interp > self.num_radial_nodes:
-            b = dct(b, axis=0, type=2) / (2 * self.num_radial_nodes)
+            b = fft.dct(b, axis=0, type=2) / (2 * self.num_radial_nodes)
             bz = np.zeros(b.shape)
             b = np.concatenate((b, bz), axis=0)
-            b = idct(b, axis=0, type=2) * 2 * b.shape[0]
+            b = fft.idct(b, axis=0, type=2) * 2 * b.shape[0]
         a = np.zeros(self.count, dtype=np.float64)
         y = [None] * (self.ell_p_max + 1)
         for i in range(self.ell_p_max + 1):

--- a/src/aspire/basis/fle_2d_utils.py
+++ b/src/aspire/basis/fle_2d_utils.py
@@ -1,5 +1,6 @@
 import numpy as np
-import scipy.sparse as sparse
+
+from aspire.numeric import sparse, xp
 
 
 def transform_complex_to_real(B, ells):
@@ -43,9 +44,9 @@ def precomp_transform_complex_to_real(ells):
     """
     count = len(ells)
     num_nonzero = np.sum(ells == 0) + 2 * np.sum(ells != 0)
-    idx = np.zeros(num_nonzero, dtype=int)
-    jdx = np.zeros(num_nonzero, dtype=int)
-    vals = np.zeros(num_nonzero, dtype=np.complex128)
+    idx = xp.zeros(num_nonzero, dtype=int)
+    jdx = xp.zeros(num_nonzero, dtype=int)
+    vals = xp.zeros(num_nonzero, dtype=np.complex128)
 
     k = 0
     for i in range(count):
@@ -190,9 +191,10 @@ def barycentric_interp_sparse(target_points, known_points, numsparse):
     # note that const cancels in numerator and denominator
     vals = vals / denom.reshape(-1, 1)
 
-    vals = vals.flatten()
-    idx = idx.flatten()
-    jdx = jdx.flatten()
+    # TODO, migrate more of this method towards `xp`
+    vals = xp.array(vals.flatten())
+    idx = xp.array(idx.flatten())
+    jdx = xp.array(jdx.flatten())
     # A is the linear operator mapping the function values from the fixed source
     # points to the fixed target points.
     # A(i,j) = \ell(x[i] ) w_j/(x[i] - xs[j]), with the notation in Eq. 3.3

--- a/src/aspire/config_default.yaml
+++ b/src/aspire/config_default.yaml
@@ -3,7 +3,7 @@ common:
     # numeric module to use - one of numpy/cupy
     numeric: cupy
     # fft backend to use - one of pyfftw/scipy/cupy/mkl
-    fft: pyfftw
+    fft: cupy
 
     # Set cache directory for ASPIRE example data.
     # By default the cache location will be set by pooch.os_cache(),

--- a/src/aspire/config_default.yaml
+++ b/src/aspire/config_default.yaml
@@ -1,7 +1,7 @@
 version: 0.12.2
 common:
     # numeric module to use - one of numpy/cupy
-    numeric: numpy
+    numeric: cupy
     # fft backend to use - one of pyfftw/scipy/cupy/mkl
     fft: pyfftw
 

--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -357,11 +357,14 @@ class Image:
         im = self.stack_reshape(-1)
 
         # compute FT with centered 0-frequency
-        fx = fft.centered_fft2(im._data)
+        fx = xp.asnumpy(fft.centered_fft2(xp.asarray(im._data)))
         # crop 2D Fourier transform for each image
         crop_fx = np.array([crop_pad_2d(fx[i], ds_res) for i in range(self.n_images)])
         # take back to real space, discard complex part, and scale
-        out = np.real(fft.centered_ifft2(crop_fx)) * (ds_res**2 / self.resolution**2)
+        out = fft.centered_ifft2(xp.asarray(crop_fx)).real * (
+            ds_res**2 / self.resolution**2
+        )
+        out = xp.asnumpy(out)
 
         return self.__class__(out).stack_reshape(original_stack_shape)
 

--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -361,9 +361,7 @@ class Image:
         # crop 2D Fourier transform for each image
         crop_fx = crop_pad_2d(fx, ds_res)
         # take back to real space, discard complex part, and scale
-        out = fft.centered_ifft2(crop_fx).real * (
-            ds_res**2 / self.resolution**2
-        )
+        out = fft.centered_ifft2(crop_fx).real * (ds_res**2 / self.resolution**2)
         out = xp.asnumpy(out)
 
         return self.__class__(out).stack_reshape(original_stack_shape)

--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -357,11 +357,11 @@ class Image:
         im = self.stack_reshape(-1)
 
         # compute FT with centered 0-frequency
-        fx = xp.asnumpy(fft.centered_fft2(xp.asarray(im._data)))
+        fx = fft.centered_fft2(xp.asarray(im._data))
         # crop 2D Fourier transform for each image
-        crop_fx = np.array([crop_pad_2d(fx[i], ds_res) for i in range(self.n_images)])
+        crop_fx = crop_pad_2d(fx, ds_res)
         # take back to real space, discard complex part, and scale
-        out = fft.centered_ifft2(xp.asarray(crop_fx)).real * (
+        out = fft.centered_ifft2(crop_fx).real * (
             ds_res**2 / self.resolution**2
         )
         out = xp.asnumpy(out)

--- a/src/aspire/numeric/__init__.py
+++ b/src/aspire/numeric/__init__.py
@@ -35,3 +35,22 @@ def fft_object(which):
 
 
 fft = fft_object(config["common"]["fft"].as_str())
+
+
+# Configure `sparse` in tandem with `numeric` as the arrays generally will need to interoperate.
+def sparse_object(which):
+    if which == "cupy":
+        from cupyx.scipy import sparse as SparseClass
+
+        # CuPy imports don't work the same as scipy
+        from cupyx.scipy.sparse.linalg import eigsh
+
+        SparseClass.linalg.eigsh = eigsh
+    elif which == "numpy":
+        from scipy import sparse as SparseClass
+    else:
+        raise RuntimeError(f"Invalid selection for sparse module: {which}")
+    return SparseClass
+
+
+sparse = sparse_object(config["common"]["numeric"].as_str())

--- a/src/aspire/numeric/__init__.py
+++ b/src/aspire/numeric/__init__.py
@@ -36,6 +36,21 @@ def fft_object(which):
 
 fft = fft_object(config["common"]["fft"].as_str())
 
+# Sanity check.
+if (config["common"]["numeric"].as_str() == "cupy") and (
+    config["common"]["fft"].as_str() != "cupy"
+):
+    raise RuntimeError(
+        "Using `cupy` numeric backend without `cupy` fft is unsupported."
+    )
+
+if (config["common"]["fft"].as_str() == "cupy") and (
+    config["common"]["numeric"].as_str() != "cupy"
+):
+    raise RuntimeError(
+        "Using `cupy` fft without `cupy` numeric backend is unsupported."
+    )
+
 
 # Configure `sparse` in tandem with `numeric` as the arrays generally will need to interoperate.
 def sparse_object(which):

--- a/src/aspire/numeric/cupy_fft.py
+++ b/src/aspire/numeric/cupy_fft.py
@@ -33,3 +33,9 @@ class CupyFFT(FFT):
 
     def ifftshift(self, x, axes=None):
         return cp.fft.ifftshift(x, axes=axes)
+
+    def dct(self, *args, **kwargs):
+        return cp.fft.dct(*args, **kwargs)
+
+    def idct(self, *args, **kwargs):
+        return cp.fft.idct(*args, **kwargs)

--- a/src/aspire/numeric/cupy_fft.py
+++ b/src/aspire/numeric/cupy_fft.py
@@ -1,4 +1,5 @@
 import cupy as cp
+import cupyx.scipy.fft as cufft
 
 from aspire.numeric.base_fft import FFT
 
@@ -35,7 +36,7 @@ class CupyFFT(FFT):
         return cp.fft.ifftshift(x, axes=axes)
 
     def dct(self, *args, **kwargs):
-        return cp.fft.dct(*args, **kwargs)
+        return cufft.dct(*args, **kwargs)
 
     def idct(self, *args, **kwargs):
-        return cp.fft.idct(*args, **kwargs)
+        return cufft.idct(*args, **kwargs)

--- a/src/aspire/numeric/numpy.py
+++ b/src/aspire/numeric/numpy.py
@@ -1,8 +1,13 @@
+import cupy as cp
 import numpy as np
 
 
 class Numpy:
-    asnumpy = staticmethod(lambda x: x)
+    @staticmethod
+    def asnumpy(x):
+        if isinstance(x, cp.ndarray):
+            x = x.get()
+        return x
 
     def __getattr__(self, item):
         """

--- a/src/aspire/numeric/pyfftw_fft.py
+++ b/src/aspire/numeric/pyfftw_fft.py
@@ -155,3 +155,9 @@ class PyfftwFFT(FFT):
 
     def ifftshift(self, a, axes=None):
         return scipy_fft.ifftshift(a, axes=axes)
+
+    def dct(self, *args, **kwargs):
+        return scipy_fft.dct(*args, **kwargs)
+
+    def idct(self, *args, **kwargs):
+        return scipy_fft.idct(*args, **kwargs)

--- a/src/aspire/numeric/scipy_fft.py
+++ b/src/aspire/numeric/scipy_fft.py
@@ -33,3 +33,9 @@ class ScipyFFT(FFT):
 
     def ifftshift(self, x, axes=None):
         return sp.fft.ifftshift(x, axes=axes)
+
+    def dct(self, *args, **kwargs):
+        return sp.fft.dct(*args, **kwargs)
+
+    def idct(self, *args, **kwargs):
+        return sp.fft.idct(*args, **kwargs)

--- a/src/aspire/utils/coor_trans.py
+++ b/src/aspire/utils/coor_trans.py
@@ -386,7 +386,7 @@ def crop_pad_2d(im, size, fill_value=0):
     elif size >= max(im_y, im_x):
         # Determine shape
         shape = list(im.shape[:-2])
-        shape.extend([size,size])
+        shape.extend([size, size])
         # ensure that we return in the same dtype as the input
         to_return = xp.full(shape, fill_value, dtype=im.dtype)
         # when padding, start_x and start_y are negative since size is larger

--- a/src/aspire/utils/coor_trans.py
+++ b/src/aspire/utils/coor_trans.py
@@ -8,6 +8,7 @@ import numpy as np
 from numpy.linalg import norm
 from scipy.linalg import svd
 
+from aspire.numeric import xp
 from aspire.utils.random import Random
 from aspire.utils.rotation import Rotation
 
@@ -368,23 +369,26 @@ def rots_to_clmatrix(rots, n_theta):
 
 def crop_pad_2d(im, size, fill_value=0):
     """
-    :param im: A 2-dimensional numpy array
+    :param im: A >=2-dimensional numpy array
     :param size: Integer size of cropped/padded output
-    :return: A numpy array of shape (size, size)
+    :return: A numpy array of shape (..., size, size)
     """
 
-    im_y, im_x = im.shape
+    im_y, im_x = im.shape[-2:]
     # shift terms
     start_x = math.floor(im_x / 2) - math.floor(size / 2)
     start_y = math.floor(im_y / 2) - math.floor(size / 2)
 
     # cropping
     if size <= min(im_y, im_x):
-        return im[start_y : start_y + size, start_x : start_x + size]
+        return im[..., start_y : start_y + size, start_x : start_x + size]
     # padding
     elif size >= max(im_y, im_x):
+        # Determine shape
+        shape = list(im.shape[:-2])
+        shape.extend([size,size])
         # ensure that we return in the same dtype as the input
-        to_return = fill_value * np.ones((size, size), dtype=im.dtype)
+        to_return = xp.full(shape, fill_value, dtype=im.dtype)
         # when padding, start_x and start_y are negative since size is larger
         # than im_x and im_y; the below line calculates where the original image
         # is placed in relation to the (now-larger) box size

--- a/tests/test_numeric_sparse.py
+++ b/tests/test_numeric_sparse.py
@@ -51,4 +51,3 @@ def test_eigsh(backends):
 
     lamb, _ = sparse.linalg.eigsh(A)
     np.testing.assert_allclose(xp.asnumpy(lamb), 1.0)
-    print(lamb)

--- a/tests/test_numeric_sparse.py
+++ b/tests/test_numeric_sparse.py
@@ -47,7 +47,7 @@ def test_eigsh(backends):
     """
     xp, sparse = backends
 
-    A = xp.eye(123)
+    A = xp.eye(1234)
 
     lamb, _ = sparse.linalg.eigsh(A)
     np.testing.assert_allclose(xp.asnumpy(lamb), 1.0)

--- a/tests/test_numeric_sparse.py
+++ b/tests/test_numeric_sparse.py
@@ -1,0 +1,54 @@
+import numpy as np
+import pytest
+
+from aspire.numeric import numeric_object, sparse_object
+
+# If cupy is not available, skip this entire test module
+pytest.importorskip("cupy")
+
+NUMERICS = ["numpy", "cupy"]
+
+
+@pytest.fixture(params=NUMERICS, ids=lambda x: f"{x}", scope="module")
+def backends(request):
+    xp = numeric_object(request.param)
+    sparse = sparse_object(request.param)
+    return xp, sparse
+
+
+def test_csr_matrix(backends):
+    """
+    Create csr_matrix and multiply with an `xp` array.
+    """
+    xp, sparse = backends
+
+    m, n = 10, 10
+    jdx = xp.arange(10)
+    idx = xp.arange(10)
+    vals = xp.random.random(10)
+
+    # Compute dense matmul
+    _A = np.diag(xp.asnumpy(vals))
+    _B = np.random.random((10, 20))
+    _C = _A @ _B
+
+    # Compute matmul using sparse csr
+    A = sparse.csr_matrix((vals, (jdx, idx)), shape=(m, n), dtype=np.float64)
+    B = xp.array(_B)
+    C = A @ B
+
+    # Compare
+    np.testing.assert_allclose(_C, xp.asnumpy(C))
+
+
+def test_eigsh(backends):
+    """
+    Invoke sparse eigsh call with `xp` arrays.
+    """
+    xp, sparse = backends
+
+    A = xp.eye(123)
+
+    lamb, _ = sparse.linalg.eigsh(A)
+    np.testing.assert_allclose(xp.asnumpy(lamb), 1.0)
+    print(lamb)

--- a/tests/test_numeric_sparse.py
+++ b/tests/test_numeric_sparse.py
@@ -23,13 +23,13 @@ def test_csr_matrix(backends):
     xp, sparse = backends
 
     m, n = 10, 10
-    jdx = xp.arange(10)
-    idx = xp.arange(10)
+    jdx = xp.arange(m)
+    idx = xp.arange(n)
     vals = xp.random.random(10)
 
     # Compute dense matmul
     _A = np.diag(xp.asnumpy(vals))
-    _B = np.random.random((10, 20))
+    _B = np.random.random((n, 20))
     _C = _A @ _B
 
     # Compute matmul using sparse csr


### PR DESCRIPTION
This cleans up my portions of the work accomplished and todo items from the first hackathon pass.

- Resolves downsample/crop_pad issue that was found during first day.
- Adds cusparse methods currently used in ASPIRE (with smoke test) via sparse wrapper hooked onto `numeric` config.
- Adds dct and idct methods to fft wrappers. These are switched via the fft backend config.
- Replace sparse and i/dct methods in FLE with those from our numeric module.
- Refactor FLE code towards using xp methods for evaluate_t and evaluate.
- Implements the memory cleanup workaround.