### PR TITLE
Mean est patches

### DIFF
--- a/src/aspire/reconstruction/estimator.py
+++ b/src/aspire/reconstruction/estimator.py
@@ -17,7 +17,7 @@ class Estimator:
         preconditioner="circulant",
         checkpoint_iterations=10,
         checkpoint_prefix="volume_checkpoint",
-        maxiter=100,
+        maxiter=50,
         boost=True,
     ):
         """

--- a/src/aspire/reconstruction/estimator.py
+++ b/src/aspire/reconstruction/estimator.py
@@ -34,9 +34,12 @@ class Estimator:
             `src` during back projection and kernel estimation steps.
         :param preconditioner: Optional kernel preconditioner (`string`).
             Currently supported options are "circulant" or None.
-        :param checkpoint_iterations: Optionally save `cg` estimated `Volume`
-            instance periodically each `checkpoint_iterations`.
-            Setting to None disables, otherwise checks for positive integer.
+        :param checkpoint_iterations: Optionally save `cg` estimated
+            `basis` coefficients periodically each
+            `checkpoint_iterations`.  Setting to `None` disables,
+            otherwise checks for positive integer.  Note, when
+            `maxiter` is not `None` and `cg` fails to converge a final
+            checkpoint will still be written.
         :param checkpoint_prefix: Optional path prefix for `cg`
             checkpoint files.  If the parent directory does not exist,
             creation is attempted.  `_iter{N}` will be appended to the

--- a/src/aspire/reconstruction/mean.py
+++ b/src/aspire/reconstruction/mean.py
@@ -231,7 +231,7 @@ class WeightedVolumesEstimator(Estimator):
 
             # Do checkpoint at `checkpoint_iterations`,
             _do_checkpoint = (
-                self.checkpoint_iterations
+                self.checkpoint_iterations is not None
                 and (self.i % self.checkpoint_iterations) == 0
             )
             # or the last iteration when `maxiter` provided.

--- a/src/aspire/reconstruction/mean.py
+++ b/src/aspire/reconstruction/mean.py
@@ -258,7 +258,9 @@ class WeightedVolumesEstimator(Estimator):
         )
 
         if info != 0:
-            raise RuntimeError("Unable to converge!")
+            logger.warning(
+                f"Conjugate gradient unable to converge after {info} iterations."
+            )
 
         return x.reshape(self.r, self.basis.count)
 

--- a/tests/test_mean_estimator.py
+++ b/tests/test_mean_estimator.py
@@ -159,10 +159,7 @@ def test_checkpoint(sim, basis, estimator):
             maxiter=test_iter + 1,
             checkpoint_prefix=prefix,
         )
-
-        # Assert we raise when reading `maxiter`.
-        with raises(RuntimeError, match="Unable to converge!"):
-            _ = _estimator.estimate()
+        _ = _estimator.estimate()
 
         # Load the checkpoint coefficients while tmp_input_dir exists.
         x_chk = np.load(f"{prefix}_iter{test_iter:04d}.npy")

--- a/tests/test_weighted_mean_estimator.py
+++ b/tests/test_weighted_mean_estimator.py
@@ -155,9 +155,7 @@ def test_checkpoint(sim, basis, estimator, weights):
             checkpoint_prefix=prefix,
         )
 
-        # Assert we raise when reading `maxiter`.
-        with raises(RuntimeError, match="Unable to converge!"):
-            _ = _estimator.estimate()
+        _ = _estimator.estimate()
 
         # Load the checkpoint coefficients while tmp_input_dir exists.
         x_chk = np.load(f"{prefix}_iter{test_iter:04d}.npy")


### PR DESCRIPTION
Some minor patches to our mean estimation area.   

I patched one case where disabling logic wasn't working as intended.  Other change is reducing the max iterations default from 100 to 50, which was the default for MATLAB.  Also fixes comment referencing Volume (basis coef are actually what is written out).

We don't usually hit that max.  I haven't seen any cases that really improve beyond 20 or so iterations anyway. Our default was previously 10, but that is sometimes a bit low. It was wishful thinking I suppose.

The main thing this changes is that we will still return a Volume after `maxiters`, instead of raising.  This was the behavior our of MATLAB, and indeed sometimes we can get a similar recon out now....