### PR TITLE
Angs

### DIFF
--- a/src/aspire/abinitio/commonline_base.py
+++ b/src/aspire/abinitio/commonline_base.py
@@ -23,7 +23,8 @@ class CLOrient3D:
         n_rad=None,
         n_theta=360,
         n_check=None,
-        tic_width=1,
+        hist_bin_width=3,
+        full_width=6,
         max_shift=0.15,
         shift_step=1,
         mask=True,
@@ -43,7 +44,10 @@ class CLOrient3D:
             of the resolution. Default is 0.15.
         :param shift_step: Resolution of shift estimation in pixels.
             Default is 1 pixel.
-        :param tic_width: Bin width in smoothing histogram (a tic is approx a degree).
+        :param hist_bin_width: Bin width in smoothing histogram (degrees).
+        :param full_width: Selection width around smoothed histogram peak (degrees).
+            `adaptive` will attempt to automatically find the smallest number of
+            `hist_bin_width`s required to find at least one valid image index.
         :param mask: Option to mask `src.images` with a fuzzy mask (boolean).
             Default, `True`, applies a mask.
         """
@@ -55,7 +59,8 @@ class CLOrient3D:
         self.n_rad = n_rad
         self.n_theta = n_theta
         self.n_check = n_check
-        self.tic_width = tic_width
+        self.hist_bin_width = hist_bin_width
+        self.full_width = full_width
         self.clmatrix = None
         self.max_shift = math.ceil(max_shift * self.n_res)
         self.shift_step = shift_step

--- a/src/aspire/abinitio/commonline_base.py
+++ b/src/aspire/abinitio/commonline_base.py
@@ -23,6 +23,7 @@ class CLOrient3D:
         n_rad=None,
         n_theta=360,
         n_check=None,
+        tic_width=1,
         max_shift=0.15,
         shift_step=1,
         mask=True,
@@ -42,6 +43,7 @@ class CLOrient3D:
             of the resolution. Default is 0.15.
         :param shift_step: Resolution of shift estimation in pixels.
             Default is 1 pixel.
+        :param tic_width: Bin width in smoothing histogram (a tic is approx a degree).
         :param mask: Option to mask `src.images` with a fuzzy mask (boolean).
             Default, `True`, applies a mask.
         """
@@ -53,6 +55,7 @@ class CLOrient3D:
         self.n_rad = n_rad
         self.n_theta = n_theta
         self.n_check = n_check
+        self.tic_width = tic_width
         self.clmatrix = None
         self.max_shift = math.ceil(max_shift * self.n_res)
         self.shift_step = shift_step

--- a/src/aspire/abinitio/commonline_c3_c4.py
+++ b/src/aspire/abinitio/commonline_c3_c4.py
@@ -561,7 +561,7 @@ class CLSymmetryC3C4(CLOrient3D, SyncVotingMixin):
         :param n_theta: The number of points in the theta direction (common lines)
         :return: The (i,j) rotation block of the synchronization matrix
         """
-        good_k = self._vote_ij(clmatrix, n_theta, i, j, k_list)
+        _, good_k = self._vote_ij(clmatrix, n_theta, i, j, k_list)
 
         rots = self._rotratio_eulerangle_vec(clmatrix, i, j, good_k, n_theta)
 

--- a/src/aspire/abinitio/commonline_sync.py
+++ b/src/aspire/abinitio/commonline_sync.py
@@ -203,7 +203,7 @@ class CLSyncVoting(CLOrient3D, SyncVotingMixin):
         :return: The (i,j) rotation block of the synchronization matrix
         """
 
-        good_k = self._vote_ij(clmatrix, n_theta, i, j, k_list)
+        _, good_k = self._vote_ij(clmatrix, n_theta, i, j, k_list)
 
         rots = self._rotratio_eulerangle_vec(clmatrix, i, j, good_k, n_theta)
 

--- a/src/aspire/abinitio/commonline_sync.py
+++ b/src/aspire/abinitio/commonline_sync.py
@@ -24,7 +24,15 @@ class CLSyncVoting(CLOrient3D, SyncVotingMixin):
     """
 
     def __init__(
-        self, src, n_rad=None, n_theta=360, max_shift=0.15, shift_step=1, mask=True
+        self,
+        src,
+        n_rad=None,
+        n_theta=360,
+        max_shift=0.15,
+        shift_step=1,
+        hist_bin_width=3,
+        full_width=6,
+        mask=True,
     ):
         """
         Initialize an object for estimating 3D orientations using synchronization matrix
