### PR TITLE
Smarter Overwrite

### DIFF
--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -17,7 +17,7 @@ from aspire.utils import (
     anorm,
     crop_pad_2d,
     grid_2d,
-    rename_file,
+    timestamp_filename,
 )
 from aspire.volume import SymmetryGroup
 
@@ -505,7 +505,7 @@ class Image:
 
         if overwrite is None and os.path.exists(mrcs_filepath):
             # If the file exists, append a timestamp to the old file and rename it
-            _ = rename_file(mrcs_filepath)
+            _ = timestamp_filename(mrcs_filepath)
 
         with mrcfile.new(mrcs_filepath, overwrite=bool(overwrite)) as mrc:
             # original input format (the image index first)

--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -17,7 +17,7 @@ from aspire.utils import (
     anorm,
     crop_pad_2d,
     grid_2d,
-    timestamp_filename,
+    rename_with_timestamp,
 )
 from aspire.volume import SymmetryGroup
 
@@ -505,7 +505,7 @@ class Image:
 
         if overwrite is None and os.path.exists(mrcs_filepath):
             # If the file exists, append a timestamp to the old file and rename it
-            _ = timestamp_filename(mrcs_filepath)
+            _ = rename_with_timestamp(mrcs_filepath)
 
         with mrcfile.new(mrcs_filepath, overwrite=bool(overwrite)) as mrc:
             # original input format (the image index first)

--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -506,8 +506,10 @@ class Image:
         if overwrite is None and os.path.exists(mrcs_filepath):
             # If the file exists, append a timestamp to the old file and rename it
             _ = rename_with_timestamp(mrcs_filepath)
+        elif overwrite is None:
+            overwrite = False
 
-        with mrcfile.new(mrcs_filepath, overwrite=bool(overwrite)) as mrc:
+        with mrcfile.new(mrcs_filepath, overwrite=overwrite) as mrc:
             # original input format (the image index first)
             mrc.set_data(self._data.astype(np.float32))
             # Note assigning voxel_size must come after `set_data`

--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -505,7 +505,7 @@ class Image:
 
         if overwrite is None and os.path.exists(mrcs_filepath):
             # If the file exists, append a timestamp to the old file and rename it
-            rename_file(mrcs_filepath)
+            _ = rename_file(mrcs_filepath)
 
         with mrcfile.new(mrcs_filepath, overwrite=bool(overwrite)) as mrc:
             # original input format (the image index first)

--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -1,6 +1,5 @@
 import logging
 import os
-from datetime import datetime
 from warnings import catch_warnings, filterwarnings, simplefilter, warn
 
 import matplotlib.pyplot as plt
@@ -13,7 +12,13 @@ import aspire.sinogram
 import aspire.volume
 from aspire.nufft import anufft, nufft
 from aspire.numeric import fft, xp
-from aspire.utils import FourierRingCorrelation, anorm, crop_pad_2d, grid_2d
+from aspire.utils import (
+    FourierRingCorrelation,
+    anorm,
+    crop_pad_2d,
+    grid_2d,
+    rename_file,
+)
 from aspire.volume import SymmetryGroup
 
 logger = logging.getLogger(__name__)
@@ -499,16 +504,8 @@ class Image:
             raise NotImplementedError("`save` is currently limited to 1D image stacks.")
 
         if overwrite is None and os.path.exists(mrcs_filepath):
-            # If the file exists, append the timestamp to the old file and rename it
-            base, ext = os.path.splitext(mrcs_filepath)
-            timestamp = datetime.now().strftime("%y%m%d_%H%M%S")
-            renamed_filepath = f"{base}_{timestamp}{ext}"
-            logger.info(
-                f"Found existing file with name {mrcs_filepath}. Renaming existing file as {renamed_filepath}."
-            )
-
-            # Rename the existing file by appending the timestamp
-            os.rename(mrcs_filepath, renamed_filepath)
+            # If the file exists, append a timestamp to the old file and rename it
+            rename_file(mrcs_filepath)
 
         with mrcfile.new(mrcs_filepath, overwrite=bool(overwrite)) as mrc:
             # original input format (the image index first)

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -28,7 +28,7 @@ from aspire.operators import (
     PowerFilter,
 )
 from aspire.storage import MrcStats, StarFile
