### PR TITLE
PowerFilter/whiten safeguard default value

### DIFF
--- a/gallery/experiments/simulated_abinitio_pipeline.py
+++ b/gallery/experiments/simulated_abinitio_pipeline.py
@@ -54,7 +54,7 @@ noise_variance = 5e-7  # Set a target noise variance
 # ---------------
 # Start with the hi-res volume map EMDB-2660 sourced from EMDB,
 # https://www.ebi.ac.uk/emdb/EMD-2660, and dowloaded via ASPIRE's downloader utility.
-og_v = emdb_2660().astype(np.float64)
+og_v = emdb_2660()
 logger.info("Original volume map data" f" shape: {og_v.shape} dtype:{og_v.dtype}")
 
 
@@ -94,7 +94,6 @@ src = Simulation(
     vols=og_v,
     noise_adder=custom_noise,
     unique_filters=ctf_filters,
-    dtype=np.float64,
 )
 
 # Downsample

--- a/src/aspire/operators/filters.py
+++ b/src/aspire/operators/filters.py
@@ -217,6 +217,7 @@ class PowerFilter(Filter):
             eps = self._epsilon
             if eps is None:
                 eps = np.finfo(filter_vals.dtype).eps
+                eps = (100 * eps) ** (-1 / self._power)
             condition = abs(filter_vals) < eps
             num_less_eps = np.count_nonzero(condition)
             if num_less_eps > 0:

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -808,6 +808,7 @@ class ImageSource(ABC):
 
         if epsilon is None:
             epsilon = np.finfo(self.dtype).eps
+            epsilon = (100 * epsilon) ** 2
 
         logger.info("Whitening source object")
         whiten_filter = PowerFilter(noise_filter, power=-0.5, epsilon=epsilon)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -353,18 +353,19 @@ def epsilon(request):
 def test_power_filter_safeguard(dtype, epsilon, caplog):
     L = 25
     arr = np.ones((L, L), dtype=dtype)
+    power = -0.5
 
-    # Set a few values below machine epsilon.
+    # Set a few values below default safeguard.
     num_eps = 3
     eps = epsilon
     if eps is None:
-        eps = np.finfo(dtype).eps
+        eps = (100 * np.finfo(dtype).eps) ** (-1 / power)
     arr[L // 2, L // 2 : L // 2 + num_eps] = eps / 2
 
     # For negative powers, values below machine eps will be set to zero.
     filt = PowerFilter(
         filter=ArrayFilter(arr),
-        power=-0.5,
+        power=power,
         epsilon=epsilon,
     )
 


### PR DESCRIPTION
Adjust `PowerFilter` and `whiten` safeguard default values to match matlab `cryo_prewhiten` safeguard value seen [here](https://github.com/PrincetonUniversity/aspire/blob/master/projections/epsd/cryo_prewhiten.m).

Resolves the behavior mentioned in #658. In particular, the behavior seen was due to all filter values being below the safeguard threshold, thus returning a zero filter.