### PR TITLE
Cl mask patch

### DIFF
--- a/src/aspire/abinitio/commonline_base.py
+++ b/src/aspire/abinitio/commonline_base.py
@@ -91,8 +91,13 @@ class CLOrient3D:
         imgs = self.src.images[:]
 
         if self.mask:
-            fuzz_mask = fuzzy_mask((self.n_res, self.n_res), self.dtype)
+            # For best results and to reproduce MATLAB:
+            #   Always compute mask (erf) in doubles.
+            fuzz_mask = fuzzy_mask((self.n_res, self.n_res), np.float64)
+            #   Apply mask in doubles (allow imgs to upcast as needed)
             imgs = imgs * fuzz_mask
+            #   Cast to desired type
+            imgs = Image(imgs.asnumpy().astype(self.dtype, copy=False))
 
         # Obtain coefficients of polar Fourier transform for input 2D images
         pft = PolarFT(

--- a/src/aspire/abinitio/commonline_base.py
+++ b/src/aspire/abinitio/commonline_base.py
@@ -4,6 +4,7 @@ import math
 import numpy as np
 import scipy.sparse as sparse
 
+from aspire.image import Image
 from aspire.operators import PolarFT
 from aspire.utils import common_line_from_rots, fuzzy_mask, tqdm
 from aspire.utils.random import choice
@@ -92,8 +93,9 @@ class CLOrient3D:
 
         if self.mask:
             # For best results and to reproduce MATLAB:
+            #   Set risetime=2
             #   Always compute mask (erf) in doubles.
-            fuzz_mask = fuzzy_mask((self.n_res, self.n_res), np.float64)
+            fuzz_mask = fuzzy_mask((self.n_res, self.n_res), np.float64, risetime=2)
             #   Apply mask in doubles (allow imgs to upcast as needed)
             imgs = imgs * fuzz_mask
             #   Cast to desired type


### PR DESCRIPTION
Found some differences in the application of `fuzzy_mask`.  I will retest to confirm, but it appears applying these two patches will reproduce the image stack going into the Polar Fourier transform just prior to the CL search and reduce the CL errors wrt MATLAB.