### PR TITLE
Fix Fuzzy Mask for small L

### DIFF
--- a/src/aspire/utils/misc.py
+++ b/src/aspire/utils/misc.py
@@ -294,7 +294,8 @@ def fuzzy_mask(L, dtype, r0=None, risetime=None):
     if r0 is None:
         r0 = np.floor(0.45 * L[0])
     if risetime is None:
-        risetime = np.floor(0.05 * L[0])
+        # Guard against zero here for small L
+        risetime = max(np.floor(0.05 * L[0]), 1.0)
 
     dim = len(L)
     axes = ["x"]


### PR DESCRIPTION
Need to ensure we have a non zero `risetime` for `fuzzy_mask`.  

For L<20, the code was generating a mask with NaNs and then injecting into the polar fourier data used in all subsequent common lines code.