### PR TITLE
Whitening Filter Threshold

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "pyshtools<=4.10.4",  # 4.11.7 might have a packaging bug
     "PyWavelets",
     "ray >= 2.9.2",
-    "scipy >= 1.10.1",
+    "scipy >= 1.10.0",
     "scikit-learn",
     "scikit-image",
     "setuptools >= 0.41",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "pyshtools<=4.10.4",  # 4.11.7 might have a packaging bug
     "PyWavelets",
     "ray >= 2.9.2",
-    "scipy >= 1.10.0",
+    "scipy >= 1.10.1",
     "scikit-learn",
     "scikit-image",
     "setuptools >= 0.41",

--- a/src/aspire/operators/filters.py
+++ b/src/aspire/operators/filters.py
@@ -333,7 +333,7 @@ class ArrayFilter(Filter):
         #  for values slightly outside the interpolation grid bounds.
         interpolator = RegularGridInterpolator(
             _input_pts,
-            self.xfer_fn_array,
+            self.xfer_fn_array.astype(np.float64),
             method="linear",
             bounds_error=False,
             fill_value=None,

--- a/src/aspire/operators/filters.py
+++ b/src/aspire/operators/filters.py
@@ -349,7 +349,8 @@ class ArrayFilter(Filter):
         # Result is 1 x np.prod(self.sz) in shape; convert to a 1-d vector
         result = np.squeeze(result, 0)
 
-        return result
+        # Recast result with correct dtype
+        return result.astype(self.xfer_fn_array.dtype)
 
     def evaluate_grid(self, L, *args, dtype=np.float32, **kwargs):
         """

--- a/src/aspire/operators/filters.py
+++ b/src/aspire/operators/filters.py
@@ -333,8 +333,7 @@ class ArrayFilter(Filter):
         #  for values slightly outside the interpolation grid bounds.
         interpolator = RegularGridInterpolator(
             _input_pts,
-            # https://github.com/scipy/scipy/issues/17718
-            self.xfer_fn_array.astype(np.float64),
+            self.xfer_fn_array,
             method="linear",
             bounds_error=False,
             fill_value=None,
@@ -349,8 +348,8 @@ class ArrayFilter(Filter):
         # Result is 1 x np.prod(self.sz) in shape; convert to a 1-d vector
         result = np.squeeze(result, 0)
 
-        # Recast result with correct dtype
-        return result.astype(self.xfer_fn_array.dtype)
+        # Scipy's interpolator will upcast singles. Recasting.
+        return result.astype(self.xfer_fn_array.dtype, copy=False)
 
     def evaluate_grid(self, L, *args, dtype=np.float32, **kwargs):
         """

--- a/src/aspire/operators/filters.py
+++ b/src/aspire/operators/filters.py
@@ -333,6 +333,7 @@ class ArrayFilter(Filter):
         #  for values slightly outside the interpolation grid bounds.
         interpolator = RegularGridInterpolator(
             _input_pts,
+            # scipy requires upcasting to use cython interpolator.
             self.xfer_fn_array.astype(np.float64),
             method="linear",
             bounds_error=False,

--- a/src/aspire/operators/filters.py
+++ b/src/aspire/operators/filters.py
@@ -333,7 +333,7 @@ class ArrayFilter(Filter):
         #  for values slightly outside the interpolation grid bounds.
         interpolator = RegularGridInterpolator(
             _input_pts,
-            # scipy requires upcasting to use cython interpolator.
+            # https://github.com/scipy/scipy/issues/17718
             self.xfer_fn_array.astype(np.float64),
             method="linear",
             bounds_error=False,
@@ -349,8 +349,7 @@ class ArrayFilter(Filter):
         # Result is 1 x np.prod(self.sz) in shape; convert to a 1-d vector
         result = np.squeeze(result, 0)
 
-        # Scipy's interpolator will upcast singles. Recasting.
-        return result.astype(self.xfer_fn_array.dtype, copy=False)
+        return result
 
     def evaluate_grid(self, L, *args, dtype=np.float32, **kwargs):
         """

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -811,8 +811,8 @@ class ImageSource(ABC):
             queried.  Alternatively, the noise PSD may be passed
             directly as a `Filter` object.
         :param epsilon: Threshold used to determine which frequencies to whiten
-            and which to set to zero. By default all filter values less than
-            100*eps(self.dtype) are zeroed out.
+            and which to set to zero. By default all PSD values in the `noise_estimate`
+            less than eps(self.dtype) are zeroed out in the whitening filter.
         :return: On return, the `ImageSource` object has been modified in place.
         """
 
@@ -830,15 +830,10 @@ class ImageSource(ABC):
                 " instead of `NoiseEstimator` or `Filter`."
             )
 
-        # Set threshold for whiten_filter. All values such that sqrt(noise_filter) < eps
-        # will be set to zero in the whiten_filter.
-        if epsilon is None:
-            epsilon = 100 * np.finfo(self.dtype).eps
-
         logger.info("Whitening source object")
         # epsilon is squared to account for the PowerFilter applying the threshold
         # to noise_filter, not sqrt(noise_filter).
-        whiten_filter = PowerFilter(noise_filter, power=-0.5, epsilon=epsilon**2)
+        whiten_filter = PowerFilter(noise_filter, power=-0.5, epsilon=epsilon)
 
         logger.info("Transforming all CTF Filters into Multiplicative Filters")
         self.unique_filters = [

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -830,6 +830,9 @@ class ImageSource(ABC):
                 " instead of `NoiseEstimator` or `Filter`."
             )
 
+        if epsilon is None:
+            epsilon = np.finfo(self.dtype).eps
+
         logger.info("Whitening source object")
         whiten_filter = PowerFilter(noise_filter, power=-0.5, epsilon=epsilon)
 

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -831,8 +831,6 @@ class ImageSource(ABC):
             )
 
         logger.info("Whitening source object")
-        # epsilon is squared to account for the PowerFilter applying the threshold
-        # to noise_filter, not sqrt(noise_filter).
         whiten_filter = PowerFilter(noise_filter, power=-0.5, epsilon=epsilon)
 
         logger.info("Transforming all CTF Filters into Multiplicative Filters")

--- a/tests/test_FLEbasis2D.py
+++ b/tests/test_FLEbasis2D.py
@@ -142,7 +142,7 @@ def testMatchFBEvaluate(basis):
     fb_images = fb_basis.evaluate(coefs)
     fle_images = basis.evaluate(coefs)
 
-    assert np.allclose(fb_images._data, fle_images._data, atol=1e-4)
+    np.testing.assert_allclose(fb_images._data, fle_images._data, atol=1e-4)
 
 
 @pytest.mark.parametrize("basis", test_bases_match_fb, ids=show_fle_params)
@@ -159,8 +159,8 @@ def testMatchFBDenseEvaluate(basis):
     fle_images = Image(fle_out.T.reshape(-1, basis.nres, basis.nres)).asnumpy()
 
     # Matrix column reording in match_fb mode flips signs of some of the basis functions
-    assert np.allclose(np.abs(fb_images), np.abs(fle_images), atol=1e-3)
-    assert np.allclose(fb_images, fle_images, atol=1e-3)
+    np.testing.assert_allclose(np.abs(fb_images), np.abs(fle_images), atol=1e-3)
+    np.testing.assert_allclose(fb_images, fle_images, atol=1e-3)
 
 
 @pytest.mark.parametrize("basis", test_bases_match_fb, ids=show_fle_params)
@@ -177,7 +177,7 @@ def testMatchFBEvaluate_t(basis):
     fb_coefs = fb_basis.evaluate_t(images)
     fle_coefs = basis.evaluate_t(images)
 
-    assert np.allclose(fb_coefs, fle_coefs, atol=1e-4)
+    np.testing.assert_allclose(fb_coefs, fle_coefs, atol=1e-4)
 
 
 @pytest.mark.parametrize("basis", test_bases_match_fb, ids=show_fle_params)
@@ -197,7 +197,7 @@ def testMatchFBDenseEvaluate_t(basis):
     fle_coefs = basis._create_dense_matrix().T @ vec.T
 
     # Matrix column reording in match_fb mode flips signs of some of the basis coefficients
-    assert np.allclose(np.abs(fb_coefs), np.abs(fle_coefs), atol=1e-4)
+    np.testing.assert_allclose(np.abs(fb_coefs), np.abs(fle_coefs), atol=1e-4)
 
 
 def testLowPass():
@@ -265,4 +265,4 @@ def testRadialConvolution():
             convolution_fft_pad[L // 2 : L // 2 + L, L // 2 : L // 2 + L]
         )
 
-    assert np.allclose(imgs_convolved_fle, imgs_convolved_slow, atol=1e-5)
+    np.testing.assert_allclose(imgs_convolved_fle, imgs_convolved_slow, atol=1e-5)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,4 +1,3 @@
-import itertools
 import logging
 import os.path
 from unittest import TestCase

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -373,7 +373,7 @@ def test_power_filter_safeguard(dtype, epsilon, caplog):
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_array_filter_dtype_passthrough(dtype):
     """
-    scipy's interpolator will upcast singles. This test
+    We upcast to use scipy's fast interpolator. This test
     ensures that we recast to the correct dtype during calculations.
     """
     L = 8

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -373,8 +373,7 @@ def test_power_filter_safeguard(dtype, epsilon, caplog):
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_array_filter_dtype_passthrough(dtype):
     """
-    Do to a bug in scipy versions < 1.10.1, scipy's interpolator crashes
-    in singles. We have a workaround that upcasts to doubles. This test
+    scipy's interpolator will upcast singles. This test
     ensures that we recast to the correct dtype during calculations.
     """
     L = 8

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -377,7 +377,7 @@ def test_array_filter_dtype_passthrough(dtype):
     on exit, so this is an expected fail for singles.
     """
     if dtype == np.float32:
-        pytest.xfail(reason="ArrayFilter currently upcasts singles.", strict=True)
+        pytest.xfail(reason="ArrayFilter currently upcasts singles.")
 
     L = 8
     arr = np.ones((L, L), dtype=dtype)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -373,9 +373,12 @@ def test_power_filter_safeguard(dtype, epsilon, caplog):
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_array_filter_dtype_passthrough(dtype):
     """
-    We upcast to use scipy's fast interpolator. This test
-    ensures that we recast to the correct dtype during calculations.
+    We upcast to use scipy's fast interpolator. We do not recast
+    on exit, so this is an expected fail for singles.
     """
+    if dtype == np.float32:
+        pytest.xfail(reason="ArrayFilter currently upcasts singles.")
+
     L = 8
     arr = np.ones((L, L), dtype=dtype)
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -333,10 +333,20 @@ class SimTestCase(TestCase):
         self.assertTrue(np.allclose(sign_filter.evaluate(self.omega), signs))
 
 
-params = list(itertools.product([np.float32, np.float64], [None, 0.01]))
+DTYPES = [np.float32, np.float64]
+EPS = [None, 0.01]
 
 
-@pytest.mark.parametrize("dtype, epsilon", params)
+@pytest.fixture(params=DTYPES, ids=lambda x: f"dtype={x}", scope="module")
+def dtype(request):
+    return request.param
+
+
+@pytest.fixture(params=EPS, ids=lambda x: f"epsilon={x}", scope="module")
+def epsilon(request):
+    return request.param
+
+
 def test_power_filter_safeguard(dtype, epsilon, caplog):
     L = 25
     arr = np.ones((L, L), dtype=dtype)
@@ -370,7 +380,6 @@ def test_power_filter_safeguard(dtype, epsilon, caplog):
     assert msg in caplog.text
 
 
-@pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_array_filter_dtype_passthrough(dtype):
     """
     We upcast to use scipy's fast interpolator. We do not recast

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -361,3 +361,19 @@ def test_power_filter_safeguard(dtype, caplog):
     # Check caplog for warning.
     msg = f"setting {num_eps} extremal filter value(s) to zero."
     assert msg in caplog.text
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_array_filter_dtype_passthrough(dtype):
+    """
+    Do to a bug in scipy versions < 1.10.1, scipy's interpolator crashes
+    in singles. We have a workaround that upcasts to doubles. This test
+    ensures that we recast to the correct dtype during calculations.
+    """
+    L = 8
+    arr = np.ones((L, L), dtype=dtype)
+
+    filt = ArrayFilter(arr)
+    filt_vals = filt.evaluate_grid(L, dtype=dtype)
+
+    assert filt_vals.dtype == dtype

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -377,7 +377,7 @@ def test_array_filter_dtype_passthrough(dtype):
     on exit, so this is an expected fail for singles.
     """
     if dtype == np.float32:
-        pytest.xfail(reason="ArrayFilter currently upcasts singles.")
+        pytest.xfail(reason="ArrayFilter currently upcasts singles.", strict=True)
 
     L = 8
     arr = np.ones((L, L), dtype=dtype)

--- a/tests/test_preprocess_pipeline.py
+++ b/tests/test_preprocess_pipeline.py
@@ -126,6 +126,15 @@ def testWhiten2(dtype):
     assert np.allclose(np.eye(2), corr_coef, atol=2e-1)
 
 
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_whiten_epsilon(dtype):
+    """Smoke test for epsilon argument"""
+    L = 25
+    sim = get_sim_object(L, dtype)
+    noise_estimator = AnisotropicNoiseEstimator(sim)
+    _ = sim.whiten(noise_estimator.filter, epsilon=0.01)
+
+
 @pytest.mark.parametrize("L, dtype", params)
 def testInvertContrast(L, dtype):
     sim1 = get_sim_object(L, dtype)

--- a/tests/test_preprocess_pipeline.py
+++ b/tests/test_preprocess_pipeline.py
@@ -101,7 +101,7 @@ def testWhiten(dtype):
     corr_coef = np.corrcoef(imgs_wt[:, L - 1, L - 1], imgs_wt[:, L - 2, L - 1])
 
     # correlation matrix should be close to identity
-    assert np.allclose(np.eye(2), corr_coef, atol=1e-1)
+    np.testing.assert_allclose(np.eye(2), corr_coef, atol=1e-1)
     # dtype of returned images should be the same
     assert dtype == imgs_wt.dtype
 
@@ -123,7 +123,7 @@ def testWhiten2(dtype):
     corr_coef = np.corrcoef(imgs_wt[:, L - 1, L - 1], imgs_wt[:, L - 2, L - 1])
 
     # Correlation matrix should be close to identity
-    assert np.allclose(np.eye(2), corr_coef, atol=2e-1)
+    np.testing.assert_allclose(np.eye(2), corr_coef, atol=2e-1)
 
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
@@ -167,7 +167,9 @@ def testInvertContrast(L, dtype):
     imgs2_rc = sim2.images[:num_images]
 
     # all images should be the same after inverting contrast
-    assert np.allclose(imgs1_rc.asnumpy(), imgs2_rc.asnumpy())
+    np.testing.assert_allclose(
+        imgs1_rc.asnumpy(), imgs2_rc.asnumpy(), rtol=1e-05, atol=1e-08
+    )
     # dtype of returned images should be the same
     assert dtype == imgs1_rc.dtype
     assert dtype == imgs2_rc.dtype


### PR DESCRIPTION
The current implementation of `whiten` uses a slightly different threshold for zeroing out filter values when dividing by small numbers.

This PR implements makes this value configurable with the same default threshold as matlab, namely sqrt(psd) < 100 * eps(src.dtype).