### PR TITLE
osx_arm updates

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -231,6 +231,9 @@ jobs:
     if: ${{ github.event_name == 'push' || github.event.pull_request.draft == false }}
     steps:
     - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
     - name: Complete Install and Log Environment
       run: |
         python --version

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -231,19 +231,9 @@ jobs:
     if: ${{ github.event_name == 'push' || github.event.pull_request.draft == false }}
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Conda
-      uses: conda-incubator/setup-miniconda@v2.3.0
-      with:
-        miniconda-version: "latest"
-        auto-update-conda: true
-        python-version: '3.8'
-        activate-environment: aspire
-        environment-file: environment-accelerate.yml
-        auto-activate-base: false
-    - name: Complete Install and Log Environment ${{ matrix.os }} Python ${{ matrix.python-version }}
+    - name: Complete Install and Log Environment
       run: |
-        conda info
-        conda list
+        python --version
         pip install -e ".[dev]"  # install aspire
         pip freeze
     - name: Test

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -222,9 +222,6 @@ jobs:
           retention-days: 7
 
   osx_arm:
-    defaults:
-      run:
-        shell: bash -l {0}
     needs: check
     runs-on: macos-14
     # Run on every code push, but only on review ready PRs

--- a/README.md
+++ b/README.md
@@ -37,11 +37,7 @@ install `aspire` safely in that environment.
 
 If you are unfamiliar with `conda`, the
 [Miniconda](https://docs.conda.io/en/latest/miniconda.html)
-distribution for `x86_64` is recommended.  For Apple silicon to use
-the osx-arm platform, patching and building some dependencies from
-source is currently required.  The Intel `osx-64` install is still
-preferred even for Apple silicon users, otherwise [notes are
-provided.](https://github.com/ComputationalCryoEM/ASPIRE-Python/discussions/969)
+distribution for `x86_64` is recommended.
 
 Assuming you have `conda` and a compatible system, the following steps
 will checkout current code release, create an environment, and install

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -34,12 +34,6 @@ to view Conda's installation instructions.
 .. note:: If you're not sure which distribution is right for you, go
    with `Miniconda <https://conda.io/miniconda.html>`__
 
-.. note:: For Apple silicon to use the osx-arm platform, patching and
-   building some dependencies from source is currently required.  The
-   Intel ``osx-64`` install is still preferred even for Apple silicon
-   users, otherwise `notes are
-   provided. <https://github.com/ComputationalCryoEM/ASPIRE-Python/discussions/969>`_
-
 Getting Started - Installation
 ************************************
 

--- a/tests/test_FLEbasis2D.py
+++ b/tests/test_FLEbasis2D.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import sys
 
 import numpy as np
@@ -70,8 +71,10 @@ def relerr(base, approx):
 
 @pytest.mark.parametrize("basis", test_bases, ids=show_fle_params)
 class TestFLEBasis2D(UniversalBasisMixin):
-    # Loosen the tolerance for `cufinufft` to be within 15%
-    test_eps = 1.15 if backend_available("cufinufft") else 1.0
+    # Loosen the tolerance for `cufinufft` and `osx_arm` to be within 15%
+    test_eps = 1.0
+    if backend_available("cufinufft") or platform.system() == "Darwin":
+        test_eps = 1.16
 
     # check closeness guarantees for fast vs dense matrix method
     def testFastVDense_T(self, basis):

--- a/tests/test_FLEbasis2D.py
+++ b/tests/test_FLEbasis2D.py
@@ -71,7 +71,7 @@ def relerr(base, approx):
 
 @pytest.mark.parametrize("basis", test_bases, ids=show_fle_params)
 class TestFLEBasis2D(UniversalBasisMixin):
-    # Loosen the tolerance for `cufinufft` and `osx_arm` to be within 15%
+    # Loosen the tolerance for `cufinufft` and `osx_arm`
     test_eps = 1.0
     if backend_available("cufinufft"):
         test_eps = 1.15

--- a/tests/test_FLEbasis2D.py
+++ b/tests/test_FLEbasis2D.py
@@ -73,8 +73,10 @@ def relerr(base, approx):
 class TestFLEBasis2D(UniversalBasisMixin):
     # Loosen the tolerance for `cufinufft` and `osx_arm` to be within 15%
     test_eps = 1.0
-    if backend_available("cufinufft") or platform.system() == "Darwin":
-        test_eps = 1.16
+    if backend_available("cufinufft"):
+        test_eps = 1.15
+    elif platform.system() == "Darwin":
+        test_eps = 1.20
 
     # check closeness guarantees for fast vs dense matrix method
     def testFastVDense_T(self, basis):

--- a/tests/test_indexed_source.py
+++ b/tests/test_indexed_source.py
@@ -22,11 +22,15 @@ def test_remapping(sim_fixture):
     sim, sim2 = sim_fixture
 
     # Check images are served correctly, using internal index.
-    assert np.allclose(sim.images[sim2.index_map].asnumpy(), sim2.images[:].asnumpy())
+    np.testing.assert_allclose(
+        sim.images[sim2.index_map].asnumpy(), sim2.images[:].asnumpy(), atol=1e-6
+    )
 
     # Check images are served correctly, using known index (evens).
     index = list(range(0, sim.n, 2))
-    assert np.allclose(sim.images[index].asnumpy(), sim2.images[:].asnumpy())
+    np.testing.assert_allclose(
+        sim.images[index].asnumpy(), sim2.images[:].asnumpy(), atol=1e-6
+    )
 
     # Check meta is served correctly.
     assert np.all(sim.get_metadata(indices=sim2.index_map) == sim2.get_metadata())

--- a/tests/test_preprocess_pipeline.py
+++ b/tests/test_preprocess_pipeline.py
@@ -168,7 +168,7 @@ def testInvertContrast(L, dtype):
 
     # all images should be the same after inverting contrast
     np.testing.assert_allclose(
-        imgs1_rc.asnumpy(), imgs2_rc.asnumpy(), rtol=1e-05, atol=1e-08
+        imgs1_rc.asnumpy(), imgs2_rc.asnumpy(), rtol=1e-05, atol=1e-06
     )
     # dtype of returned images should be the same
     assert dtype == imgs1_rc.dtype

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -604,7 +604,9 @@ class SimTestCase(TestCase):
             relion_src = RelionSource(star_filepath, tmpdir, max_rows=1024)
             imgs_sav = relion_src.images[:1024]
             # Compare original images with saved images
-            self.assertTrue(np.allclose(imgs_org.asnumpy(), imgs_sav.asnumpy()))
+            np.testing.assert_allclose(
+                imgs_org.asnumpy(), imgs_sav.asnumpy(), atol=1e-6
+            )
             # Save images into multiple MRCS files based on batch size
             batch_size = 512
             info = self.sim.save(star_filepath, batch_size=batch_size, overwrite=False)
@@ -623,7 +625,9 @@ class SimTestCase(TestCase):
             relion_src = RelionSource(star_filepath, tmpdir, max_rows=1024)
             imgs_sav = relion_src.images[:1024]
             # Compare original images with saved images
-            self.assertTrue(np.allclose(imgs_org.asnumpy(), imgs_sav.asnumpy()))
+            np.testing.assert_allclose(
+                imgs_org.asnumpy(), imgs_sav.asnumpy(), atol=1e-6
+            )
 
 
 def test_default_symmetry_group():
@@ -666,9 +670,11 @@ def test_cached_image_accessors():
     cached_src = src.cache()
 
     # Compare the cached vs dynamic image sets.
-    np.testing.assert_allclose(cached_src.projections[:], src.projections[:])
-    np.testing.assert_allclose(cached_src.images[:], src.images[:])
-    np.testing.assert_allclose(cached_src.clean_images[:], src.clean_images[:])
+    np.testing.assert_allclose(cached_src.projections[:], src.projections[:], atol=1e-6)
+    np.testing.assert_allclose(cached_src.images[:], src.images[:], atol=1e-6)
+    np.testing.assert_allclose(
+        cached_src.clean_images[:], src.clean_images[:], atol=1e-6
+    )
 
 
 def test_mismatched_pixel_size():

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -141,32 +141,28 @@ class SimTestCase(TestCase):
     def testGaussianBlob(self):
         blobs = self.sim.vols.asnumpy()
         ref = np.load(os.path.join(DATA_DIR, "sim_blobs.npy"))
-        self.assertTrue(np.allclose(blobs, ref))
+        np.testing.assert_allclose(blobs, ref, rtol=1e-05, atol=1e-08)
 
     def testSimulationRots(self):
-        self.assertTrue(
-            np.allclose(
-                self.sim.rots_zyx_to_legacy_aspire(self.sim.rotations[0, :, :]),
-                np.array(
-                    [
-                        [0.91675498, 0.2587233, 0.30433956],
-                        [0.39941773, -0.58404652, -0.70665065],
-                        [-0.00507853, 0.76938412, -0.63876622],
-                    ]
-                ),
-                atol=utest_tolerance(self.dtype),
-            )
+        np.testing.assert_allclose(
+            self.sim.rots_zyx_to_legacy_aspire(self.sim.rotations[0, :, :]),
+            np.array(
+                [
+                    [0.91675498, 0.2587233, 0.30433956],
+                    [0.39941773, -0.58404652, -0.70665065],
+                    [-0.00507853, 0.76938412, -0.63876622],
+                ]
+            ),
+            atol=utest_tolerance(self.dtype),
         )
 
     def testSimulationImages(self):
         images = self.sim.clean_images[:512].asnumpy()
-        self.assertTrue(
-            np.allclose(
-                images,
-                np.load(os.path.join(DATA_DIR, "sim_clean_images.npy")),
-                rtol=1e-2,
-                atol=utest_tolerance(self.sim.dtype),
-            )
+        np.testing.assert_allclose(
+            images,
+            np.load(os.path.join(DATA_DIR, "sim_clean_images.npy")),
+            rtol=1e-2,
+            atol=utest_tolerance(self.sim.dtype),
         )
 
     def testSimulationCached(self):
@@ -184,32 +180,28 @@ class SimTestCase(TestCase):
             dtype=self.dtype,
         )
         sim_cached = sim_cached.cache()
-        self.assertTrue(
-            np.array_equal(sim_cached.images[:].asnumpy(), self.sim.images[:].asnumpy())
+        np.testing.assert_allclose(
+            sim_cached.images[:].asnumpy(), self.sim.images[:].asnumpy(), atol=1e-6
         )
 
     def testSimulationImagesNoisy(self):
         images = self.sim.images[:512].asnumpy()
-        self.assertTrue(
-            np.allclose(
-                images,
-                np.load(os.path.join(DATA_DIR, "sim_images_with_noise.npy")),
-                rtol=1e-2,
-                atol=utest_tolerance(self.sim.dtype),
-            )
+        np.testing.assert_allclose(
+            images,
+            np.load(os.path.join(DATA_DIR, "sim_images_with_noise.npy")),
+            rtol=1e-2,
+            atol=utest_tolerance(self.sim.dtype),
         )
 
     def testSimulationImagesDownsample(self):
         # The simulation already generates images of size 8 x 8; Downsampling to resolution 8 should thus have no effect
         self.sim = self.sim.downsample(8)
         images = self.sim.clean_images[:512].asnumpy()
-        self.assertTrue(
-            np.allclose(
-                images,
-                np.load(os.path.join(DATA_DIR, "sim_clean_images.npy")),
-                rtol=1e-2,
-                atol=utest_tolerance(self.sim.dtype),
-            )
+        np.testing.assert_allclose(
+            images,
+            np.load(os.path.join(DATA_DIR, "sim_clean_images.npy")),
+            rtol=1e-2,
+            atol=utest_tolerance(self.sim.dtype),
         )
 
     def testSimulationImagesShape(self):
@@ -225,192 +217,192 @@ class SimTestCase(TestCase):
 
     def testSimulationEigen(self):
         eigs_true, lambdas_true = self.sim.eigs()
-        self.assertTrue(
-            np.allclose(
-                eigs_true.asnumpy()[0, :, :, 2],
-                np.array(
+        np.testing.assert_allclose(
+            eigs_true.asnumpy()[0, :, :, 2],
+            np.array(
+                [
                     [
-                        [
-                            -1.67666201e-07,
-                            -7.95741380e-06,
-                            -1.49160041e-04,
-                            -1.10151654e-03,
-                            -3.11287888e-03,
-                            -3.09157884e-03,
-                            -9.91418026e-04,
-                            -1.31673165e-04,
-                        ],
-                        [
-                            -1.15402077e-06,
-                            -2.49849709e-05,
-                            -3.51658906e-04,
-                            -2.21575261e-03,
-                            -7.83315487e-03,
-                            -9.44795180e-03,
-                            -4.07636259e-03,
-                            -9.02186439e-04,
-                        ],
-                        [
-                            -1.88737249e-05,
-                            -1.91418396e-04,
-                            -1.09021540e-03,
-                            -1.02020288e-03,
-                            1.39411855e-02,
-                            8.58035963e-03,
-                            -5.54619730e-03,
-                            -3.86377703e-03,
-                        ],
-                        [
-                            -1.21280536e-04,
-                            -9.51461843e-04,
-                            -3.22565017e-03,
-                            -1.05731178e-03,
-                            2.61375736e-02,
-                            3.11595201e-02,
-                            6.40814053e-03,
-                            -2.31698658e-02,
-                        ],
-                        [
-                            -2.44067283e-04,
-                            -1.40560151e-03,
-                            -6.73082832e-05,
-                            1.44160679e-02,
-                            2.99893934e-02,
-                            5.92632964e-02,
-                            7.75623545e-02,
-                            3.06570008e-02,
-                        ],
-                        [
-                            -1.53507499e-04,
-                            -7.21709803e-04,
-                            8.54929152e-04,
-                            -1.27235036e-02,
-                            -5.34382043e-03,
-                            2.18879692e-02,
-                            6.22706190e-02,
-                            4.51998860e-02,
-                        ],
-                        [
-                            -3.00595184e-05,
-                            -1.43038429e-04,
-                            -2.15870258e-03,
-                            -9.99002904e-02,
-                            -7.79077187e-02,
-                            -1.53395887e-02,
-                            1.88777559e-02,
-                            1.68759506e-02,
-                        ],
-                        [
-                            3.22692649e-05,
-                            4.07977635e-03,
-                            1.63959339e-02,
-                            -8.68835449e-02,
-                            -7.86240026e-02,
-                            -1.75694861e-02,
-                            3.24984640e-03,
-                            1.95389288e-03,
-                        ],
-                    ]
-                ),
-            )
+                        -1.67666201e-07,
+                        -7.95741380e-06,
+                        -1.49160041e-04,
+                        -1.10151654e-03,
+                        -3.11287888e-03,
+                        -3.09157884e-03,
+                        -9.91418026e-04,
+                        -1.31673165e-04,
+                    ],
+                    [
+                        -1.15402077e-06,
+                        -2.49849709e-05,
+                        -3.51658906e-04,
+                        -2.21575261e-03,
+                        -7.83315487e-03,
+                        -9.44795180e-03,
+                        -4.07636259e-03,
+                        -9.02186439e-04,
+                    ],
+                    [
+                        -1.88737249e-05,
+                        -1.91418396e-04,
+                        -1.09021540e-03,
+                        -1.02020288e-03,
+                        1.39411855e-02,
+                        8.58035963e-03,
+                        -5.54619730e-03,
+                        -3.86377703e-03,
+                    ],
+                    [
+                        -1.21280536e-04,
+                        -9.51461843e-04,
+                        -3.22565017e-03,
+                        -1.05731178e-03,
+                        2.61375736e-02,
+                        3.11595201e-02,
+                        6.40814053e-03,
+                        -2.31698658e-02,
+                    ],
+                    [
+                        -2.44067283e-04,
+                        -1.40560151e-03,
+                        -6.73082832e-05,
+                        1.44160679e-02,
+                        2.99893934e-02,
+                        5.92632964e-02,
+                        7.75623545e-02,
+                        3.06570008e-02,
+                    ],
+                    [
+                        -1.53507499e-04,
+                        -7.21709803e-04,
+                        8.54929152e-04,
+                        -1.27235036e-02,
+                        -5.34382043e-03,
+                        2.18879692e-02,
+                        6.22706190e-02,
+                        4.51998860e-02,
+                    ],
+                    [
+                        -3.00595184e-05,
+                        -1.43038429e-04,
+                        -2.15870258e-03,
+                        -9.99002904e-02,
+                        -7.79077187e-02,
+                        -1.53395887e-02,
+                        1.88777559e-02,
+                        1.68759506e-02,
+                    ],
+                    [
+                        3.22692649e-05,
+                        4.07977635e-03,
+                        1.63959339e-02,
+                        -8.68835449e-02,
+                        -7.86240026e-02,
+                        -1.75694861e-02,
+                        3.24984640e-03,
+                        1.95389288e-03,
+                    ],
+                ]
+            ),
+            rtol=1e-05,
+            atol=1e-08,
         )
 
     def testSimulationMean(self):
         mean_vol = self.sim.mean_true()
-        self.assertTrue(
-            np.allclose(
+        np.testing.assert_allclose(
+            [
                 [
-                    [
-                        0.00000930,
-                        0.00033866,
-                        0.00490734,
-                        0.01998369,
-                        0.03874487,
-                        0.04617764,
-                        0.02970645,
-                        0.00967604,
-                    ],
-                    [
-                        0.00003904,
-                        0.00247391,
-                        0.03818476,
-                        0.12325402,
-                        0.22278425,
-                        0.25246665,
-                        0.14093882,
-                        0.03683474,
-                    ],
-                    [
-                        0.00014177,
-                        0.01191146,
-                        0.14421064,
-                        0.38428235,
-                        0.78645319,
-                        0.86522675,
-                        0.44862473,
-                        0.16382280,
-                    ],
-                    [
-                        0.00066036,
-                        0.03137806,
-                        0.29226971,
-                        0.97105378,
-                        2.39410496,
-                        2.17099857,
-                        1.23595858,
-                        0.49233940,
-                    ],
-                    [
-                        0.00271748,
-                        0.05491289,
-                        0.49955708,
-                        2.05356097,
-                        3.70941424,
-                        3.01578689,
-                        1.51441932,
-                        0.52054572,
-                    ],
-                    [
-                        0.00584845,
-                        0.06962635,
-                        0.50568032,
-                        1.99643707,
-                        3.77415895,
-                        2.76039767,
-                        1.04602003,
-                        0.20633197,
-                    ],
-                    [
-                        0.00539583,
-                        0.06068972,
-                        0.47008955,
-                        1.17128026,
-                        1.82821035,
-                        1.18743944,
-                        0.30667788,
-                        0.04851476,
-                    ],
-                    [
-                        0.00246362,
-                        0.04867788,
-                        0.65284950,
-                        0.65238875,
-                        0.65745538,
-                        0.37955678,
-                        0.08053055,
-                        0.01210055,
-                    ],
+                    0.00000930,
+                    0.00033866,
+                    0.00490734,
+                    0.01998369,
+                    0.03874487,
+                    0.04617764,
+                    0.02970645,
+                    0.00967604,
                 ],
-                mean_vol.asnumpy()[0, :, :, 4],
-            )
+                [
+                    0.00003904,
+                    0.00247391,
+                    0.03818476,
+                    0.12325402,
+                    0.22278425,
+                    0.25246665,
+                    0.14093882,
+                    0.03683474,
+                ],
+                [
+                    0.00014177,
+                    0.01191146,
+                    0.14421064,
+                    0.38428235,
+                    0.78645319,
+                    0.86522675,
+                    0.44862473,
+                    0.16382280,
+                ],
+                [
+                    0.00066036,
+                    0.03137806,
+                    0.29226971,
+                    0.97105378,
+                    2.39410496,
+                    2.17099857,
+                    1.23595858,
+                    0.49233940,
+                ],
+                [
+                    0.00271748,
+                    0.05491289,
+                    0.49955708,
+                    2.05356097,
+                    3.70941424,
+                    3.01578689,
+                    1.51441932,
+                    0.52054572,
+                ],
+                [
+                    0.00584845,
+                    0.06962635,
+                    0.50568032,
+                    1.99643707,
+                    3.77415895,
+                    2.76039767,
+                    1.04602003,
+                    0.20633197,
+                ],
+                [
+                    0.00539583,
+                    0.06068972,
+                    0.47008955,
+                    1.17128026,
+                    1.82821035,
+                    1.18743944,
+                    0.30667788,
+                    0.04851476,
+                ],
+                [
+                    0.00246362,
+                    0.04867788,
+                    0.65284950,
+                    0.65238875,
+                    0.65745538,
+                    0.37955678,
+                    0.08053055,
+                    0.01210055,
+                ],
+            ],
+            mean_vol.asnumpy()[0, :, :, 4],
+            rtol=1e-05,
+            atol=1e-08,
         )
 
     def testSimulationVolCoords(self):
         coords, norms, inners = self.sim.vol_coords()
-        self.assertTrue(np.allclose([4.72837704, -4.72837709], coords, atol=1e-4))
-        self.assertTrue(np.allclose([8.20515764e-07, 1.17550184e-06], norms, atol=1e-4))
-        self.assertTrue(
-            np.allclose([3.78030562e-06, -4.20475816e-06], inners, atol=1e-4)
+        np.testing.assert_allclose([4.72837704, -4.72837709], coords, atol=1e-4)
+        np.testing.assert_allclose([8.20515764e-07, 1.17550184e-06], norms, atol=1e-4)
+        np.testing.assert_allclose(
+            [[3.78030562e-06, -4.20475816e-06]], inners, atol=1e-4
         )
 
     def testSimulationCovar(self):
@@ -498,23 +490,23 @@ class SimTestCase(TestCase):
             ],
         ]
 
-        self.assertTrue(np.allclose(result, covar[:, :, 4, 4, 4, 4], atol=1e-4))
+        np.testing.assert_allclose(result, covar[:, :, 4, 4, 4, 4], atol=1e-4)
 
     def testSimulationEvalMean(self):
         mean_est = Volume(np.load(os.path.join(DATA_DIR, "mean_8_8_8.npy")))
         result = self.sim.eval_mean(mean_est)
 
-        self.assertTrue(np.allclose(result["err"], 2.664116055950763, atol=1e-4))
-        self.assertTrue(np.allclose(result["rel_err"], 0.1765943704851626, atol=1e-4))
-        self.assertTrue(np.allclose(result["corr"], 0.9849211540734224, atol=1e-4))
+        np.testing.assert_allclose(result["err"], 2.664116055950763, atol=1e-4)
+        np.testing.assert_allclose(result["rel_err"], 0.1765943704851626, atol=1e-4)
+        np.testing.assert_allclose(result["corr"], 0.9849211540734224, atol=1e-4)
 
     def testSimulationEvalCovar(self):
         covar_est = np.load(os.path.join(DATA_DIR, "covar_8_8_8_8_8_8.npy"))
         result = self.sim.eval_covar(covar_est)
 
-        self.assertTrue(np.allclose(result["err"], 13.322721549011165, atol=1e-4))
-        self.assertTrue(np.allclose(result["rel_err"], 0.5958936073938558, atol=1e-4))
-        self.assertTrue(np.allclose(result["corr"], 0.8405347287741631, atol=1e-4))
+        np.testing.assert_allclose(result["err"], 13.322721549011165, atol=1e-4)
+        np.testing.assert_allclose(result["rel_err"], 0.5958936073938558, atol=1e-4)
+        np.testing.assert_allclose(result["corr"], 0.8405347287741631, atol=1e-4)
 
     def testSimulationEvalCoords(self):
         mean_est = Volume(np.load(os.path.join(DATA_DIR, "mean_8_8_8.npy")))
@@ -528,58 +520,54 @@ class SimTestCase(TestCase):
 
         result = self.sim.eval_coords(mean_est, eigs_est, clustered_coords_est)
 
-        self.assertTrue(
-            np.allclose(
-                result["err"][0, :10],
-                [
-                    1.58382394,
-                    1.58382394,
-                    3.72076112,
-                    1.58382394,
-                    1.58382394,
-                    3.72076112,
-                    3.72076112,
-                    1.58382394,
-                    1.58382394,
-                    1.58382394,
-                ],
-            )
+        np.testing.assert_allclose(
+            result["err"][0, :10],
+            [
+                1.58382394,
+                1.58382394,
+                3.72076112,
+                1.58382394,
+                1.58382394,
+                3.72076112,
+                3.72076112,
+                1.58382394,
+                1.58382394,
+                1.58382394,
+            ],
         )
 
-        self.assertTrue(
-            np.allclose(
-                result["rel_err"][0, :10],
-                [
-                    0.11048937,
-                    0.11048937,
-                    0.21684697,
-                    0.11048937,
-                    0.11048937,
-                    0.21684697,
-                    0.21684697,
-                    0.11048937,
-                    0.11048937,
-                    0.11048937,
-                ],
-            )
+        np.testing.assert_allclose(
+            result["rel_err"][0, :10],
+            [
+                0.11048937,
+                0.11048937,
+                0.21684697,
+                0.11048937,
+                0.11048937,
+                0.21684697,
+                0.21684697,
+                0.11048937,
+                0.11048937,
+                0.11048937,
+            ],
         )
 
-        self.assertTrue(
-            np.allclose(
-                result["corr"][0, :10],
-                [
-                    0.99390133,
-                    0.99390133,
-                    0.97658719,
-                    0.99390133,
-                    0.99390133,
-                    0.97658719,
-                    0.97658719,
-                    0.99390133,
-                    0.99390133,
-                    0.99390133,
-                ],
-            )
+        np.testing.assert_allclose(
+            result["corr"][0, :10],
+            [
+                0.99390133,
+                0.99390133,
+                0.97658719,
+                0.99390133,
+                0.99390133,
+                0.97658719,
+                0.97658719,
+                0.99390133,
+                0.99390133,
+                0.99390133,
+            ],
+            rtol=1e-05,
+            atol=1e-08,
         )
 
     def testSimulationSaveFile(self):


### PR DESCRIPTION
Now that I have removed PyFFTW, pyshtools, and updated to FINUFFT 2.3.0 I think ASPIRE should be good to run native M1 out of the box.  This PR patches the CI and removes the mention of the x86_64 conda install/workarounds.

I'll confirm with my own M1 machine a little later this morning before sending this for review.