-from aspire.utils import Rotation, grid_2d, rename_file, support_mask, trange
+from aspire.utils import Rotation, grid_2d, support_mask, timestamp_filename, trange
 from aspire.volume import IdentitySymmetryGroup, SymmetryGroup
 
 logger = logging.getLogger(__name__)
@@ -997,7 +997,7 @@ class ImageSource(ABC):
         """
         if overwrite is None and os.path.exists(starfile_filepath):
             # If the file exists, append the timestamp to the old file and rename it
-            renamed_filepath = rename_file(starfile_filepath, move=False)
+            renamed_filepath = timestamp_filename(starfile_filepath, move=False)
 
             # Retrieve original ImageSource and save with new starfile name.
             from aspire.source import RelionSource

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -1008,6 +1008,9 @@ class ImageSource(ABC):
             # Allow overwriting old files.
             overwrite = True
 
+        elif overwrite is None:
+            overwrite = False
+
         logger.info("save metadata into STAR file")
         filename_indices = self.save_metadata(
             starfile_filepath,
@@ -1021,7 +1024,7 @@ class ImageSource(ABC):
             starfile_filepath,
             filename_indices=filename_indices,
             batch_size=batch_size,
-            overwrite=bool(overwrite),
+            overwrite=overwrite,
         )
         # return some information about the saved files
         info = {"starfile": starfile_filepath, "mrcs": unique_filenames}

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -5,7 +5,6 @@ import os.path
 from abc import ABC, abstractmethod
 from collections import OrderedDict
 from collections.abc import Iterable
-from datetime import datetime
 
 import mrcfile
 import numpy as np
@@ -29,7 +28,7 @@ from aspire.operators import (
     PowerFilter,
 )
 from aspire.storage import MrcStats, StarFile
-from aspire.utils import Rotation, grid_2d, support_mask, trange
+from aspire.utils import Rotation, grid_2d, rename_file, support_mask, trange
 from aspire.volume import IdentitySymmetryGroup, SymmetryGroup
 
 logger = logging.getLogger(__name__)
@@ -998,12 +997,7 @@ class ImageSource(ABC):
         """
         if overwrite is None and os.path.exists(starfile_filepath):
             # If the file exists, append the timestamp to the old file and rename it
-            base, ext = os.path.splitext(starfile_filepath)
-            timestamp = datetime.now().strftime("%y%m%d_%H%M%S")
-            renamed_filepath = f"{base}_{timestamp}{ext}"
-            logger.info(
-                f"Found existing file with name {starfile_filepath}. Renaming existing file as {renamed_filepath}."
-            )
+            renamed_filepath = rename_file(starfile_filepath, move=False)
 
             # Retrieve original ImageSource and save with new starfile name.
             from aspire.source import RelionSource

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -28,7 +28,7 @@ from aspire.operators import (
     PowerFilter,
 )
 from aspire.storage import MrcStats, StarFile
-from aspire.utils import Rotation, grid_2d, support_mask, timestamp_filename, trange
+from aspire.utils import Rotation, grid_2d, rename_with_timestamp, support_mask, trange
 from aspire.volume import IdentitySymmetryGroup, SymmetryGroup
 
 logger = logging.getLogger(__name__)
@@ -997,7 +997,7 @@ class ImageSource(ABC):
         """
         if overwrite is None and os.path.exists(starfile_filepath):
             # If the file exists, append the timestamp to the old file and rename it
-            renamed_filepath = timestamp_filename(starfile_filepath, move=False)
+            renamed_filepath = rename_with_timestamp(starfile_filepath, move=False)
 
             # Retrieve original ImageSource and save with new starfile name.
             from aspire.source import RelionSource

--- a/src/aspire/source/micrograph.py
+++ b/src/aspire/source/micrograph.py
@@ -10,7 +10,7 @@ from aspire.image import Image
 from aspire.source import Simulation
 from aspire.source.image import _ImageAccessor
 from aspire.storage import StarFile
-from aspire.utils import Random, grid_2d
+from aspire.utils import Random, grid_2d, timestamp_filename
 from aspire.volume import Volume
 
 logger = logging.getLogger(__name__)
@@ -44,7 +44,7 @@ class MicrographSource(ABC):
         """
         return self.micrograph_count
 