@@ -36,6 +44,10 @@ class CLSyncVoting(CLOrient3D, SyncVotingMixin):
         :param max_shift: Determines maximum range for shifts as a proportion
             of the resolution. Default is 0.15.
         :param shift_step: Resolution for shift estimation in pixels. Default is 1 pixel.
+        :param hist_bin_width: Bin width in smoothing histogram (degrees).
+        :param full_width: Selection width around smoothed histogram peak (degrees).
+            `adaptive` will attempt to automatically find the smallest number of
+            `hist_bin_width`s required to find at least one valid image index.
         :param mask: Option to mask `src.images` with a fuzzy mask (boolean).
             Default, `True`, applies a mask.
         """
@@ -45,6 +57,8 @@ class CLSyncVoting(CLOrient3D, SyncVotingMixin):
             n_theta=n_theta,
             max_shift=max_shift,
             shift_step=shift_step,
+            hist_bin_width=hist_bin_width,
+            full_width=full_width,
             mask=mask,
         )
         self.syncmatrix = None

--- a/src/aspire/abinitio/commonline_sync3n.py
+++ b/src/aspire/abinitio/commonline_sync3n.py
@@ -255,19 +255,11 @@ class CLSync3N(CLOrient3D, SyncVotingMixin):
             # to multiply:
             v = Dhalf @ v
 
-        # # quick hack the matlab code in here
-        H = v.T.reshape(3, self.n_img, 3)
-        rotations = np.zeros((self.n_img, 3, 3), dtype=np.float64)
-        for i in range(self.n_img):
-            U, _, V = np.linalg.svd(H[:, i, :])
-            # breakpoint()
-            rotations[i] = U @ V
+        # Yield estimated rotations from the eigen-vectors
+        rotations = v.reshape(self.n_img, 3, 3).transpose(0, 2, 1)
 
-        # # Yield estimated rotations from the eigen-vectors
-        # rotations = v.reshape(self.n_img, 3, 3).transpose(0, 2, 1)
-
-        # # Enforce we are returning actual rotations
-        # rotations = nearest_rotations(rotations)
+        # Enforce we are returning actual rotations
+        rotations = nearest_rotations(rotations)
 
         return rotations.astype(self.dtype)
 

--- a/src/aspire/abinitio/commonline_sync3n.py
+++ b/src/aspire/abinitio/commonline_sync3n.py
@@ -259,7 +259,7 @@ class CLSync3N(CLOrient3D, SyncVotingMixin):
         rotations = v.reshape(self.n_img, 3, 3).transpose(0, 2, 1)
 
         # Enforce we are returning actual rotations
-        rotations = nearest_rotations(rotations)
+        rotations = nearest_rotations(rotations, allow_reflection=True)
 
         return rotations.astype(self.dtype)
 

--- a/src/aspire/abinitio/commonline_sync3n.py
+++ b/src/aspire/abinitio/commonline_sync3n.py
@@ -52,6 +52,8 @@ class CLSync3N(CLOrient3D, SyncVotingMixin):
         n_theta=360,
         max_shift=0.15,
         shift_step=1,
+        hist_bin_width=1,
+        full_width="adaptive",
         epsilon=1e-2,
         max_iters=1000,
         seed=None,
@@ -69,6 +71,10 @@ class CLSync3N(CLOrient3D, SyncVotingMixin):
         :param n_theta: The number of points in the theta direction
         :param max_shift: Maximum range for shifts as a proportion of box size. Default = 0.15.
         :param shift_step: Step size of shift estimation in pixels. Default = 1 pixel.
+        :param hist_bin_width: Bin width in smoothing histogram (degrees).
+        :param full_width: Selection width around smoothed histogram peak (degrees).
+            `adaptive` will attempt to automatically find the smallest number of
+            `hist_bin_width`s required to find at least one valid image index.
         :param epsilon: Tolerance for the power method.
         :param max_iter: Maximum iterations for the power method.
         :param seed: Optional seed for RNG.
@@ -91,6 +97,8 @@ class CLSync3N(CLOrient3D, SyncVotingMixin):
             n_theta=n_theta,
             max_shift=max_shift,
             shift_step=shift_step,
+            hist_bin_width=hist_bin_width,
+            full_width=full_width,
             mask=mask,
         )
 

--- a/src/aspire/abinitio/commonline_sync3n.py
+++ b/src/aspire/abinitio/commonline_sync3n.py
@@ -835,11 +835,6 @@ class CLSync3N(CLOrient3D, SyncVotingMixin):
             angles[1] = np.mean(alphas)
             angles[2] = -np.pi / 2 - clmatrix[j, i] * 2 * np.pi / n_theta
             rot = Rotation.from_euler(angles).matrices
-            # from scipy.spatial.transform import Rotation as sprot
-            # angles[0] = clmatrix[i, j] * 2 * np.pi / n_theta - np.pi
-            # angles[1] = np.mean(alphas)
-            # angles[2] = np.pi - clmatrix[j, i] * 2 * np.pi / n_theta
-            # rot = sprot.from_euler("ZXZ", angles).as_matrix()
 
         else:
             # This is for the case that images i and j correspond to the same
@@ -901,7 +896,7 @@ class CLSync3N(CLOrient3D, SyncVotingMixin):
 
         # We need only the signs of the eigenvector
         J_sync = np.sign(vec)
-        J_sync = -1 * np.sign(J_sync[0]) * J_sync  # Stabilize J_sync
+        J_sync = np.sign(J_sync[0]) * J_sync  # Stabilize J_sync
 
         return J_sync
 

--- a/src/aspire/abinitio/commonline_sync3n.py
+++ b/src/aspire/abinitio/commonline_sync3n.py
@@ -5,16 +5,10 @@ import warnings
 import numpy as np
 from numpy.linalg import norm
 from scipy.optimize import curve_fit
+from scipy.spatial.transform import Rotation as sprot
 
 from aspire.abinitio import CLOrient3D, SyncVotingMixin
-from aspire.utils import (
-    J_conjugate,
-    Rotation,
-    all_pairs,
-    nearest_rotations,
-    tqdm,
-    trange,
-)
+from aspire.utils import J_conjugate, all_pairs, nearest_rotations, tqdm, trange
 from aspire.utils.matlab_compat import stable_eigsh
 from aspire.utils.random import randn
 
@@ -819,13 +813,20 @@ class CLSync3N(CLOrient3D, SyncVotingMixin):
 
         angle = self._rotratio_eulerangle_vec(clmatrix, i, j, good_k, n_theta)
         angles = np.zeros(3)
-        
+
         if angle is not None:
-            # Convert the Euler angles with ZYZ conversion to rotation matrices
-            angles[0] = clmatrix[i, j] * 2 * np.pi / n_theta + np.pi / 2
+            # # # BAD
+            # # Convert the Euler angles with ZYZ conversion to rotation matrices
+            # angles[0] = clmatrix[i, j] * 2 * np.pi / n_theta + np.pi / 2
+            # angles[1] = angle
+            # angles[2] = -np.pi / 2 - clmatrix[j, i] * 2 * np.pi / n_theta
+            # rot = Rotation.from_euler(angles).matrices
+
+            angles[0] = clmatrix[i, j] * 2 * np.pi / n_theta - np.pi
             angles[1] = angle
-            angles[2] = -np.pi / 2 - clmatrix[j, i] * 2 * np.pi / n_theta
-            rot = Rotation.from_euler(angles).matrices
+            angles[2] = np.pi - clmatrix[j, i] * 2 * np.pi / n_theta
+            rot = sprot.from_euler("ZXZ", angles).as_matrix()
+
         else:
             # This is for the case that images i and j correspond to the same
             # viewing direction and differ only by in-plane rotation.

--- a/src/aspire/abinitio/commonline_sync3n.py
+++ b/src/aspire/abinitio/commonline_sync3n.py
@@ -5,10 +5,16 @@ import warnings
 import numpy as np
 from numpy.linalg import norm
 from scipy.optimize import curve_fit
-from scipy.spatial.transform import Rotation as sprot
 
 from aspire.abinitio import CLOrient3D, SyncVotingMixin
-from aspire.utils import J_conjugate, all_pairs, nearest_rotations, tqdm, trange
+from aspire.utils import (
+    J_conjugate,
+    Rotation,
+    all_pairs,
+    nearest_rotations,
+    tqdm,
+    trange,
+)
 from aspire.utils.matlab_compat import stable_eigsh
 from aspire.utils.random import randn
 
@@ -819,11 +825,10 @@ class CLSync3N(CLOrient3D, SyncVotingMixin):
         angles = np.zeros(3)
 
         if alphas is not None:
-            # TODO, fixup to ZYZ? or?
-            angles[0] = clmatrix[i, j] * 2 * np.pi / n_theta - np.pi
+            angles[0] = clmatrix[i, j] * 2 * np.pi / n_theta + np.pi / 2
             angles[1] = np.mean(alphas)
-            angles[2] = np.pi - clmatrix[j, i] * 2 * np.pi / n_theta
-            rot = sprot.from_euler("ZXZ", angles).as_matrix()
+            angles[2] = -np.pi / 2 - clmatrix[j, i] * 2 * np.pi / n_theta
+            rot = Rotation.from_euler(angles).matrices
 
         else:
             # This is for the case that images i and j correspond to the same

--- a/src/aspire/abinitio/sync_voting.py
+++ b/src/aspire/abinitio/sync_voting.py
@@ -71,9 +71,10 @@ class SyncVotingMixin(object):
         :param i: The i image
         :param j: The j image
         :param k_list: The list of images for the third image for voting algorithm
-        :param sync:
-        :return:  good_k, the list of all third images in the peak of the histogram
-            corresponding to the pair of images (i,j)
+        :param sync: Perform 180 degree ambiguity synchronization.
+        :return: (alpha, good_k), angles and list of all third images
+            in the peak of the histogram corresponding to the pair of
+            images (i,j)
         """
 
         if i == j or clmatrix[i, j] == -1:
