### PR TITLE
Arm updates

### DIFF
--- a/tests/test_FLEbasis2D.py
+++ b/tests/test_FLEbasis2D.py
@@ -76,7 +76,7 @@ class TestFLEBasis2D(UniversalBasisMixin):
     if backend_available("cufinufft"):
         test_eps = 1.15
     elif platform.system() == "Darwin":
-        test_eps = 1.20
+        test_eps = 1.30
 
     # check closeness guarantees for fast vs dense matrix method
     def testFastVDense_T(self, basis):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -397,6 +397,11 @@ def matplotlib_no_gui():
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", r"Matplotlib is currently using agg.*")
 
+        # Ignore the specific UserWarning about non-interactive FigureCanvasAgg
+        warnings.filterwarnings(
+            "ignore", r"FigureCanvasAgg is non-interactive, and thus cannot be shown"
+        )
+
         yield
 
     # Explicitly close all figures before making backend changes.


### PR DESCRIPTION
After updating my conda installation to the M1 version I came across a couple test failures and warnings:

```
FAILED tests/test_FLEbasis2D.py::TestFLEBasis2D::testFastVDense_T[32-1e-14] - assert 1.2014224262161716e-14 < (1.2 * 1e-14)
FAILED tests/test_FLEbasis2D.py::TestFLEBasis2D::testFastVDense[32-1e-14] - assert 1.2593864071972545e-14 < (1.2 * 1e-14)
FAILED tests/test_FLEbasis2D.py::TestFLEBasis2D::testFastVDense[33-1e-14] - assert 1.2064917977487149e-14 < (1.2 * 1e-14)
```

```
tests/test_fourier_correlation.py: 32 warnings
  /Users/carmichael/Work/ASPIRE-python.test_arm/src/aspire/utils/resolution_estimation.py:387: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown
    plt.show()

tests/test_image.py: 1 warning
tests/test_micrograph_source.py: 8 warnings
tests/test_simulation.py: 3 warnings
  /Users/carmichael/Work/ASPIRE-python.test_arm/src/aspire/image/image.py:691: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown
    plt.show()
```

This PR resolves all the warnings and failed tests for Python 3.8-3.11 on the arm platform (aside from the numpy.distutils deprecation warning related to an external package).