### PR TITLE
Pixel Size Attributes

### DIFF
--- a/gallery/tutorials/aspire_introduction.py
+++ b/gallery/tutorials/aspire_introduction.py
@@ -571,7 +571,7 @@ defocus_ct = 7
 
 # Generate several CTFs.
 ctf_filters = [
-    RadialCTFFilter(pixel_size=5, defocus=d)
+    RadialCTFFilter(pixel_size=vol_ds.pixel_size, defocus=d)
     for d in np.linspace(defocus_min, defocus_max, defocus_ct)
 ]
 

--- a/gallery/tutorials/pipeline_demo.py
+++ b/gallery/tutorials/pipeline_demo.py
@@ -63,7 +63,7 @@ defocus_max = 25000
 defocus_ct = 7
 
 ctf_filters = [
-    RadialCTFFilter(pixel_size=5, defocus=d)
+    RadialCTFFilter(pixel_size=vol.pixel_size, defocus=d)
     for d in np.linspace(defocus_min, defocus_max, defocus_ct)
 ]
 

--- a/gallery/tutorials/tutorials/cov3d_simulation.py
+++ b/gallery/tutorials/tutorials/cov3d_simulation.py
@@ -47,7 +47,9 @@ sim = Simulation(
     L=img_size,
     n=num_imgs,
     vols=vols,
-    unique_filters=[RadialCTFFilter(defocus=d) for d in np.linspace(1.5e4, 2.5e4, 7)],
+    unique_filters=[
+        RadialCTFFilter(pixel_size=10, defocus=d) for d in np.linspace(1.5e4, 2.5e4, 7)
+    ],
     dtype=dtype,
 )
 

--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -130,10 +130,10 @@ def load_tiff(filepath):
 
     # Future todo, extract `voxel_size` if available in TIFF tags (custom tag?)
     # For now, default to `None`.
-    voxel_size = None
+    pixel_size = None
 
     # Cast image data as numpy array
-    return np.array(img), voxel_size
+    return np.array(img), pixel_size
 
 
 class Image:
@@ -160,7 +160,7 @@ class Image:
 
         :param data: Numpy array containing image data with shape
             `(..., resolution, resolution)`.
-        :param pixel_size: Optional pixel size in Angstroms.
+        :param pixel_size: Optional pixel size in angstroms.
             When provided will be saved with `mrc` metadata.
             Default of `None` will not write to file,
             but will be considered unit pixels (1) for FSC.

--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -361,8 +361,12 @@ class Image:
         return self.__class__(np.flip(self._data, axis), pixel_size=self.pixel_size)
 
     def __repr__(self):
+        px_msg = "."
+        if self.pixel_size is not None:
+            px_msg = f" with pixel_size={self.pixel_size} angstroms."
+
         msg = f"{self.n_images} {self.dtype} images arranged as a {self.stack_shape} stack"
-        msg += f" each of size {self.resolution}x{self.resolution}."
+        msg += f" each of size {self.resolution}x{self.resolution}{px_msg}"
         return msg
 
     def asnumpy(self):