@@ -200,7 +201,7 @@ class SyncVotingMixin(object):
         :param cl_diff3: Difference of common line indices on C3 created by
             its intersection with C2 and C1
         :param n_theta: The number of points in the theta direction (common lines)
-        :param sync:
+        :param sync: Perform 180 degree ambiguity synchronization.
         :return: cos values of rotation angles between i and j images
             and indices for good k
         """

--- a/src/aspire/abinitio/sync_voting.py
+++ b/src/aspire/abinitio/sync_voting.py
@@ -2,8 +2,6 @@ import logging
 
 import numpy as np
 
-from aspire.utils import Rotation
-
 logger = logging.getLogger(__name__)
 
 
@@ -46,14 +44,7 @@ class SyncVotingMixin(object):
             return None
         alpha = np.arccos(c_alpha)
 
-        # Convert the Euler angles with ZYZ conversion to rotation matrices
-        angles = np.zeros((alpha.shape[0], 3))
-        angles[:, 0] = clmatrix[i, j] * 2 * np.pi / n_theta + np.pi / 2
-        angles[:, 1] = alpha
-        angles[:, 2] = -np.pi / 2 - clmatrix[j, i] * 2 * np.pi / n_theta
-        r = Rotation.from_euler(angles).matrices
-
-        return r[good_idx, :, :]
+        return np.mean(alpha)
 
     def _vote_ij(self, clmatrix, n_theta, i, j, k_list):
         """

