### PR TITLE
Scores bound bug

### DIFF
--- a/src/aspire/abinitio/commonline_sync3n.py
+++ b/src/aspire/abinitio/commonline_sync3n.py
@@ -455,10 +455,13 @@ class CLSync3N(CLOrient3D, SyncVotingMixin):
 
                     # Update histogram
                     # Find integer bin [0,self.hist_intervals)
-                    _l1, _l2, _l3 = np.minimum(
-                        (self.hist_intervals * s).astype(int),  # implicit floor
-                        self.hist_intervals - 1,
-                    )  # clamp upper bound
+                    _l1, _l2, _l3 = np.maximum(
+                        np.minimum(
+                            (self.hist_intervals * s).astype(int),  # implicit floor
+                            self.hist_intervals - 1,  # clamp upper bound
+                        ),
+                        0,  # clamp lower bound
+                    )
 
                     scores_hist[_l1] += 1
                     scores_hist[_l2] += 1


### PR DESCRIPTION
Looks like (at least) one of my review changes created a array bounds bug compared to the original code.

This updates the code to have the same result (`0`) as the original code in the case that no scores are above the base bin.