### PR TITLE
ClassAvgSource SymmetryGroup Pass-through

### DIFF
--- a/src/aspire/denoising/class_avg.py
+++ b/src/aspire/denoising/class_avg.py
@@ -76,6 +76,7 @@ class ClassAvgSource(ImageSource):
             L=self.averager.src.L,
             n=self.averager.src.n,
             dtype=self.averager.src.dtype,
+            symmetry_group=self.src.symmetry_group,
         )
 
         # Any further operations should not mutate this instance.

--- a/tests/test_class_src.py
+++ b/tests/test_class_src.py
@@ -128,7 +128,14 @@ def class_sim_fixture(dtype, img_size):
     # Note using a single volume via C=1 is critical to matching
     # alignment without the complexity of remapping via states etc.
     src = Simulation(
-        L=img_size, n=n, vols=v, offsets=0, amplitudes=1, C=1, angles=true_rots.angles
+        L=img_size,
+        n=n,
+        vols=v,
+        offsets=0,
+        amplitudes=1,
+        C=1,
+        angles=true_rots.angles,
+        symmetry_group="C4",  # For testing symmetry_group pass-through.
     )
     # Prefetch all the images
     src = src.cache()
@@ -192,6 +199,9 @@ def test_basic_averaging(class_sim_fixture, test_src_cls, basis, classifier):
     # Check we match class indices between automatic and manual slice.
     k = len(src2.class_indices)
     np.testing.assert_equal(src2.class_indices, test_src.class_indices[::3][:k])
+
+    # Check symmetry_group pass-through.
+    assert test_src.symmetry_group == class_sim_fixture.symmetry_group
 
 
 # Test the _HeapItem helper class

--- a/tests/test_indexed_source.py
+++ b/tests/test_indexed_source.py
@@ -13,7 +13,7 @@ def sim_fixture():
     """
     Generate a very small simulation and slice it.
     """
-    sim = Simulation(L=8, n=10, C=1)
+    sim = Simulation(L=8, n=10, C=1, symmetry_group="D3")
     sim2 = sim[0::2]  # Slice the evens
     return sim, sim2
 
@@ -30,6 +30,9 @@ def test_remapping(sim_fixture):
 
     # Check meta is served correctly.
     assert np.all(sim.get_metadata(indices=sim2.index_map) == sim2.get_metadata())
+
+    # Check symmetry_group pass-through.
+    assert sim.symmetry_group == sim2.symmetry_group
 
 
 def test_repr(sim_fixture):


### PR DESCRIPTION
Looks like we were missing the `symmetry_group` pass-through for `ClassAvgSource`'s. Added the pass-through with a test to merge into #1149, so we're actually taking advantage of boosting in the C4 experimental reconstruction.