### PR TITLE
FFB2D fix anufft warning

### DIFF
--- a/src/aspire/basis/ffb_2d.py
+++ b/src/aspire/basis/ffb_2d.py
@@ -167,7 +167,9 @@ class FFBBasis2D(FBBasis2D):
         # perform inverse non-uniformly FFT transform back to 2D coordinate basis
         freqs = m_reshape(self._precomp["freqs"], (2, n_r * n_theta))
 
-        x = 2 * anufft(pf, 2 * pi * freqs, self.sz, real=True)
+        x = 2 * anufft(
+            pf.astype(complex_type(self.dtype)), 2 * pi * freqs, self.sz, real=True
+        )
 
         # Return X as Image instance with the last two dimensions as *self.sz
         x = x.reshape((*sz_roll, *self.sz))


### PR DESCRIPTION
Removes the cufinufft warning:

`UserWarning: Argument ``data`` does not satisfy the following requirement: C. Copying array (this may reduce performance)`