-    def save(self, path, name_prefix="micrograph", overwrite=True):
+    def save(self, path, name_prefix="micrograph", overwrite=None):
         """
         Save micrographs to `path`.
 
@@ -54,10 +54,17 @@ class MicrographSource(ABC):
 
         :param path: Directory to save data.
         :param name_prefix: Optional, name prefix string for micrograph files.
-        :param overwrite: Optional, bool. Allow writing to existing directory,
-            and overwriting existing files.
+        :param overwrite: Options to control overwrite behavior (default is None):
+            - True: Overwrites the existing path if it exists.
+            - False: Raises an error if the path exists.
+            - None: Renames the old path by appending a time/date stamp.
         :return: List of saved `.mrc` files.
         """
+
+        if overwrite is None and os.path.exists(path):
+            # If the directory exists, append a timestamp to existing directory.
+            _ = timestamp_filename(path)
+            overwrite = True
 
         # Make dir if does not exist.
         Path(path).mkdir(parents=True, exist_ok=overwrite)

--- a/src/aspire/source/micrograph.py
+++ b/src/aspire/source/micrograph.py
@@ -10,7 +10,7 @@ from aspire.image import Image
 from aspire.source import Simulation
 from aspire.source.image import _ImageAccessor
 from aspire.storage import StarFile
-from aspire.utils import Random, grid_2d, timestamp_filename
+from aspire.utils import Random, grid_2d, rename_with_timestamp
 from aspire.volume import Volume
 
 logger = logging.getLogger(__name__)
@@ -63,7 +63,7 @@ class MicrographSource(ABC):
 
         if overwrite is None and os.path.exists(path):
             # If the directory exists, append a timestamp to existing directory.
-            _ = timestamp_filename(path)
+            _ = rename_with_timestamp(path)
             overwrite = True
 
         # Make dir if does not exist.