--- a/src/aspire/operators/filters.py
+++ b/src/aspire/operators/filters.py
@@ -403,7 +403,7 @@ class IdentityFilter(ScalarFilter):
 class CTFFilter(Filter):
     def __init__(
         self,
-        pixel_size=10,
+        pixel_size=1,
         voltage=200,
         defocus_u=15000,
         defocus_v=15000,
@@ -415,7 +415,7 @@ class CTFFilter(Filter):
         """
         A CTF (Contrast Transfer Function) Filter
 
-        :param pixel_size:  Pixel size in angstrom
+        :param pixel_size:  Pixel size in angstrom, default 1.
         :param voltage:     Electron voltage in kV
         :param defocus_u:   Defocus depth along the u-axis in angstrom
         :param defocus_v:   Defocus depth along the v-axis in angstrom
@@ -425,7 +425,7 @@ class CTFFilter(Filter):
         :param B:           Envelope decay in inverse square angstrom (default 0)
         """
         super().__init__(dim=2, radial=defocus_u == defocus_v)
-        self.pixel_size = pixel_size
+        self.pixel_size = float(pixel_size)
         self.voltage = voltage
         self.wavelength = voltage_to_wavelength(self.voltage)
         self.defocus_u = defocus_u
@@ -482,7 +482,7 @@ class CTFFilter(Filter):
 
 class RadialCTFFilter(CTFFilter):
     def __init__(
-        self, pixel_size=10, voltage=200, defocus=15000, Cs=2.26, alpha=0.07, B=0
+        self, pixel_size=1, voltage=200, defocus=15000, Cs=2.26, alpha=0.07, B=0
     ):
         super().__init__(
             pixel_size=pixel_size,

--- a/src/aspire/source/coordinates.py
+++ b/src/aspire/source/coordinates.py
@@ -490,7 +490,9 @@ class CoordinateSource(ImageSource, ABC):
                     cropped = self._crop_micrograph(arr, next(coord))
                     im[i] = cropped
         # Finally, apply transforms to resulting Image
-        return self.generation_pipeline.forward(Image(im), indices)
+        return self.generation_pipeline.forward(
+            Image(im, pixel_size=self.pixel_size), indices
+        )
 
     @staticmethod
     def _is_number(text):

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -170,7 +170,7 @@ class ImageSource(ABC):
             The path of the base directory to use as a data store or None. If None is given, no caching is performed.
         :param symmetry_group: A SymmetryGroup instance or string indicating the underlying symmetry of the molecule.
             Defaults to the `IdentitySymmetryGroup`, which represents an asymmetric particle, if none provided.
-        :param pixel_size: Pixel size of the images in Angstroms, default `None`.
+        :param pixel_size: Pixel size of the images in angstroms, default `None`.
         """
 
         # Instantiate the accessor for the `images` property
@@ -1673,6 +1673,7 @@ class ArrayImageSource(ImageSource):
         :param metadata: A Dataframe of metadata information corresponding to this ImageSource's images
         :param angles: Optional n-by-3 array of rotation angles corresponding to `im`.
         :param symmetry_group: A SymmetryGroup instance or string indicating the underlying symmetry of the molecule.
+        :param pixel_size: Pixel size of the images in angstroms, default `None`.
         """
 
         if not isinstance(im, Image):

--- a/src/aspire/source/micrograph.py
+++ b/src/aspire/source/micrograph.py
@@ -196,7 +196,7 @@ class DiskMicrographSource(MicrographSource):
         # Size will be checked during on-the-fly loading of subsequent micrographs.
         micrograph0 = Image.load(self.micrograph_files[0])
         if micrograph0.pixel_size is not None and micrograph0.pixel_size != pixel_size:
-            raise NotImplementedError(
+            raise ValueError(
                 f"Mismatched pixel size. {micrograph0.pixel_size} angstroms defined in {self.micrograph_files[0]}, but provided {pixel_size} angstroms."
             )
 
@@ -277,7 +277,7 @@ class DiskMicrographSource(MicrographSource):
                 micrograph.pixel_size is not None
                 and micrograph.pixel_size != self.pixel_size
             ):
-                raise NotImplementedError(
+                raise ValueError(
                     f"Mismatched pixel size. {micrograph.pixel_size} angstroms defined in {self.micrograph_files[ind]}, but provided {self.pixel_size} angstroms."
                 )
 

--- a/src/aspire/source/micrograph.py
+++ b/src/aspire/source/micrograph.py
@@ -122,6 +122,7 @@ class ArrayMicrographSource(MicrographSource):
             Currently only `float32` and `float64` are supported.
             Note, due to limitations of common MRC implementations,
             saving is limited to single precision.
+        :param pixel_size: Pixel size of the images in angstroms, default `None`.
         """
 
         # Check micrographs is an array

--- a/src/aspire/source/micrograph.py
+++ b/src/aspire/source/micrograph.py
@@ -274,10 +274,10 @@ class DiskMicrographSource(MicrographSource):
             # Assert pixel_size
             if (
                 micrograph.pixel_size is not None
-                and micrograph.pixel_size != pixel_size
+                and micrograph.pixel_size != self.pixel_size
             ):
                 raise NotImplementedError(
-                    f"Mismatched pixel size. {micrograph.pixel_size} defined in {self.micrograph_files[ind]}, but provided {pixel_size}."
+                    f"Mismatched pixel size. {micrograph.pixel_size} defined in {self.micrograph_files[ind]}, but provided {self.pixel_size}."
                 )
 
         return Image(micrographs, pixel_size=self.pixel_size)

--- a/src/aspire/source/micrograph.py
+++ b/src/aspire/source/micrograph.py
@@ -197,7 +197,7 @@ class DiskMicrographSource(MicrographSource):
         micrograph0 = Image.load(self.micrograph_files[0])
         if micrograph0.pixel_size is not None and micrograph0.pixel_size != pixel_size:
             raise NotImplementedError(
-                f"Mismatched pixel size. {micrograph0.pixel_size} defined in {self.micrograph_files[0]}, but provided {pixel_size}."
+                f"Mismatched pixel size. {micrograph0.pixel_size} angstroms defined in {self.micrograph_files[0]}, but provided {pixel_size} angstroms."
             )
 
         super().__init__(
@@ -278,7 +278,7 @@ class DiskMicrographSource(MicrographSource):
                 and micrograph.pixel_size != self.pixel_size
             ):
                 raise NotImplementedError(
-                    f"Mismatched pixel size. {micrograph.pixel_size} defined in {self.micrograph_files[ind]}, but provided {self.pixel_size}."
+                    f"Mismatched pixel size. {micrograph.pixel_size} angstroms defined in {self.micrograph_files[ind]}, but provided {self.pixel_size} angstroms."
                 )
 
         return Image(micrographs, pixel_size=self.pixel_size)

--- a/src/aspire/source/relion.py
+++ b/src/aspire/source/relion.py
@@ -59,7 +59,6 @@ class RelionSource(ImageSource):
 
         self.filepath = filepath
         self.data_folder = data_folder
-        self.pixel_size = pixel_size
         self.B = B
         self.n_workers = n_workers
         self.max_rows = max_rows
@@ -112,6 +111,7 @@ class RelionSource(ImageSource):
             metadata=metadata,
             symmetry_group=symmetry_group,
             memory=memory,
+            pixel_size=pixel_size,
         )
 
         # CTF estimation parameters coming from Relion
@@ -272,4 +272,6 @@ class RelionSource(ImageSource):
         logger.debug(f"Loading {len(indices)} images complete")
 
         # Finally, apply transforms to resulting Image
-        return self.generation_pipeline.forward(Image(im), indices)
+        return self.generation_pipeline.forward(
+            Image(im, pixel_size=self.pixel_size), indices
+        )

--- a/src/aspire/source/simulation.py
+++ b/src/aspire/source/simulation.py
@@ -255,7 +255,7 @@ class Simulation(ImageSource):
                 f_pixel_size, self.pixel_size
             ):
                 raise ValueError(
-                    f"`Simulation.pixel_size` {self.pixel_size} does not match filter {f} {f_pixel_size}."
+                    f"`Simulation.pixel_size` {self.pixel_size} does not match filter {f} pixel size {f_pixel_size}."
                     "Ensure provided `pixel_size` attributes match."
                 )
 

--- a/src/aspire/source/simulation.py
+++ b/src/aspire/source/simulation.py
@@ -80,7 +80,7 @@ class Simulation(ImageSource):
         :param noise_adder: Optionally append instance of `NoiseAdder`
             to generation pipeline.
         :param symmetry_group: A SymmetryGroup instance or string indicating symmetry of the molecule.
-        :param pixel_size: Pixel size of the images in Angstroms, default `None`.
+        :param pixel_size: Pixel size of the images in angstroms, default `None`.
 
         :return: A Simulation object.
         """

--- a/src/aspire/source/simulation.py
+++ b/src/aspire/source/simulation.py
@@ -260,7 +260,7 @@ class Simulation(ImageSource):
             im_k = self.vols[k - 1].project(rot_matrices=rot)
             im[idx_k, :, :] = im_k.asnumpy()
 
-        return Image(im)
+        return Image(im, pixel_size=self.pixel_size)
 
     @property
     def clean_images(self):

--- a/src/aspire/volume/volume.py
+++ b/src/aspire/volume/volume.py
@@ -420,7 +420,7 @@ class Volume:
 
         im_f = fft.centered_ifft2(im_f)
         # todo add pixel_size to Image
-        return aspire.image.Image(xp.asnumpy(im_f.real))
+        return aspire.image.Image(xp.asnumpy(im_f.real), pixel_size=self.pixel_size)
 
     def to_vec(self):
         """Returns an N x resolution ** 3 array."""
@@ -756,7 +756,8 @@ class Volume:
     @staticmethod
     def _vx_array_to_size(vx):
         """
-        Utility to convert from several possible `mrcfile.voxel_size` representations to a single (float) value or None.
+        Utility to convert from several possible `mrcfile.voxel_size`
+        representations to a single (float) value or None.
         """
 
         # Convert from recarray to single values,

--- a/src/aspire/volume/volume.py
+++ b/src/aspire/volume/volume.py
@@ -645,9 +645,10 @@ class Volume:
             )
 
         with mrcfile.new(filename, overwrite=overwrite) as mrc:
-            if self.pixel_size is not None:
-                mrc.voxel_size(self.pixel_size)
             mrc.set_data(self._data.astype(np.float32))
+            # Note assigning voxel_size must come after `set_data`
+            if self.pixel_size is not None:
+                mrc.voxel_size = self.pixel_size
 
         if self.dtype != np.float32:
             logger.info(f"Volume with dtype {self.dtype} saved with dtype float32")
@@ -757,6 +758,7 @@ class Volume:
         """
         Utility to convert from several possible `mrcfile.voxel_size` representations to a single (float) value or None.
         """
+
         # Convert from recarray to single values,
         #   checks uniformity.
         if isinstance(vx, np.recarray):
@@ -765,7 +767,9 @@ class Volume:
             vx = vx.x
 
         # Convert `0` to `None`
-        if (isinstance(vx, int) or isinstance(vx, float)) and vx == 0:
+        if (
+            isinstance(vx, int) or isinstance(vx, float) or isinstance(vx, np.ndarray)
+        ) and vx == 0:
             vx = None
 
         # Consistently return a `float` when not None

--- a/src/aspire/volume/volume.py
+++ b/src/aspire/volume/volume.py
@@ -76,7 +76,7 @@ class Volume:
             `(..., resolution, resolution, resolution)`.
         :param dtype: Optionally cast `data` to this dtype.
             Defaults to `data.dtype`.
-        :param pixel_size: Optional voxel_size in Angstroms.
+        :param pixel_size: Optional voxel_size in angstroms.
             When provided will be saved with `map`/`mrc` metadata.
             Default of `None` will not write to file,
             but will be considered unit pixels (1) for FSC.
@@ -262,7 +262,7 @@ class Volume:
     def __repr__(self):
         px_msg = "."
         if self.pixel_size is not None:
-            px_msg = f" with pixel_size={self.pixel_size} Angstroms."
+            px_msg = f" with pixel_size={self.pixel_size} angstroms."
 
         msg = (
             f"{self.n_vols} {self.dtype} volumes arranged as a {self.stack_shape} stack"
@@ -423,7 +423,6 @@ class Volume:
             im_f[:, :, 0] = 0
 
         im_f = fft.centered_ifft2(im_f)
-        # todo add pixel_size to Image
         return aspire.image.Image(xp.asnumpy(im_f.real), pixel_size=self.pixel_size)
 
     def to_vec(self):

--- a/src/aspire/volume/volume.py
+++ b/src/aspire/volume/volume.py
@@ -625,6 +625,12 @@ class Volume:
         """
         with mrcfile.open(filename, permissive=permissive) as mrc:
             loaded_data = mrc.data
+            pixel_size = mrc.voxel_size
+
+        # Handle default pixel_size.
+        # `mrcfile` defaults to zero, where we use `None`.
+        if pixel_size == 0:
+            pixel_size = None
 
         # FINUFFT work around
         if loaded_data.dtype == np.float32:
@@ -635,7 +641,12 @@ class Volume:
         if loaded_data.dtype != dtype:
             logger.info(f"{filename} with dtype {loaded_data.dtype} loaded as {dtype}")
 
-        return cls(loaded_data, symmetry_group=symmetry_group, dtype=dtype)
+        return cls(
+            loaded_data,
+            pixel_size=pixel_size,
+            symmetry_group=symmetry_group,
+            dtype=dtype,
+        )
 
     def fsc(self, other, cutoff=None, method="fft", plot=False):
         r"""

--- a/src/aspire/volume/volume.py
+++ b/src/aspire/volume/volume.py
@@ -553,7 +553,9 @@ class Volume:
 
         # returns a new Volume object
         return self.__class__(
-            xp.asnumpy(out), pixel_size=ds_pixel_size, symmetry_group=self.symmetry_group
+            xp.asnumpy(out),
+            pixel_size=ds_pixel_size,
+            symmetry_group=self.symmetry_group,
         ).stack_reshape(original_stack_shape)
 
     def shift(self):

--- a/src/aspire/volume/volume.py
+++ b/src/aspire/volume/volume.py
@@ -260,10 +260,14 @@ class Volume:
         )
 
     def __repr__(self):
+        px_msg = "."
+        if self.pixel_size is not None:
+            px_msg = f" with pixel_size={self.pixel_size} Angstroms."
+
         msg = (
             f"{self.n_vols} {self.dtype} volumes arranged as a {self.stack_shape} stack"
         )
-        msg += f" each of size {self.resolution}x{self.resolution}x{self.resolution}."
+        msg += f" each of size {self.resolution}x{self.resolution}x{self.resolution}{px_msg}"
         return msg
 
     def __len__(self):

--- a/src/aspire/volume/volume_synthesis.py
+++ b/src/aspire/volume/volume_synthesis.py
@@ -48,7 +48,10 @@ class GaussianBlobsVolume(SyntheticVolumeBase):
         :param C: Number of Volumes to generate.
         :param K: Number of Gaussian blobs used to construct the Volume(s).
         :param alpha: Scaling factor for variance of Gaussian blobs. Default=1.
-        :param pixel_size: Optional voxel_size in angstroms. Default=1.
+        :param pixel_size: Optional voxel_size in angstroms.
+            When provided will be saved with `map`/`mrc` metadata.
+            Default of `None` will not write to file,
+            but will be considered unit pixels (1) for FSC.
         :param seed: Random seed for generating random Gaussian blobs.
         :param dtype: dtype for Volume(s)
         """
@@ -184,7 +187,10 @@ class CnSymmetricVolume(GaussianBlobsVolume):
         :param C: Number of Volumes to generate.
         :param order: An integer representing the cyclic order of the Volume(s).
         :param K: Number of Gaussian blobs used to construct the Volume(s).
-        :param pixel_size: Optional voxel_size in angstroms. Default=1.
+        :param pixel_size: Optional voxel_size in angstroms.
+            When provided will be saved with `map`/`mrc` metadata.
+            Default of `None` will not write to file,
+            but will be considered unit pixels (1) for FSC.
         :param seed: Random seed for generating random Gaussian blobs.
         :param dtype: dtype for Volume(s)
         """

--- a/src/aspire/volume/volume_synthesis.py
+++ b/src/aspire/volume/volume_synthesis.py
@@ -48,7 +48,7 @@ class GaussianBlobsVolume(SyntheticVolumeBase):
         :param C: Number of Volumes to generate.
         :param K: Number of Gaussian blobs used to construct the Volume(s).
         :param alpha: Scaling factor for variance of Gaussian blobs. Default=1.
-        :param pixel_size: Optional voxel_size in Angstroms. Default=1.
+        :param pixel_size: Optional voxel_size in angstroms. Default=1.
         :param seed: Random seed for generating random Gaussian blobs.
         :param dtype: dtype for Volume(s)
         """
@@ -184,7 +184,7 @@ class CnSymmetricVolume(GaussianBlobsVolume):
         :param C: Number of Volumes to generate.
         :param order: An integer representing the cyclic order of the Volume(s).
         :param K: Number of Gaussian blobs used to construct the Volume(s).
-        :param pixel_size: Optional voxel_size in Angstroms. Default=1.
+        :param pixel_size: Optional voxel_size in angstroms. Default=1.
         :param seed: Random seed for generating random Gaussian blobs.
         :param dtype: dtype for Volume(s)
         """

--- a/tests/test_anisotropic_noise.py
+++ b/tests/test_anisotropic_noise.py
@@ -20,7 +20,9 @@ class SimTestCase(TestCase):
             n=1024,
             vols=self.vol,
             unique_filters=[
-                RadialCTFFilter(defocus=d) for d in np.linspace(1.5e4, 2.5e4, 7)
+                # Set legacy pixel size
+                RadialCTFFilter(pixel_size=10, defocus=d)
+                for d in np.linspace(1.5e4, 2.5e4, 7)
             ],
             dtype=self.dtype,
         )

--- a/tests/test_downsample.py
+++ b/tests/test_downsample.py
@@ -162,6 +162,7 @@ def test_downsample_project(volume, res_ds):
         tol = 1e-09
     np.testing.assert_allclose(im_ds_proj, im_proj_ds, atol=tol)
 
+
 def test_pixel_size():
     """
     Test downsampling is rescaling the `pixel_size` attribute.
@@ -182,4 +183,3 @@ def test_pixel_size():
         img.pixel_size * L / dsL,
         err_msg="Incorrect pixel size.",
     )
-

--- a/tests/test_downsample.py
+++ b/tests/test_downsample.py
@@ -90,6 +90,9 @@ def test_downsample_2d_case(L, L_ds):
     assert (N, L_ds, L_ds) == imgs_ds.shape
     # check center points for all images
     assert checkCenterPoint(imgs_org, imgs_ds)
+    # Confirm default `pixel_size`
+    assert imgs_org.pixel_size is None
+    assert imgs_ds.pixel_size is None
 
 
 @pytest.mark.parametrize("L", [65, 66])
@@ -103,6 +106,9 @@ def test_downsample_3d_case(L, L_ds):
     assert checkCenterPoint(vols_org, vols_ds)
     # check signal energy is conserved
     assert checkSignalEnergy(vols_org, vols_ds)
+    # Confirm default `pixel_size`
+    assert vols_org.pixel_size is None
+    assert vols_ds.pixel_size is None
 
 
 def test_integer_offsets():
@@ -155,3 +161,25 @@ def test_downsample_project(volume, res_ds):
     if volume.dtype == np.float64:
         tol = 1e-09
     np.testing.assert_allclose(im_ds_proj, im_proj_ds, atol=tol)
+
+def test_pixel_size():
+    """
+    Test downsampling is rescaling the `pixel_size` attribute.
+    """
+    # Image sizes in pixels
+    L = 8  # original
+    dsL = 5  # downsampled
+
+    # Construct a small test Image
+    img = Image(np.random.random((1, L, L)).astype(DTYPE, copy=False), pixel_size=1.23)
+
+    # Downsample the image
+    result = img.downsample(dsL)
+
+    # Confirm the pixel size is scaled
+    np.testing.assert_approx_equal(
+        result.pixel_size,
+        img.pixel_size * L / dsL,
+        err_msg="Incorrect pixel size.",
+    )
+

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -118,7 +118,8 @@ class SimTestCase(TestCase):
         self.assertEqual(result.shape, (256,))
 
     def testRadialCTFFilterGrid(self):
-        filter = RadialCTFFilter(defocus=2.5e4)
+        # Set legacy pixel size
+        filter = RadialCTFFilter(pixel_size=10, defocus=2.5e4)
         result = filter.evaluate_grid(8, dtype=self.dtype)
 
         self.assertEqual(result.shape, (8, 8))
@@ -218,7 +219,10 @@ class SimTestCase(TestCase):
         )
 
     def testRadialCTFFilterMultiplierGrid(self):
-        filter = RadialCTFFilter(defocus=2.5e4) * RadialCTFFilter(defocus=2.5e4)
+        # Set legacy pixel size
+        filter = RadialCTFFilter(pixel_size=10, defocus=2.5e4) * RadialCTFFilter(
+            pixel_size=10, defocus=2.5e4
+        )
         result = filter.evaluate_grid(8, dtype=self.dtype)
 
         self.assertEqual(result.shape, (8, 8))

--- a/tests/test_fourier_correlation.py
+++ b/tests/test_fourier_correlation.py
@@ -178,7 +178,7 @@ def test_frc_plot(image_fixture, method):
 def test_fsc_id(volume_fixture, method):
     vol, _ = volume_fixture
 
-    fsc_resolution, fsc = vol.fsc(vol, pixel_size=1, cutoff=0.143, method=method)
+    fsc_resolution, fsc = vol.fsc(vol, cutoff=0.143, method=method)
     assert np.isclose(fsc_resolution[0], 2, rtol=0.02)
     assert np.allclose(fsc, 1, rtol=0.01)
 
@@ -186,11 +186,11 @@ def test_fsc_id(volume_fixture, method):
 def test_fsc_trunc(volume_fixture, method):
     vol_a, vol_b = volume_fixture
 
-    fsc_resolution, fsc = vol_a.fsc(vol_b, pixel_size=1, cutoff=0.143, method=method)
+    fsc_resolution, fsc = vol_a.fsc(vol_b, cutoff=0.143, method=method)
     assert fsc_resolution[0] > 3.0
 
     # The follow should correspond to the test_fsc_plot below.
-    fsc_resolution, fsc = vol_a.fsc(vol_b, pixel_size=1, cutoff=0.5, method=method)
+    fsc_resolution, fsc = vol_a.fsc(vol_b, cutoff=0.5, method=method)
     assert fsc_resolution[0] > 3.9
 
 
@@ -202,13 +202,13 @@ def test_fsc_vol_plot(volume_fixture):
 
     # Plot to screen
     with matplotlib_no_gui():
-        _ = vol_a.fsc(vol_b, pixel_size=1, cutoff=0.5, plot=True)
+        _ = vol_a.fsc(vol_b, cutoff=0.5, plot=True)
 
     # Plot to file
     # Also tests `cutoff=None`
     with tempfile.TemporaryDirectory() as tmp_input_dir:
         file_path = os.path.join(tmp_input_dir, "vol_fsc_curve.png")
-        vol_a.fsc(vol_b, pixel_size=1, cutoff=None, plot=file_path)
+        vol_a.fsc(vol_b, cutoff=None, plot=file_path)
         assert os.path.exists(file_path)
 
 
@@ -218,9 +218,7 @@ def test_fsc_plot(volume_fixture, method):
     """
     vol_a, vol_b = volume_fixture
 
-    fsc = FourierShellCorrelation(
-        vol_a.asnumpy(), vol_b.asnumpy(), pixel_size=1, method=method
-    )
+    fsc = FourierShellCorrelation(vol_a.asnumpy(), vol_b.asnumpy(), method=method)
 
     with matplotlib_no_gui():
         fsc.plot(cutoff=0.5)
@@ -314,7 +312,7 @@ def test_vol_type_mismatch():
     b = a.asnumpy()
 
     with pytest.raises(TypeError, match=r"`other` volume must be an `Volume` instance"):
-        _ = a.fsc(b, pixel_size=1, cutoff=0.143)
+        _ = a.fsc(b, cutoff=0.143)
 
 
 # Broadcasting
@@ -378,7 +376,7 @@ def test_fsc_id_bcast(volume_fixture, method):
     k = 3
     vol_b = Volume(np.tile(vol.asnumpy(), (3, 1, 1, 1)))
 
-    fsc_resolution, fsc = vol.fsc(vol_b, pixel_size=1, cutoff=0.143, method=method)
+    fsc_resolution, fsc = vol.fsc(vol_b, cutoff=0.143, method=method)
     assert np.allclose(
         fsc_resolution,
         [

--- a/tests/test_fourier_correlation.py
+++ b/tests/test_fourier_correlation.py
@@ -115,7 +115,7 @@ def volume_fixture(img_size, dtype):
 def test_frc_id(image_fixture, method):
     img, _, _ = image_fixture
 
-    frc_resolution, frc = img.frc(img, pixel_size=1, cutoff=0.143, method=method)
+    frc_resolution, frc = img.frc(img, cutoff=0.143, method=method)
     assert np.isclose(frc_resolution[0], 2, rtol=0.02)
     assert np.allclose(frc, 1, rtol=0.01)
 
@@ -123,14 +123,14 @@ def test_frc_id(image_fixture, method):
 def test_frc_trunc(image_fixture, method):
     img_a, img_b, _ = image_fixture
     assert img_a.dtype == img_b.dtype
-    frc_resolution, frc = img_a.frc(img_b, pixel_size=1, cutoff=0.143, method=method)
+    frc_resolution, frc = img_a.frc(img_b, cutoff=0.143, method=method)
     assert frc_resolution[0] > 3.0
 
 
 def test_frc_noise(image_fixture, method):
     img_a, _, img_n = image_fixture
 
-    frc_resolution, frc = img_a.frc(img_n, pixel_size=1, cutoff=0.143, method=method)
+    frc_resolution, frc = img_a.frc(img_n, cutoff=0.143, method=method)
     assert frc_resolution[0] > 3.5
 
 
@@ -142,13 +142,13 @@ def test_frc_img_plot(image_fixture):
 
     # Plot to screen
     with matplotlib_no_gui():
-        _ = img_a.frc(img_n, pixel_size=1, cutoff=0.143, plot=True)
+        _ = img_a.frc(img_n, cutoff=0.143, plot=True)
 
     # Plot to file
     # Also tests `cutoff=None`
     with tempfile.TemporaryDirectory() as tmp_input_dir:
         file_path = os.path.join(tmp_input_dir, "img_frc_curve.png")
-        img_a.frc(img_n, pixel_size=1, cutoff=None, plot=file_path)
+        img_a.frc(img_n, cutoff=None, plot=file_path)
         assert os.path.exists(file_path)
 
 
@@ -160,9 +160,7 @@ def test_frc_plot(image_fixture, method):
     """
     img_a, img_b, _ = image_fixture
 
-    frc = FourierRingCorrelation(
-        img_a.asnumpy(), img_b.asnumpy(), pixel_size=1, method=method
-    )
+    frc = FourierRingCorrelation(img_a.asnumpy(), img_b.asnumpy(), method=method)
 
     with matplotlib_no_gui():
         frc.plot(cutoff=0.5)
@@ -304,7 +302,7 @@ def test_img_type_mismatch():
     b = a.asnumpy()
 
     with pytest.raises(TypeError, match=r"`other` image must be an `Image` instance"):
-        _ = a.frc(b, pixel_size=1, cutoff=0.143)
+        _ = a.frc(b, cutoff=0.143)
 
 
 def test_vol_type_mismatch():
@@ -327,7 +325,7 @@ def test_frc_id_bcast(image_fixture, method):
     k = 3
     img_b = Image(np.tile(img, (3, 1, 1)))
 
-    frc_resolution, frc = img.frc(img_b, pixel_size=1, cutoff=0.143, method=method)
+    frc_resolution, frc = img.frc(img_b, cutoff=0.143, method=method)
     assert np.allclose(
         frc_resolution,
         [
@@ -342,7 +340,7 @@ def test_frc_id_bcast(image_fixture, method):
     # (1) x (1,3)
     img_b = img_b.stack_reshape(1, 3)
 
-    frc_resolution, frc = img.frc(img_b, pixel_size=1, cutoff=0.143, method=method)
+    frc_resolution, frc = img.frc(img_b, cutoff=0.143, method=method)
     assert np.allclose(
         frc_resolution,
         [
@@ -357,7 +355,7 @@ def test_frc_id_bcast(image_fixture, method):
     # (1) x (3,1)
     img_b = img_b.stack_reshape(3, 1)
 
-    frc_resolution, frc = img.frc(img_b, pixel_size=1, cutoff=0.143, method=method)
+    frc_resolution, frc = img.frc(img_b, cutoff=0.143, method=method)
     assert np.allclose(
         frc_resolution,
         [
@@ -398,12 +396,12 @@ def test_frc_img_plot_bcast(image_fixture):
 
     # Plot to screen, one:many
     with matplotlib_no_gui():
-        _ = img_a.frc(img_b, pixel_size=1, cutoff=0.143, plot=True)
+        _ = img_a.frc(img_b, cutoff=0.143, plot=True)
 
     # Plot to file, many elementwise
     with tempfile.TemporaryDirectory() as tmp_input_dir:
         file_path = os.path.join(tmp_input_dir, "img_frc_curve.png")
-        img_b.frc(img_b, pixel_size=1, cutoff=0.143, plot=file_path)
+        img_b.frc(img_b, cutoff=0.143, plot=file_path)
         assert os.path.exists(file_path)
 
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -24,8 +24,22 @@ params = [(0, np.float32), (1, np.float32), (0, np.float64), (1, np.float64)]
 n = 3
 mdim = 2
 
+PARITY = [0, 1]
+DTYPES = [np.float32, np.float64]
 
-def get_images(parity=0, dtype=np.float32):
+
+@pytest.fixture(params=PARITY, ids=lambda x: f"parity={x}", scope="module")
+def parity(request):
+    return request.param
+
+
+@pytest.fixture(params=DTYPES, ids=lambda x: f"dtype={x}", scope="module")
+def dtype(request):
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def get_images(parity, dtype):
     size = 768 - parity
     # numpy array for top-level functions that directly expect it
     im_np = face(gray=True).astype(dtype)[np.newaxis, :size, :size]
@@ -33,36 +47,40 @@ def get_images(parity=0, dtype=np.float32):
     im_np /= denom  # Normalize test image data to 0,1
 
     # Independent Image object for testing Image methods
-    im = Image(im_np.copy())
+    im = Image(im_np.copy(), pixel_size=1.23)
     return im_np, im
 
 
-def get_stacks(parity=0, dtype=np.float32):
-    im_np, im = get_images(parity, dtype)
+@pytest.fixture(scope="module")
+def get_stacks(get_images, dtype):
+    im_np, im = get_images
 
     # Construct a simple stack of Images
-    ims_np = np.empty((n, *im_np.shape[1:]), dtype=dtype)
+    ims_np = np.empty((n, *im_np.shape[1:]), dtype=im_np.dtype)
     for i in range(n):
         ims_np[i] = im_np * (i + 1) / float(n)
 
     # Independent Image stack object for testing Image methods
-    ims = Image(ims_np)
+    ims = Image(ims_np.copy())
     return ims_np, ims
 
 
-def get_mdim_images(parity=0, dtype=np.float32):
-    ims_np, im = get_stacks(parity, dtype)
+# Note that `get_mdim_images` is mutated by some tests,
+# force per function scope.
+@pytest.fixture(scope="function")
+def get_mdim_images(get_stacks):
+    ims_np, im = get_stacks
     # Multi dimensional stack Image object
     mdim = 2
     mdim_ims_np = np.concatenate([ims_np] * mdim).reshape(mdim, *ims_np.shape)
 
     # Independent multidimensional Image stack object for testing Image methods
-    mdim_ims = Image(mdim_ims_np)
+    mdim_ims = Image(mdim_ims_np.copy())
     return mdim_ims_np, mdim_ims
 
 
-def testRepr():
-    _, mdim_ims = get_mdim_images()
+def testRepr(get_mdim_images):
+    _, mdim_ims = get_mdim_images
     r = repr(mdim_ims)
     logger.info(f"Image repr:\n{r}")
 
@@ -73,9 +91,8 @@ def testNonSquare():
         _ = Image(np.empty((4, 5)))
 
 
-@pytest.mark.parametrize("parity,dtype", params)
-def testImShift(parity, dtype):
-    im_np, im = get_images(parity, dtype)
+def testImShift(get_images, dtype):
+    im_np, im = get_images
     # Note that the _im_translate method can handle float input shifts, as it
     # computes the shifts in Fourier space, rather than performing a roll
     # However, NumPy's roll() only accepts integer inputs
@@ -101,10 +118,8 @@ def testImShift(parity, dtype):
     np.testing.assert_allclose(im0.asnumpy()[0, :, :], im3, atol=atol)
 
 
-@pytest.mark.parametrize("parity,dtype", params)
-def testImShiftStack(parity, dtype):
-    ims_np, ims = get_stacks(parity, dtype)
-
+def testImShiftStack(get_stacks, dtype):
+    ims_np, ims = get_stacks
     # test stack of shifts (same number as Image.num_img)
     # mix of odd and even
     shifts = np.array([[100, 200], [203, 150], [55, 307]])
@@ -131,8 +146,8 @@ def testImShiftStack(parity, dtype):
     np.testing.assert_allclose(im0.asnumpy(), im3, atol=atol)
 
 
-def testImageShiftErrors():
-    _, im = get_images(0, np.float32)
+def testImageShiftErrors(get_images):
+    _, im = get_images
     # test bad shift shape
     with pytest.raises(ValueError, match="Input shifts must be of shape"):
         _ = im.shift(np.array([100, 100, 100]))
@@ -141,18 +156,16 @@ def testImageShiftErrors():
         _ = im.shift(np.array([[100, 200], [100, 200]]))
 
 
-@pytest.mark.parametrize("parity,dtype", params)
-def testImageSqrt(parity, dtype):
-    im_np, im = get_images(parity, dtype)
-    ims_np, ims = get_stacks(parity, dtype)
+def testImageSqrt(get_images, get_stacks):
+    im_np, im = get_images
+    ims_np, ims = get_stacks
     assert np.allclose(im.sqrt().asnumpy(), np.sqrt(im_np))
     assert np.allclose(ims.sqrt().asnumpy(), np.sqrt(ims_np))
 
 
-@pytest.mark.parametrize("parity,dtype", params)
-def testImageTranspose(parity, dtype):
-    im_np, im = get_images(parity, dtype)
-    ims_np, ims = get_stacks(parity, dtype)
+def testImageTranspose(get_images, get_stacks):
+    im_np, im = get_images
+    ims_np, ims = get_stacks
     # test method and abbreviation
     assert np.allclose(im.T.asnumpy(), np.transpose(im_np, (0, 2, 1)))
     assert np.allclose(im.transpose().asnumpy(), np.transpose(im_np, (0, 2, 1)))
@@ -163,10 +176,9 @@ def testImageTranspose(parity, dtype):
         assert np.allclose(ims.transpose()[i], ims_np[i].T)
 
 
-@pytest.mark.parametrize("parity,dtype", params)
-def testImageFlip(parity, dtype):
-    im_np, im = get_images(parity, dtype)
-    ims_np, ims = get_stacks(parity, dtype)
+def testImageFlip(get_images, get_stacks):
+    im_np, im = get_images
+    ims_np, ims = get_stacks
     for axis in powerset(range(1, 3)):
         if not axis:
             # test default
@@ -188,31 +200,31 @@ def testImageFlip(parity, dtype):
             _ = im.flip(axis)
 
 
-def testShape():
-    ims_np, ims = get_stacks()
+def testShape(get_stacks):
+    ims_np, ims = get_stacks
     assert ims.shape == ims_np.shape
     assert ims.stack_shape == ims_np.shape[:-2]
     assert ims.stack_ndim == 1
 
 
-def testMultiDimShape():
-    ims_np, ims = get_stacks()
-    mdim_ims_np, mdim_ims = get_mdim_images()
+def testMultiDimShape(get_stacks, get_mdim_images):
+    ims_np, ims = get_stacks
+    mdim_ims_np, mdim_ims = get_mdim_images
     assert mdim_ims.shape == mdim_ims_np.shape
     assert mdim_ims.stack_shape == mdim_ims_np.shape[:-2]
     assert mdim_ims.stack_ndim == mdim
     assert mdim_ims.n_images == mdim * ims.n_images
 
 
-def testBadKey():
-    mdim_ims_np, mdim_ims = get_mdim_images()
+def testBadKey(get_mdim_images):
+    mdim_ims_np, mdim_ims = get_mdim_images
     with pytest.raises(ValueError, match="slice length must be"):
         _ = mdim_ims[tuple(range(mdim_ims.ndim + 1))]
 
 
-def testMultiDimGets():
-    ims_np, ims = get_stacks()
-    mdim_ims_np, mdim_ims = get_mdim_images()
+def testMultiDimGets(get_stacks, get_mdim_images):
+    ims_np, ims = get_stacks
+    mdim_ims_np, mdim_ims = get_mdim_images
     for X in mdim_ims:
         assert np.allclose(ims_np, X)
 
@@ -220,9 +232,9 @@ def testMultiDimGets():
     assert np.allclose(mdim_ims[:, 1:], ims[1:])
 
 
-def testMultiDimSets():
-    ims_np, ims = get_stacks()
-    mdim_ims_np, mdim_ims = get_mdim_images()
+def testMultiDimSets(get_stacks, get_mdim_images):
+    ims_np, ims = get_stacks
+    mdim_ims_np, mdim_ims = get_mdim_images
     mdim_ims[0, 1] = 123
     # Check the values changed
     assert np.allclose(mdim_ims[0, 1], 123)
@@ -232,9 +244,9 @@ def testMultiDimSets():
     assert np.allclose(mdim_ims[1, :], ims_np)
 
 
-def testMultiDimSetsSlice():
-    ims_np, ims = get_stacks()
-    mdim_ims_np, mdim_ims = get_mdim_images()
+def testMultiDimSetsSlice(get_stacks, get_mdim_images):
+    ims_np, ims = get_stacks
+    mdim_ims_np, mdim_ims = get_mdim_images
     # Test setting a slice
     mdim_ims[0, 1:] = 456
     # Check the values changed
@@ -244,9 +256,9 @@ def testMultiDimSetsSlice():
     assert np.allclose(mdim_ims[1, :], ims_np)
 
 
-def testMultiDimReshape():
+def testMultiDimReshape(get_mdim_images):
     # Try mdim reshape
-    mdim_ims_np, mdim_ims = get_mdim_images()
+    mdim_ims_np, mdim_ims = get_mdim_images
     X = mdim_ims.stack_reshape(*mdim_ims.stack_shape[::-1])
     assert X.stack_shape == mdim_ims.stack_shape[::-1]
     # Compare with direct np.reshape of axes of ndarray
@@ -254,22 +266,22 @@ def testMultiDimReshape():
     assert np.allclose(X.asnumpy(), mdim_ims_np.reshape(shape))
 
 
-def testMultiDimFlattens():
-    mdim_ims_np, mdim_ims = get_mdim_images()
+def testMultiDimFlattens(get_mdim_images):
+    mdim_ims_np, mdim_ims = get_mdim_images
     # Try flattening
     X = mdim_ims.stack_reshape(mdim_ims.n_images)
     assert X.stack_shape, (mdim_ims.n_images,)
 
 
-def testMultiDimFlattensTrick():
-    mdim_ims_np, mdim_ims = get_mdim_images()
+def testMultiDimFlattensTrick(get_mdim_images):
+    mdim_ims_np, mdim_ims = get_mdim_images
     # Try flattening with -1
     X = mdim_ims.stack_reshape(-1)
     assert X.stack_shape == (mdim_ims.n_images,)
 
 
-def testMultiDimReshapeTuples():
-    mdim_ims_np, mdim_ims = get_mdim_images()
+def testMultiDimReshapeTuples(get_mdim_images):
+    mdim_ims_np, mdim_ims = get_mdim_images
     # Try flattening with (-1,)
     X = mdim_ims.stack_reshape((-1,))
     assert X.stack_shape, (mdim_ims.n_images,)
@@ -279,8 +291,8 @@ def testMultiDimReshapeTuples():
     assert X.stack_shape == mdim_ims.stack_shape[::-1]
 
 
-def testMultiDimBadReshape():
-    mdim_ims_np, mdim_ims = get_mdim_images()
+def testMultiDimBadReshape(get_mdim_images):
+    mdim_ims_np, mdim_ims = get_mdim_images
     # Incorrect flat shape
     with pytest.raises(ValueError, match="Number of images"):
         _ = mdim_ims.stack_reshape(8675309)
@@ -290,11 +302,11 @@ def testMultiDimBadReshape():
         _ = mdim_ims.stack_reshape(42, 8675309)
 
 
-def testMultiDimBroadcast():
-    ims_np, ims = get_stacks()
-    mdim_ims_np, mdim_ims = get_mdim_images()
+def testMultiDimBroadcast(get_stacks, get_mdim_images):
+    ims_np, ims = get_stacks
+    mdim_ims_np, mdim_ims = get_mdim_images
     X = mdim_ims + ims
-    assert np.allclose(X[0], 2 * ims.asnumpy())
+    np.testing.assert_allclose(X[0], 2 * ims.asnumpy())
 
 
 @matplotlib_dry_run
@@ -306,12 +318,12 @@ def testShow():
     im.show()
 
 
-def test_backproject_symmetry_group():
+def test_backproject_symmetry_group(dtype):
     """
     Test backproject SymmetryGroup pass through and error message.
     """
     ary = np.random.random((5, 8, 8))
-    im = Image(ary)
+    im = Image(ary, dtype=dtype)
     rots = Rotation.generate_random_rotations(5).matrices
 
     # Attempt backproject with bad symmetry group.
@@ -324,9 +336,7 @@ def test_backproject_symmetry_group():
     assert isinstance(vol.symmetry_group, CnSymmetryGroup)
 
     # Symmetry from instance.
-    vol = im.backproject(
-        rots, symmetry_group=CnSymmetryGroup(order=3, dtype=np.float32)
-    )
+    vol = im.backproject(rots, symmetry_group=CnSymmetryGroup(order=3, dtype=dtype))
     assert isinstance(vol.symmetry_group, CnSymmetryGroup)
 
 
@@ -381,7 +391,7 @@ def test_load_bad_ext():
         _ = Image.load("bad.ext")
 
 
-def test_load_mrc():
+def test_load_mrc(dtype):
     """
     Test `Image.load` round-trip.
     """
@@ -390,27 +400,19 @@ def test_load_mrc():
     filepath = os.path.join(DATA_DIR, "sample.mrc")
 
     # Load data from file
-    im = Image.load(filepath)
-    im_64 = Image.load(filepath, dtype=np.float64)
+    im = Image.load(filepath, dtype=dtype)
 
     with tempfile.TemporaryDirectory() as tmpdir_name:
         # tmp filename
         test_filepath = os.path.join(tmpdir_name, "test.mrc")
-        test_filepath_64 = os.path.join(tmpdir_name, "test_64.mrc")
 
         im.save(test_filepath)
-        im_64.save(test_filepath_64)
 
-        im2 = Image.load(test_filepath)
-        im2_64 = Image.load(test_filepath_64, dtype=np.float64)
+        im2 = Image.load(test_filepath, dtype)
 
     # Check the single precision round-trip
     assert np.array_equal(im, im2)
-    assert im2.dtype == np.float32
-
-    # check the double precision round-trip
-    assert np.array_equal(im_64, im2_64)
-    assert im2_64.dtype == np.float64
+    assert im2.dtype == dtype
 
 
 def test_load_tiff():

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -438,3 +438,30 @@ def test_load_tiff():
 
     # Check contents
     assert np.array_equal(im, im2)
+
+
+def test_save_load_pixel_size(get_images, dtype):
+    """
+    Test saving and loading an MRC with pixel size attribute
+    """
+
+    im_np, im = get_images
+
+    with tempfile.TemporaryDirectory() as tmpdir_name:
+        # tmp filename
+        test_filepath = os.path.join(tmpdir_name, "test.mrc")
+
+        # Save image to file
+        im.save(test_filepath)
+
+        # Load image from file
+        im2 = Image.load(test_filepath, dtype)
+
+    # Check we've loaded the image data
+    np.testing.assert_allclose(im2, im)
+    # Check we've loaded the image dtype
+    assert im2.dtype == im.dtype, "Image dtype mismatched on save-load"
+    # Check we've loaded the pixel size
+    np.testing.assert_almost_equal(
+        im2.pixel_size, im.pixel_size, err_msg="Image pixel_size incorrect save-load"
+    )

--- a/tests/test_mean_estimator_boosting.py
+++ b/tests/test_mean_estimator_boosting.py
@@ -122,7 +122,7 @@ def weighted_source(weighted_volume):
 def test_fsc(source, estimated_volume):
     """Compare estimated volume to source volume with FSC."""
     # Fourier Shell Correlation
-    fsc_resolution, fsc = source.vols.fsc(estimated_volume, pixel_size=1, cutoff=0.5)
+    fsc_resolution, fsc = source.vols.fsc(estimated_volume, cutoff=0.5)
 
     # Check that resolution is less than 2.1 pixels.
     np.testing.assert_array_less(fsc_resolution, 2.1)

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -116,8 +116,10 @@ class SimTestCase(TestCase):
             n=self.n,
             L=self.L,
             vols=self.vols,
+            # Set legacy pixel_size
             unique_filters=[
-                RadialCTFFilter(defocus=d) for d in np.linspace(1.5e4, 2.5e4, 7)
+                RadialCTFFilter(pixel_size=10, defocus=d)
+                for d in np.linspace(1.5e4, 2.5e4, 7)
             ],
             noise_adder=WhiteNoiseAdder(var=1),
             dtype=self.dtype,
@@ -168,7 +170,9 @@ class SimTestCase(TestCase):
             vols=self.vols,
             offsets=self.sim.offsets,
             unique_filters=[
-                RadialCTFFilter(defocus=d) for d in np.linspace(1.5e4, 2.5e4, 7)
+                # Set legacy pixel size
+                RadialCTFFilter(pixel_size=10, defocus=d)
+                for d in np.linspace(1.5e4, 2.5e4, 7)
             ],
             noise_adder=WhiteNoiseAdder(var=1),
             dtype=self.dtype,

--- a/tests/test_synthetic_volume.py
+++ b/tests/test_synthetic_volume.py
@@ -20,6 +20,9 @@ logger = logging.getLogger(__name__)
 # dtype fixture to pass into volume fixture.
 DTYPES = [np.float32, pytest.param(np.float64, marks=pytest.mark.expensive)]
 
+# Pixel sized used to test assignment
+PXSZ = 3.0
+
 
 @pytest.fixture(params=DTYPES)
 def dtype_fixture(request):
@@ -87,7 +90,7 @@ def vol_fixture(request, dtype_fixture):
 
     # Assign some volumes a pixel_size, leave others as default.
     if res % 2:
-        vol_kwargs["pixel_size"] = 3.0
+        vol_kwargs["pixel_size"] = PXSZ
 
     return vol_class(**vol_kwargs)
 
@@ -108,7 +111,7 @@ def test_volume_generate(vol_fixture):
 
     # In vol_fixture, we assign pixel_size to volumes having odd voxel sizes.
     if vol_fixture.L % 2:
-        assert v.pixel_size == 3
+        np.testing.assert_approx_equal(v.pixel_size, PXSZ)
 
 
 def test_simulation_init(vol_fixture):

--- a/tests/test_synthetic_volume.py
+++ b/tests/test_synthetic_volume.py
@@ -85,6 +85,10 @@ def vol_fixture(request, dtype_fixture):
     if len(params) > 2:
         vol_kwargs["order"] = params[2]
 
+    # Assign some volumes a pixel_size, leave others as default.
+    if res % 2:
+        vol_kwargs["pixel_size"] = 3.0
+
     return vol_class(**vol_kwargs)
 
 
@@ -96,8 +100,15 @@ def test_volume_repr(vol_fixture):
 
 
 def test_volume_generate(vol_fixture):
-    """Test that a volume is generated"""
-    _ = vol_fixture.generate()
+    """
+    Test that a volume is generated
+    and stores pixel_size when provided.
+    """
+    v = vol_fixture.generate()
+
+    # In vol_fixture, we assign pixel_size to volumes having odd voxel sizes.
+    if vol_fixture.L % 2:
+        assert v.pixel_size == 3
 
 
 def test_simulation_init(vol_fixture):

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -589,7 +589,7 @@ def test_downsample(res):
     # Confirm the pixel size is scaled
     np.testing.assert_approx_equal(
         result.pixel_size,
-        vols.pixel_size * res / ds_res,
+        vols.pixel_size * og_res / ds_res,
         err_msg="Incorrect pixel size.",
     )
 

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -30,6 +30,7 @@ def res_id(params):
 
 
 RES = [42, 43]
+TEST_PX_SZ = 4.56
 
 
 @pytest.fixture(params=RES, ids=res_id, scope="module")
@@ -75,7 +76,7 @@ def vols_1(data_1):
 
 @pytest.fixture
 def vols_2(data_2):
-    return Volume(data_2, pixel_size=4.56)
+    return Volume(data_2, pixel_size=TEST_PX_SZ)
 
 
 @pytest.fixture
@@ -293,6 +294,13 @@ def test_save_load(vols_1):
         assert np.allclose(vols_1, vols_loaded_double)
         assert vols_loaded_single.pixel_size is None, "Pixel size should be None"
         assert vols_loaded_double.pixel_size is None, "Pixel size should be None"
+
+
+def test_volume_pixel_size(vols_2):
+    """
+    Test volume is storing pixel_size attribute.
+    """
+    assert np.isclose(TEST_PX_SZ, vols_2.pixel_size), "Incorrect Volume pixel_size"
 
 
 def test_save_load_pixel_size(vols_2):


### PR DESCRIPTION
Closes #1152 .

Adds pixel_size attribute to Volume and tests saving/loading default and non-default values.
Adds pixel_size attribute to Image and tests saving/loading default and non-default values.
Tests downsampling with default and non-default values.
Partially refactors Image tests to actually use fixtures (faster) and scopes them.