### PR TITLE
Long running workflow patches

### DIFF
--- a/.github/workflows/long_workflow.yml
+++ b/.github/workflows/long_workflow.yml
@@ -1,14 +1,14 @@
 name: ASPIRE Python Long Running Test Suite
 
 on:
-  push:
-    branches:
-      - 'main'
-      - 'develop'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   expensive_tests:
     runs-on: self-hosted
+    # Only run on review ready pull_requests
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == false }}
     timeout-minutes: 360
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/long_workflow.yml
+++ b/.github/workflows/long_workflow.yml
@@ -33,8 +33,9 @@ jobs:
         cat ${WORK_DIR}/config.yaml
     - name: Run
       run: |
+        export OMP_NUM_THREADS=1
         ASPIREDIR=${{ env.WORK_DIR }} python -c \
         "import aspire; print(aspire.config['ray']['temp_dir'])"
-        ASPIREDIR=${{ env.WORK_DIR }} python -m pytest -m "expensive" --durations=0
+        ASPIREDIR=${{ env.WORK_DIR }} python -m pytest -n8 -m "expensive" --durations=0
     - name: Cleanup
       run: rm -rf ${{ env.WORK_DIR }}

--- a/src/aspire/nufft/__init__.py
+++ b/src/aspire/nufft/__init__.py
@@ -3,6 +3,7 @@ import logging
 import numpy as np
 
 from aspire import config
+from aspire.numeric import xp
 from aspire.utils import LogFilterByCount, complex_type, real_type
 
 cp = None
@@ -198,8 +199,8 @@ def anufft(sig_f, fourier_pts, sz, real=False, epsilon=1e-8):
 
     adjoint = adjoint.real if real else adjoint
 
-    if cp and isinstance(adjoint, cp.ndarray) and not _keep_on_gpu:
-        adjoint = adjoint.get()
+    if not _keep_on_gpu:
+        adjoint = xp.asnumpy(adjoint)
 
     return adjoint
 
@@ -259,7 +260,7 @@ def nufft(sig_f, fourier_pts, real=False, epsilon=1e-8):
 
     transform = transform.real if real else transform
 
-    if cp and isinstance(transform, cp.ndarray) and not _keep_on_gpu:
-        transform = transform.get()
+    if not _keep_on_gpu:
+        transform = xp.asnumpy(transform)
 
     return transform

--- a/src/aspire/nufft/__init__.py
+++ b/src/aspire/nufft/__init__.py
@@ -198,7 +198,7 @@ def anufft(sig_f, fourier_pts, sz, real=False, epsilon=1e-8):
 
     adjoint = adjoint.real if real else adjoint
 
-    if cp and not _keep_on_gpu:
+    if cp and isinstance(adjoint, cp.ndarray) and not _keep_on_gpu:
         adjoint = adjoint.get()
 
     return adjoint
@@ -259,7 +259,7 @@ def nufft(sig_f, fourier_pts, real=False, epsilon=1e-8):
 
     transform = transform.real if real else transform
 
-    if cp and not _keep_on_gpu:
+    if cp and isinstance(transform, cp.ndarray) and not _keep_on_gpu:
         transform = transform.get()
 
     return transform


### PR DESCRIPTION
Some updates for the long running workflow.

- Patch for mixed cupy mode with cufinufft disabled
- Skip very large FFB2D when running on GPU (currently it isn't being run in the suite, but in case it is in future)
- Small change to long_workflow so that is takes a lot less time (10-30m depending on machine load)
- Change long_workflow to run when PR is "ready"ed, since it takes less time now.