--- a/src/aspire/utils/__init__.py
+++ b/src/aspire/utils/__init__.py
@@ -28,7 +28,7 @@ from .misc import (  # isort:skip
     inverse_r,
     J_conjugate,
     powerset,
-    timestamp_filename,
+    rename_with_timestamp,
     sha256sum,
     support_mask,
     fuzzy_mask,

--- a/src/aspire/utils/__init__.py
+++ b/src/aspire/utils/__init__.py
@@ -28,7 +28,7 @@ from .misc import (  # isort:skip
     inverse_r,
     J_conjugate,
     powerset,
-    rename_file,
+    timestamp_filename,
     sha256sum,
     support_mask,
     fuzzy_mask,

--- a/src/aspire/utils/__init__.py
+++ b/src/aspire/utils/__init__.py
@@ -28,6 +28,7 @@ from .misc import (  # isort:skip
     inverse_r,
     J_conjugate,
     powerset,
+    rename_file,
     sha256sum,
     support_mask,
     fuzzy_mask,

--- a/src/aspire/utils/misc.py
+++ b/src/aspire/utils/misc.py
@@ -50,7 +50,7 @@ def importlib_path(package, resource):
     return p
 
 
-def rename_file(filepath, move=True):
+def timestamp_filename(filepath, move=True):
     """
     Rename a file by appending a timestamp to the end of the filename.
 

--- a/src/aspire/utils/misc.py
+++ b/src/aspire/utils/misc.py
@@ -5,7 +5,9 @@ Miscellaneous Utilities that have no better place (yet).
 import hashlib
 import importlib.resources
 import logging
+import os
 import sys
+from datetime import datetime
 from itertools import chain, combinations
 
 import numpy as np
@@ -46,6 +48,27 @@ def importlib_path(package, resource):
         )
 
     return p
+
+
+def rename_file(filepath, move=True):
+    """
+    Rename a file by appending a timestamp to the end of the filename.
+
+    :param filepath: Filepath to rename.
+    :param move: Option to rename the file on disk.
+
+    :return: If move=False, returns filepath with timestamp appended.
+    """
+    base, ext = os.path.splitext(filepath)
+    timestamp = datetime.now().strftime("%y%m%d_%H%M%S")
+    renamed_filepath = f"{base}_{timestamp}{ext}"
+    logger.info(f"Renaming {filepath} as {renamed_filepath}.")
+
+    # Rename the existing file by appending the timestamp.
+    if move:
+        os.rename(filepath, renamed_filepath)
+    else:
+        return renamed_filepath
 
 
 def abs2(x):

--- a/src/aspire/utils/misc.py
+++ b/src/aspire/utils/misc.py
@@ -57,7 +57,7 @@ def rename_file(filepath, move=True):
     :param filepath: Filepath to rename.
     :param move: Option to rename the file on disk.
 
-    :return: If move=False, returns filepath with timestamp appended.
+    :return: filepath with timestamp appended.
     """
     base, ext = os.path.splitext(filepath)
     timestamp = datetime.now().strftime("%y%m%d_%H%M%S")
@@ -67,8 +67,8 @@ def rename_file(filepath, move=True):
     # Rename the existing file by appending the timestamp.
     if move:
         os.rename(filepath, renamed_filepath)
-    else:
-        return renamed_filepath
+
+    return renamed_filepath
 
 
 def abs2(x):

--- a/src/aspire/utils/misc.py
+++ b/src/aspire/utils/misc.py
@@ -66,7 +66,11 @@ def timestamp_filename(filepath, move=True):
 
     # Rename the existing file by appending the timestamp.
     if move:
-        os.rename(filepath, renamed_filepath)
+        try:
+            os.rename(filepath, renamed_filepath)
+        except FileNotFoundError:
+            logger.warning(f"File '{filepath}' not found, could not rename.")
+            return None
 
     return renamed_filepath
 

--- a/src/aspire/utils/misc.py
+++ b/src/aspire/utils/misc.py
@@ -50,7 +50,7 @@ def importlib_path(package, resource):
     return p
 
 
-def timestamp_filename(filepath, move=True):
+def rename_with_timestamp(filepath, move=True):
     """
     Rename a file by appending a timestamp to the end of the filename.
 

--- a/src/aspire/volume/volume.py
+++ b/src/aspire/volume/volume.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import warnings
-from datetime import datetime
 
 import mrcfile
 import numpy as np
@@ -18,6 +17,7 @@ from aspire.utils import (
     grid_2d,
     grid_3d,
     mat_to_vec,
+    rename_file,
     vec_to_mat,
 )
 from aspire.volume import IdentitySymmetryGroup, SymmetryGroup
@@ -653,16 +653,8 @@ class Volume:
             )
 
         if overwrite is None and os.path.exists(filename):
-            # If the file exists, append the timestamp to the old file and rename it
-            base, ext = os.path.splitext(filename)
-            timestamp = datetime.now().strftime("%y%m%d_%H%M%S")
-            renamed_filepath = f"{base}_{timestamp}{ext}"
-            logger.info(
-                f"Found existing file with name {filename}. Renaming existing file as {renamed_filepath}."
-            )
-
-            # Rename the existing file by appending the timestamp
-            os.rename(filename, renamed_filepath)
+            # If the file exists, append a timestamp to the old file and rename it
+            rename_file(filename)
 
         with mrcfile.new(filename, overwrite=bool(overwrite)) as mrc:
             mrc.set_data(self._data.astype(np.float32))

--- a/src/aspire/volume/volume.py
+++ b/src/aspire/volume/volume.py
@@ -655,8 +655,10 @@ class Volume:
         if overwrite is None and os.path.exists(filename):
             # If the file exists, append a timestamp to the old file and rename it
             _ = rename_with_timestamp(filename)
+        elif overwrite is None:
+            overwrite = False
 
-        with mrcfile.new(filename, overwrite=bool(overwrite)) as mrc:
+        with mrcfile.new(filename, overwrite=overwrite) as mrc:
             mrc.set_data(self._data.astype(np.float32))
             # Note assigning voxel_size must come after `set_data`
             if self.pixel_size is not None:

--- a/src/aspire/volume/volume.py
+++ b/src/aspire/volume/volume.py
@@ -654,7 +654,7 @@ class Volume:
 
         if overwrite is None and os.path.exists(filename):
             # If the file exists, append a timestamp to the old file and rename it
-            rename_file(filename)
+            _ = rename_file(filename)
 
         with mrcfile.new(filename, overwrite=bool(overwrite)) as mrc:
             mrc.set_data(self._data.astype(np.float32))

--- a/src/aspire/volume/volume.py
+++ b/src/aspire/volume/volume.py
@@ -17,7 +17,7 @@ from aspire.utils import (
     grid_2d,
     grid_3d,
     mat_to_vec,
-    rename_file,
+    timestamp_filename,
     vec_to_mat,
 )
 from aspire.volume import IdentitySymmetryGroup, SymmetryGroup
@@ -654,7 +654,7 @@ class Volume:
 
         if overwrite is None and os.path.exists(filename):
             # If the file exists, append a timestamp to the old file and rename it
-            _ = rename_file(filename)
+            _ = timestamp_filename(filename)
 
         with mrcfile.new(filename, overwrite=bool(overwrite)) as mrc:
             mrc.set_data(self._data.astype(np.float32))

--- a/src/aspire/volume/volume.py
+++ b/src/aspire/volume/volume.py
@@ -17,7 +17,7 @@ from aspire.utils import (
     grid_2d,
     grid_3d,
     mat_to_vec,
-    timestamp_filename,
+    rename_with_timestamp,
     vec_to_mat,
 )
 from aspire.volume import IdentitySymmetryGroup, SymmetryGroup
@@ -654,7 +654,7 @@ class Volume:
 
         if overwrite is None and os.path.exists(filename):
             # If the file exists, append a timestamp to the old file and rename it
-            _ = timestamp_filename(filename)
+            _ = rename_with_timestamp(filename)
 
         with mrcfile.new(filename, overwrite=bool(overwrite)) as mrc:
             mrc.set_data(self._data.astype(np.float32))

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -392,7 +392,7 @@ def test_save_overwrite(caplog):
             im3.save(mrc_path, overwrite=None)
 
             # Check that the existing file was renamed and logged
-            assert f"Found existing file with name {mrc_path}" in caplog.text
+            assert f"Renaming {mrc_path}" in caplog.text
 
             # Find the renamed file by checking the directory contents
             renamed_file = None

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -391,9 +391,9 @@ def test_save_overwrite(caplog):
 
         # Case 3: overwrite=None (should rename the existing file and save im3 with original filename)
         # Mock datetime to return a fixed timestamp.
-        mock_timestamp = datetime(1879, 3, 14, 12, 0, 0).strftime("%y%m%d_%H%M%S")
+        mock_datetime_value = datetime(1879, 3, 14, 12, 0, 0)
         with mock.patch("aspire.utils.misc.datetime") as mock_datetime:
-            mock_datetime.now.return_value = datetime(1879, 3, 14, 12, 0, 0)
+            mock_datetime.now.return_value = mock_datetime_value
             mock_datetime.strftime = datetime.strftime
 
             with caplog.at_level(logging.INFO):
@@ -403,6 +403,7 @@ def test_save_overwrite(caplog):
                 assert f"Renaming {mrc_path}" in caplog.text
 
                 # Construct the expected renamed filename using the mock timestamp
+                mock_timestamp = mock_datetime_value.strftime("%y%m%d_%H%M%S")
                 renamed_file = f"{base}_{mock_timestamp}{ext}"
 
                 # Assert that the renamed file exists

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -360,6 +360,10 @@ def test_save_overwrite(caplog):
     - overwrite=False: Raises an error if the file exists.
     - overwrite=None: Renames the existing file and saves the new one.
     """
+    im1 = Image(np.ones((1, 8, 8), dtype=np.float32))
+    im2 = Image(2 * np.ones((1, 8, 8), dtype=np.float32))
+    im3 = Image(3 * np.ones((1, 8, 8), dtype=np.float32))
+
     # Create a tmp dir for this test output
     with tempfile.TemporaryDirectory() as tmpdir_name:
         # tmp filename
@@ -367,11 +371,9 @@ def test_save_overwrite(caplog):
         base, ext = os.path.splitext(mrc_path)
 
         # Create and save the first image
-        im1 = Image(np.ones((1, 8, 8), dtype=np.float32))
         im1.save(mrc_path, overwrite=True)
 
         # Case 1: overwrite=True (should overwrite the existing file)
-        im2 = Image(2 * np.ones((1, 8, 8), dtype=np.float32))
         im2.save(mrc_path, overwrite=True)
 
         # Load and check if im2 has overwritten im1
@@ -379,8 +381,6 @@ def test_save_overwrite(caplog):
         np.testing.assert_allclose(im2.asnumpy(), im2_loaded.asnumpy())
 
         # Case 2: overwrite=False (should raise an overwrite error)
-        im3 = Image(3 * np.ones((1, 8, 8), dtype=np.float32))
-
         with pytest.raises(
             ValueError,
             match="File '.*' already exists; set overwrite=True to overwrite it",

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -391,7 +391,7 @@ def test_save_overwrite(caplog):
 
         # Case 3: overwrite=None (should rename the existing file and save im3 with original filename)
         # Mock datetime to return a fixed timestamp.
-        mock_datetime_value = datetime(1879, 3, 14, 12, 0, 0)
+        mock_datetime_value = datetime(2024, 10, 18, 12, 0, 0)
         with mock.patch("aspire.utils.misc.datetime") as mock_datetime:
             mock_datetime.now.return_value = mock_datetime_value
             mock_datetime.strftime = datetime.strftime

--- a/tests/test_micrograph_simulation.py
+++ b/tests/test_micrograph_simulation.py
@@ -348,10 +348,7 @@ def test_save_overwrite(caplog):
         np.testing.assert_array_equal(save_paths_1, save_paths_2)
 
         # Case2: overwrite=False (should raise error)
-        with pytest.raises(
-            FileExistsError,
-            match="File exists: '.*'",
-        ):
+        with pytest.raises(FileExistsError):
             _ = mg_sim.save(path, overwrite=False)
 
         # Case 3: overwrite=None (should rename the existing directory)

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -696,6 +696,9 @@ def test_save_overwrite(caplog):
             atol=utest_tolerance(sim2.dtype),
         )
 
+        # Check that metadata is unchanged.
+        check_metadata(sim2, sim2_loaded)
+
         # Case 2: overwrite=False (should raise an overwrite error)
         with raises(
             ValueError,
@@ -726,6 +729,7 @@ def test_save_overwrite(caplog):
             sim3_loaded.images[:].asnumpy(),
             atol=utest_tolerance(sim3.dtype),
         )
+        check_metadata(sim3, sim3_loaded)
 
         # Also check that the renamed file still contains sim2's data
         sim2_loaded_renamed = RelionSource(renamed_file)
@@ -734,6 +738,23 @@ def test_save_overwrite(caplog):
             sim2_loaded_renamed.images[:].asnumpy(),
             atol=utest_tolerance(sim2.dtype),
         )
+        check_metadata(sim2, sim2_loaded_renamed)
+
+
+def check_metadata(sim_src, relion_src):
+    """
+    Helper function to test if metadata fields in a Simulation match
+    those in a RelionSource.
+    """
+    for k, v in sim_src._metadata.items():
+        try:
+            # First try allclose. Loaded metadata might be strings,
+            # so we cast to the same type as v.
+            np.testing.assert_allclose(
+                v, np.array(relion_src._metadata[k]).astype(type(v[0]))
+            )
+        except:
+            np.testing.assert_array_equal(v, relion_src._metadata[k])
 
 
 def test_mismatched_pixel_size():

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -711,7 +711,7 @@ def test_save_overwrite(caplog):
             sim3.save(starfile, overwrite=None)
 
             # Check that the existing file was renamed and logged
-            assert f"Found existing file with name {starfile}" in caplog.text
+            assert f"Renaming {starfile}" in caplog.text
 
             # Find the renamed file by checking the directory contents
             renamed_file = None

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -748,13 +748,12 @@ def check_metadata(sim_src, relion_src):
     """
     for k, v in sim_src._metadata.items():
         try:
-            # First try allclose. Loaded metadata might be strings,
-            # so we cast to the same type as v.
+            np.testing.assert_array_equal(v, relion_src._metadata[k])
+        except AssertionError:
+            # Loaded metadata might be strings so recast.
             np.testing.assert_allclose(
                 v, np.array(relion_src._metadata[k]).astype(type(v[0]))
             )
-        except:
-            np.testing.assert_array_equal(v, relion_src._metadata[k])
 
 
 def test_mismatched_pixel_size():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,7 +22,7 @@ from aspire.utils import (
     num_procs_suggestion,
     physical_core_cpu_suggestion,
     powerset,
-    timestamp_filename,
+    rename_with_timestamp,
     utest_tolerance,
     virtual_core_cpu_suggestion,
 )
@@ -115,7 +115,7 @@ def test_get_full_version_unexpected(monkeypatch):
         assert get_full_version() == __version__ + ".x"
 
 
-def test_timestamp_filename(caplog):
+def test_rename_with_timestamp(caplog):
     with tempfile.TemporaryDirectory() as tmpdir_name:
         filepath = os.path.join(tmpdir_name, "test_file.name")
         base, ext = os.path.splitext(filepath)
@@ -133,12 +133,12 @@ def test_timestamp_filename(caplog):
             mock_datetime.strftime = datetime.strftime
 
             # Case 1: move=False should return the new file name with appended timestamp.
-            renamed_file = timestamp_filename(filepath, move=False)
+            renamed_file = rename_with_timestamp(filepath, move=False)
             assert renamed_file == f"{base}_{mock_timestamp}{ext}"
 
             # Case 2: move=True (default) should rename file on disk.
             with caplog.at_level(logging.INFO):
-                renamed_file = timestamp_filename(filepath)
+                renamed_file = rename_with_timestamp(filepath)
 
                 # Check log for renaming operation.
                 assert f"Renaming {filepath} as {renamed_file}" in caplog.text
@@ -152,7 +152,7 @@ def test_timestamp_filename(caplog):
         # Case 3: Test when the file does not exist.
         non_existent_file = os.path.join(tmpdir_name, "non_existent_file.name")
         with caplog.at_level(logging.WARNING):
-            result = timestamp_filename(non_existent_file)
+            result = rename_with_timestamp(non_existent_file)
 
             # Check that None is returned since the file doesn't exist.
             assert result is None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,7 +21,7 @@ from aspire.utils import (
     num_procs_suggestion,
     physical_core_cpu_suggestion,
     powerset,
-    rename_file,
+    timestamp_filename,
     utest_tolerance,
     virtual_core_cpu_suggestion,
 )
@@ -114,7 +114,7 @@ def test_get_full_version_unexpected(monkeypatch):
         assert get_full_version() == __version__ + ".x"
 
 
-def test_rename_file():
+def test_timestamp_filename():
     with tempfile.TemporaryDirectory() as tmpdir_name:
         filepath = os.path.join(tmpdir_name, "test_file.name")
         base, ext = os.path.splitext(filepath)
@@ -124,14 +124,14 @@ def test_rename_file():
             f.write("Test file")
 
         # Case 1: move=False should return the new file name with apended timestamp.
-        renamed_file = rename_file(filepath, move=False)
+        renamed_file = timestamp_filename(filepath, move=False)
         timestamp = datetime.now().strftime("%y%m%d_%H%M")
         assert renamed_file.startswith(f"{base}_{timestamp}") and renamed_file.endswith(
             f"{ext}"
         )
 
         # Case 2: move=True (default) should rename file on disk.
-        renamed_file = rename_file(filepath)
+        renamed_file = timestamp_filename(filepath)
 
         # Check that the original file no longer exists.
         assert not os.path.exists(filepath)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -125,7 +125,7 @@ def test_timestamp_filename(caplog):
             f.write("Test file")
 
         # Mock datetime to return a fixed timestamp.
-        mock_datetime_value = datetime(1707, 4, 15, 12, 0, 0)
+        mock_datetime_value = datetime(2024, 10, 18, 12, 0, 0)
         mock_timestamp = mock_datetime_value.strftime("%y%m%d_%H%M%S")
 
         with mock.patch("aspire.utils.misc.datetime") as mock_datetime:

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -335,7 +335,7 @@ def test_save_overwrite(caplog):
             vol3.save(mrc_path, overwrite=None)
 
             # Check that the existing file was renamed and logged
-            assert f"Found existing file with name {mrc_path}" in caplog.text
+            assert f"Renaming {mrc_path}" in caplog.text
 
             # Find the renamed file by checking the directory contents
             renamed_file = None

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -2,7 +2,9 @@ import logging
 import os
 import tempfile
 import warnings
+from datetime import datetime
 from itertools import product
+from unittest import mock
 
 import numpy as np
 import pytest
@@ -331,20 +333,24 @@ def test_save_overwrite(caplog):
             vol3.save(mrc_path, overwrite=False)
 
         # Case 3: overwrite=None (should rename the existing file and save vol3 with original filename)
-        with caplog.at_level(logging.INFO):
-            vol3.save(mrc_path, overwrite=None)
+        # Mock datetime to return a fixed timestamp
+        mock_datetime_value = datetime(1768, 3, 21, 12, 0, 0)
+        with mock.patch("aspire.utils.misc.datetime") as mock_datetime:
+            mock_datetime.now.return_value = mock_datetime_value
+            mock_datetime.strftime = datetime.strftime
 
-            # Check that the existing file was renamed and logged
-            assert f"Renaming {mrc_path}" in caplog.text
+            with caplog.at_level(logging.INFO):
+                vol3.save(mrc_path, overwrite=None)
 
-            # Find the renamed file by checking the directory contents
-            renamed_file = None
-            for filename in os.listdir(tmpdir_name):
-                if filename.startswith("og_") and filename.endswith(".mrc"):
-                    renamed_file = os.path.join(tmpdir_name, filename)
-                    break
+                # Check that the existing file was renamed and logged
+                assert f"Renaming {mrc_path}" in caplog.text
 
-            assert renamed_file is not None, "Renamed file not found"
+                # Construct the expected renamed filename using the mock timestamp
+                mock_timestamp = mock_datetime_value.strftime("%y%m%d_%H%M%S")
+                renamed_file = f"{base}_{mock_timestamp}{ext}"
+
+                # Assert that the renamed file exists
+                assert os.path.exists(renamed_file), "Renamed file not found"
 
         # Load and check that vol3 was saved to the original path
         vol3_loaded = Volume.load(mrc_path)

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -334,7 +334,7 @@ def test_save_overwrite(caplog):
 
         # Case 3: overwrite=None (should rename the existing file and save vol3 with original filename)
         # Mock datetime to return a fixed timestamp
-        mock_datetime_value = datetime(1768, 3, 21, 12, 0, 0)
+        mock_datetime_value = datetime(2024, 10, 18, 12, 0, 0)
         with mock.patch("aspire.utils.misc.datetime") as mock_datetime:
             mock_datetime.now.return_value = mock_datetime_value
             mock_datetime.strftime = datetime.strftime

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -303,6 +303,10 @@ def test_save_overwrite(caplog):
     - overwrite=False: Raises an error if the file exists.
     - overwrite=None: Renames the existing file and saves the new one.
     """
+    vol1 = Volume(np.ones((1, 8, 8, 8), dtype=np.float32))
+    vol2 = Volume(2 * np.ones((1, 8, 8, 8), dtype=np.float32))
+    vol3 = Volume(3 * np.ones((1, 8, 8, 8), dtype=np.float32))
+
     # Create a tmp dir for this test output
     with tempfile.TemporaryDirectory() as tmpdir_name:
         # tmp filename
@@ -310,11 +314,9 @@ def test_save_overwrite(caplog):
         base, ext = os.path.splitext(mrc_path)
 
         # Create and save the first image
-        vol1 = Volume(np.ones((1, 8, 8, 8), dtype=np.float32))
         vol1.save(mrc_path, overwrite=True)
 
         # Case 1: overwrite=True (should overwrite the existing file)
-        vol2 = Volume(2 * np.ones((1, 8, 8, 8), dtype=np.float32))
         vol2.save(mrc_path, overwrite=True)
 
         # Load and check if vol2 has overwritten vol1
@@ -322,8 +324,6 @@ def test_save_overwrite(caplog):
         np.testing.assert_allclose(vol2.asnumpy(), vol2_loaded.asnumpy())
 
         # Case 2: overwrite=False (should raise an overwrite error)
-        vol3 = Volume(3 * np.ones((1, 8, 8, 8), dtype=np.float32))
-
         with pytest.raises(
             ValueError,
             match="File '.*' already exists; set overwrite=True to overwrite it",


### PR DESCRIPTION
Set default overwrite to rename existing files with timestamp for `Image`, `Volume`, and `ImageSource`.