### PR TITLE
Propose sim amplitude/offset fix

### DIFF
--- a/src/aspire/source/simulation.py
+++ b/src/aspire/source/simulation.py
@@ -171,8 +171,13 @@ class Simulation(ImageSource):
         else:
             self.filter_indices = np.zeros(n, dtype=int)
 
+        # Initialize ImageSource values
+        # Assign the Simulation projection values with deep copy of the same.
+        # This uncouples the ImageSource and Simulation attributes
         self.offsets = offsets
+        self.sim_offsets = copy.deepcopy(self.offsets)
         self.amplitudes = amplitudes
+        self.sim_amplitudes = copy.deepcopy(self.amplitudes)
 
         self._projections_accessor = _ImageAccessor(self._projections, self.n)
         self._clean_images_accessor = _ImageAccessor(self._clean_images, self.n)
@@ -320,9 +325,11 @@ class Simulation(ImageSource):
         # apply original CTF distortion to image
         im = self._apply_sim_filters(im, indices)
 
-        im = im.shift(self.offsets[indices, :])
+        im = im.shift(self.sim_offsets[indices, :])
 
-        im *= self.amplitudes[indices].reshape(len(indices), 1, 1).astype(self.dtype)
+        im *= (
+            self.sim_amplitudes[indices].reshape(len(indices), 1, 1).astype(self.dtype)
+        )
 
         if not clean_images and self.noise_adder is not None:
             im = self.noise_adder.forward(im, indices=indices)

--- a/tests/test_anisotropic_noise.py
+++ b/tests/test_anisotropic_noise.py
@@ -29,6 +29,7 @@ class SimTestCase(TestCase):
 
         # Keep hardcoded tests passing after fixing swapped offsets.
         # See github issue #1146.
+        self.sim.sim_offsets = self.sim.offsets[:, [1, 0]]
         self.sim = self.sim.update(offsets=self.sim.offsets[:, [1, 0]])
 
     def tearDown(self):

--- a/tests/test_downsample.py
+++ b/tests/test_downsample.py
@@ -217,7 +217,7 @@ def test_downsample_offsets(dtype, res):
     n = 10
     ds_scale = 2
 
-    offsets = np.random.choice([L // 8, -L // 8], size=(n, 2))
+    offsets = np.random.choice([L // 8, -L // 8], size=(n, 2)).astype(dtype, copy=False)
     src = Simulation(
         L=L,
         n=n,
@@ -240,8 +240,8 @@ def test_downsample_offsets(dtype, res):
 
     # Check `offsets` and `sim_offsets` attributes are as expected, ie.
     # `sim_offsets` are same as original while `offsets` are scaled by downsample.
-    np.testing.assert_array_equal(src_ds.sim_offsets, src.offsets)
-    np.testing.assert_array_equal(src_ds.offsets, src.offsets / offset_scale)
+    np.testing.assert_array_equal(src_ds.sim_offsets, offsets)
+    np.testing.assert_array_equal(src_ds.offsets, offsets / offset_scale)
 
     # Check that centering works for original and downsampled images.
     np.testing.assert_allclose(

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -133,6 +133,7 @@ class SimTestCase(TestCase):
 
         # Keep hardcoded tests passing after fixing swapped offsets.
         # See github issue #1146.
+        self.sim.sim_offsets = self.sim.offsets[:, [1, 0]]
         self.sim = self.sim.update(offsets=self.sim.offsets[:, [1, 0]])
 
     def tearDown(self):


### PR DESCRIPTION
There is more to do/check here, but I think this resolves the behavior reported in #1196 and preserves the ability to set these properties upstream.

@j-c-c , can you continue working this issue (validating and creating some tests).  Also we should check for other properties that might have been missed by the same oversight in the past. (I'm thinking rotations? 😬 )

Thanks