--- a/src/aspire/abinitio/sync_voting.py
+++ b/src/aspire/abinitio/sync_voting.py
@@ -93,8 +93,11 @@ class SyncVotingMixin(object):
         # cl_diff2 is for the angle on C2 created by its intersection with C1 and C3.
         # cl_diff3 is for the angle on C3 created by its intersection with C2 and C1.
         cl_diff1 = cl_idx13 - cl_idx12
+        # bad or just a trig identity?
         cl_diff2 = cl_idx21 - cl_idx23
+        # cl_diff2 = cl_idx23 - cl_idx21  # theta2 = (clmatrix(j,K)-clmatrix(j,i)) * 2*pi/L;
         cl_diff3 = cl_idx32 - cl_idx31
+
         # Calculate the cos values of rotation angles between i an j images for good k images
         cos_phi2, good_idx = self._get_cos_phis(cl_diff1, cl_diff2, cl_diff3, n_theta)
 
@@ -115,7 +118,7 @@ class SyncVotingMixin(object):
             return []
 
         # Parameters used to compute the smoothed angle histogram.
-        ntics = 60
+        ntics = int(180 / self.tic_width)
         angles_grid = np.linspace(0, 180, ntics, True)
         # Get angles between images i and j for computing the histogram
         angles = np.arccos(phis[:]) * 180 / np.pi
@@ -218,4 +221,5 @@ class SyncVotingMixin(object):
         cos_phi2 = (c3[good_idx] - c1[good_idx] * c2[good_idx]) / (
             np.sin(theta1[good_idx]) * np.sin(theta2[good_idx])
         )
+
         return cos_phi2, good_idx

