### PR TITLE
Rmsh

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -244,7 +244,6 @@ jobs:
       run: |
         conda info
         conda list
-        conda install pyshtools  # debug depends issues
         pip install -e ".[dev]"  # install aspire
         pip freeze
     - name: Test

--- a/environment-accelerate.yml
+++ b/environment-accelerate.yml
@@ -7,7 +7,6 @@ channels:
 dependencies:
   - pip
   - python=3.8
-  - pyshtools
   - numpy=1.24.1
   - scipy=1.10.1
   - scikit-learn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ dependencies = [
     "pillow",
     "psutil",
     "pymanopt",
-    "pyshtools<=4.10.4",  # 4.11.7 might have a packaging bug
     "PyWavelets",
     "ray >= 2.9.2",
     "scipy >= 1.10.0",

--- a/src/aspire/basis/basis_utils.py
+++ b/src/aspire/basis/basis_utils.py
@@ -178,7 +178,7 @@ def sph_harm(j, m, theta, phi):
 
     # Use identity for negative `m`
     if m < 0:
-        (-1) ** (m % 2) * np.conj(y)
+        y = (-1) ** (m % 2) * np.conj(y)
 
     return y
 

--- a/src/aspire/basis/basis_utils.py
+++ b/src/aspire/basis/basis_utils.py
@@ -4,12 +4,11 @@ prolate spheroidal wave function (PSWF) objects.
 """
 
 import logging
-import warnings
 
 import numpy as np
 from numpy import diff, exp, log, pi
 from numpy.polynomial.legendre import leggauss
-from scipy.special import jn, jv, sph_harm, factorial
+from scipy.special import factorial, jn, jv
 
 from aspire.utils import grid_2d, grid_3d
 
@@ -156,6 +155,7 @@ def norm_assoc_legendre(j, m, x):
 
     return px
 
+
 def _sph_harm(m, j, theta, phi):
     """
     Compute spherical harmonics.
@@ -167,10 +167,15 @@ def _sph_harm(m, j, theta, phi):
     """
 
     if m < 0:
-        return (-1)**(m%2)*np.conj(_sph_harm(-m, j, phi, theta))
+        return (-1) ** (m % 2) * np.conj(_sph_harm(-m, j, phi, theta))
 
-    from scipy.special import lpmv    
-    y = np.sqrt( ((2*j+1)/(4*np.pi)) * factorial(j-m)/factorial(j+m)) * lpmv(m, j, np.cos(phi)) * np.exp(1j*m*theta)  # OKAY
+    from scipy.special import lpmv
+
+    y = (
+        np.sqrt(((2 * j + 1) / (4 * np.pi)) * factorial(j - m) / factorial(j + m))
+        * lpmv(m, j, np.cos(phi))
+        * np.exp(1j * m * theta)
+    )  # OKAY
     # _y = norm_assoc_legendre(j, m, np.cos(phi)) * np.exp(1j*m*theta) / np.sqrt( ((2*j+1)/(4*np.pi)) * factorial(j-m)/factorial(j+m)) # not the right factor?
 
     # # also not the right factor
@@ -179,8 +184,8 @@ def _sph_harm(m, j, theta, phi):
     #     k =1
     # _y = norm_assoc_legendre(j, m, np.cos(phi)) * np.exp(1j*m*theta) / np.sqrt( k*(2*j+1) * factorial(j-m)/factorial(j+m))
 
-    
     return y
+
 
 def real_sph_harmonic(j, m, theta, phi):
     """
@@ -199,10 +204,9 @@ def real_sph_harmonic(j, m, theta, phi):
     # The `scipy` sph_harm implementation is much faster,
     #   but incorrectly returns NaN for high orders.
     y = _sph_harm(abs_m, j, phi, theta)
-    #y = sph_harm(abs_m, j, phi, theta)  # scipy
+    # from scipy.special import sph_harm
+    # y = sph_harm(abs_m, j, phi, theta)  # scipy
 
-
-    
     if m < 0:
         y = np.sqrt(2) * np.imag(y)
     elif m > 0:

--- a/tests/test_basis_utils.py
+++ b/tests/test_basis_utils.py
@@ -38,12 +38,13 @@ def test_sph_harm_high_order():
     y = 0.56789
 
     # If scipy fixed their implementation for higher orders in the future,
-    # this check will we may wish to take it.
+    # this check should fail and we can reconsider that package.
     ref = sp_sph_harm(m, j, y, x)  # Note calling convention is different
     assert not np.isfinite(ref)
 
     # Can manually check against pyshtools,
     # but we are avoiding that package dependency.
+    # Leaving this here intentionally for future developers.
     # y = spharm_lm(
     #     j,
     #     abs_m,

--- a/tests/test_basis_utils.py
+++ b/tests/test_basis_utils.py
@@ -27,6 +27,11 @@ def test_sph_harm_low_order():
     ref = sp_sph_harm(m, j, y, x)  # Note calling convention is different
     np.testing.assert_allclose(sph_harm(j, m, x, y), ref)
 
+    # negative m
+    m *= -1
+    ref = sp_sph_harm(m, j, y, x)  # Note calling convention is different
+    np.testing.assert_allclose(sph_harm(j, m, x, y), ref)
+
 
 def test_sph_harm_high_order():
     """

--- a/tests/test_basis_utils.py
+++ b/tests/test_basis_utils.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 import numpy as np
+from scipy.special import sph_harm as sp_sph_harm
 
 from aspire.basis.basis_utils import (
     all_besselj_zeros,
@@ -9,8 +10,53 @@ from aspire.basis.basis_utils import (
     norm_assoc_legendre,
     real_sph_harmonic,
     sph_bessel,
+    sph_harm,
     unique_coords_nd,
 )
+
+
+def test_sph_harm_low_order():
+    """
+    Test the `sph_harm` implementation matches `scipy` at lower orders.
+    """
+    m = 3
+    j = 5
+    x = np.linspace(0, np.pi, 42)
+    y = np.linspace(0, 2 * np.pi, 42)
+
+    ref = sp_sph_harm(m, j, y, x)  # Note calling convention is different
+    np.testing.assert_allclose(sph_harm(j, m, x, y), ref)
+
+
+def test_sph_harm_high_order():
+    """
+    Test we remain finite at higher orders where `scipy.special.sph_harm` overflows.
+    """
+    m = 87
+    j = 87
+    x = 0.12345
+    y = 0.56789
+
+    # If scipy fixed their implementation for higher orders in the future,
+    # this check will we may wish to take it.
+    ref = sp_sph_harm(m, j, y, x)  # Note calling convention is different
+    assert not np.isfinite(ref)
+
+    # Can manually check against pyshtools,
+    # but we are avoiding that package dependency.
+    # y = spharm_lm(
+    #     j,
+    #     abs_m,
+    #     theta,
+    #     phi,
+    #     kind="complex",
+    #     degrees=False,
+    #     csphase=-1,
+    #     normalization="ortho",
+    # )
+
+    # Check we are finite.
+    assert np.isfinite(sph_harm(j, m, x, y))
 
 
 class BesselTestCase(TestCase):


### PR DESCRIPTION
Implements `sph_harm` using the recurrence based normalized associated Legendre polynomial method.  FB3D should now operate for the same orders as FFB3D.

Adds tests that compare low orders against `scipy`. 
Checks `scipy` is not finite for higher orders (they may fix one day...).
Checks this implementation is finite for an order that was previously a problem.

Purges `pyshtools`.