--- a/src/aspire/abinitio/sync_voting.py
+++ b/src/aspire/abinitio/sync_voting.py
@@ -49,7 +49,6 @@ class SyncVotingMixin(object):
             return None
         alpha = np.arccos(c_alpha)
 
-        # # TODO??
         # Convert the Euler angles with ZYZ conversion to rotation matrices
         angles = np.zeros((alpha.shape[0], 3))
         angles[:, 0] = clmatrix[i, j] * 2 * np.pi / n_theta + np.pi / 2

--- a/src/aspire/utils/coor_trans.py
+++ b/src/aspire/utils/coor_trans.py
@@ -2,6 +2,7 @@
 General purpose math functions, mostly geometric in nature.
 """
 
+import logging
 import math
 
 import numpy as np
@@ -11,6 +12,8 @@ from scipy.linalg import svd
 from aspire.numeric import xp
 from aspire.utils.random import Random
 from aspire.utils.rotation import Rotation
+
+logger = logging.getLogger(__name__)
 
 
 def cart2pol(x, y):
@@ -299,7 +302,7 @@ def mean_aligned_angular_distance(rots_est, rots_gt, degree_tol=None):
         and the ground truth (in degrees).
     """
     Q_mat, flag = register_rotations(rots_est, rots_gt)
-    print("Q_mat", Q_mat, "\nflag", flag)
+    logger.debug(f"Registration Q_mat: {Q_mat}\nflag: {flag}")
     regrot = get_aligned_rotations(rots_est, Q_mat, flag)
     mean_ang_dist = Rotation.mean_angular_distance(regrot, rots_gt) * 180 / np.pi
 

--- a/src/aspire/utils/coor_trans.py
+++ b/src/aspire/utils/coor_trans.py
@@ -299,6 +299,7 @@ def mean_aligned_angular_distance(rots_est, rots_gt, degree_tol=None):
         and the ground truth (in degrees).
     """
     Q_mat, flag = register_rotations(rots_est, rots_gt)
+    print("Q_mat", Q_mat, "\nflag", flag)
     regrot = get_aligned_rotations(rots_est, Q_mat, flag)
     mean_ang_dist = Rotation.mean_angular_distance(regrot, rots_gt) * 180 / np.pi
 

--- a/src/aspire/utils/matrix.py
+++ b/src/aspire/utils/matrix.py
@@ -434,11 +434,12 @@ def best_rank1_approximation(A):
     return (U @ S_rank1 @ V).reshape(og_shape)
 
 
-def nearest_rotations(A):
+def nearest_rotations(A, allow_reflection=False):
     """
     Uses the SVD method to compute the set of nearest rotations to the set A of noisy rotations.
 
     :param A: A 2D array or a 3D array where the first axis is the stack axis.
+    :param allow_reflection: Optionally correct reflections.
     :return: ndarray of rotations of equal size to A.
     """
     og_shape = A.shape
@@ -451,12 +452,16 @@ def nearest_rotations(A):
             f"Array must be of shape (3, 3) or (n, 3, 3). Found shape {A.shape}."
         )
 
-    # For the singular value decomposition A = U @ S @ V, we compute the nearest rotation
-    # matrices R = U @ V. If det(U)*det(V) = -1, we negate the third singular value to ensure
-    # we have a rotation.
+    # For the singular value decomposition A = U @ S @ V,
+    # we compute the nearest rotation matrices R = U @ V.
     U, _, V = np.linalg.svd(A)
-    neg_det_idx = np.linalg.det(U) * np.linalg.det(V) < 0
-    U[neg_det_idx] = U[neg_det_idx] @ np.diag((1, 1, -1)).astype(dtype, copy=False)
+
+    if not allow_reflection:
+        # If det(U)*det(V) = -1, we negate the third singular value to
+        # ensure we have a rotation.
+        neg_det_idx = np.linalg.det(U) * np.linalg.det(V) < 0
+        U[neg_det_idx] = U[neg_det_idx] @ np.diag((1, 1, -1)).astype(dtype, copy=False)
+
     rots = U @ V
 
     return rots.reshape(og_shape)

--- a/src/aspire/utils/matrix.py
+++ b/src/aspire/utils/matrix.py
@@ -438,8 +438,10 @@ def nearest_rotations(A, allow_reflection=False):
     """
     Uses the SVD method to compute the set of nearest rotations to the set A of noisy rotations.
 
+    Note when `allow_reflection` is `True`, results may contain reflections.
+
     :param A: A 2D array or a 3D array where the first axis is the stack axis.
-    :param allow_reflection: Optionally correct reflections.
+    :param allow_reflection: Optionally allow reflections (disables correction).
     :return: ndarray of rotations of equal size to A.
     """
     og_shape = A.shape

--- a/tests/test_commonline_sync3n.py
+++ b/tests/test_commonline_sync3n.py
@@ -53,7 +53,7 @@ def source_orientation_objs(resolution, offsets, dtype):
         seed=456,
     ).cache()
 
-    orient_est = CLSync3N(src, S_weighting=True, seed=789)
+    orient_est = CLSync3N(src, n_theta=72, S_weighting=True, seed=789)
 
     return src, orient_est
 
@@ -68,15 +68,15 @@ def test_build_clmatrix(source_orientation_objs):
 
     angle_diffs = abs(orient_est.clmatrix - gt_clmatrix) * 360 / orient_est.n_theta
 
-    # Count number of estimates within 5 degrees of ground truth.
-    within_5 = np.sum((angle_diffs - 360) % 360 < 5)
+    # Count number of estimates near ground truth.
+    within = np.sum((angle_diffs - 360) % 360 < 10)
 
-    # Check that at least 98% of estimates are within 5 degrees.
-    tol = 0.98
+    # Check that at least 95% of estimates are within degree range.
+    tol = 0.96
     if src.offsets.all() != 0:
         # Set tolerance to 95% when using nonzero offsets.
         tol = 0.95
-    assert within_5 / angle_diffs.size > tol
+    assert within / angle_diffs.size > tol
 
 
 def test_estimate_rotations(source_orientation_objs):

--- a/tests/test_commonline_sync3n.py
+++ b/tests/test_commonline_sync3n.py
@@ -71,7 +71,7 @@ def test_build_clmatrix(source_orientation_objs):
     # Count number of estimates near ground truth.
     within = np.sum((angle_diffs - 360) % 360 < 10)
 
-    # Check that at least 95% of estimates are within degree range.
+    # Check estimates are within degree range.
     tol = 0.96
     if src.offsets.all() != 0:
         # Set tolerance to 95% when using nonzero offsets.

--- a/tests/test_commonline_sync3n.py
+++ b/tests/test_commonline_sync3n.py
@@ -53,7 +53,7 @@ def source_orientation_objs(resolution, offsets, dtype):
         seed=456,
     ).cache()
 
-    orient_est = CLSync3N(src, n_theta=72, S_weighting=True, seed=789)
+    orient_est = CLSync3N(src, S_weighting=True, seed=789)
 
     return src, orient_est
 
@@ -68,15 +68,15 @@ def test_build_clmatrix(source_orientation_objs):
 
     angle_diffs = abs(orient_est.clmatrix - gt_clmatrix) * 360 / orient_est.n_theta
 
-    # Count number of estimates near ground truth.
-    within = np.sum((angle_diffs - 360) % 360 < 10)
+    # Count number of estimates within 5 degrees of ground truth.
+    within_5 = np.sum((angle_diffs - 360) % 360 < 5)
 
-    # Check estimates are within degree range.
-    tol = 0.96
+    # Check that at least 98% of estimates are within 5 degrees.
+    tol = 0.98
     if src.offsets.all() != 0:
         # Set tolerance to 95% when using nonzero offsets.
         tol = 0.95
-    assert within / angle_diffs.size > tol
+    assert within_5 / angle_diffs.size > tol
 
 
 def test_estimate_rotations(source_orientation_objs):


### PR DESCRIPTION
Stashing debug work.

So far I have found two errors in the initial estimating rotations method preventing us from achieving the results from MATLAB.  First we should be taking the average of 1d (alpha) angles, not the rotation matrices. Second, the euler to rotation conversion in our current python code is not equivalent to the one in MATLAB (and originally ported by Junchao).

I saved the alpha angles from MATLAB for all i,j image pairs.  Following #1171 we can make an equivalent CL mat.  Following above we can take the alpha MATLAB angles and generate the same rotations.

There is a small (1.5*) discrepancy between the alpha angles computed in Python and those in MATLAB.  This is coincidentally the value I would expect in this particular problem if we had an 'off by one bin' error.  (Not sure, just thinking atm).

I will continue working this, hopefully resulting in MATLAB parity up to initial rotation estimates for one of the JSB problems.