### PR TITLE
Oriented Source Updates

### DIFF
--- a/.github/workflows/long_workflow.yml
+++ b/.github/workflows/long_workflow.yml
@@ -27,15 +27,12 @@ jobs:
         echo "WORK_DIR=${WORK_DIR}"
         echo "Stash the WORK_DIR to GitHub env so we can clean it up later."
         echo "WORK_DIR=${WORK_DIR}" >> $GITHUB_ENV
-        echo -e "ray:\n    temp_dir: ${WORK_DIR}\n" > ${WORK_DIR}/config.yaml
         echo -e "nufft:\n    backends: [finufft, pynfft]\n" >> ${WORK_DIR}/config.yaml
         echo "Log the config: ${WORK_DIR}/config.yaml"
         cat ${WORK_DIR}/config.yaml
     - name: Run
       run: |
         export OMP_NUM_THREADS=1
-        ASPIREDIR=${{ env.WORK_DIR }} python -c \
-        "import aspire; print(aspire.config['ray']['temp_dir'])"
         ASPIREDIR=${{ env.WORK_DIR }} python -m pytest -n8 -m "expensive" --durations=0
     - name: Cleanup
       run: rm -rf ${{ env.WORK_DIR }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -148,7 +148,6 @@ jobs:
         echo "WORK_DIR=${WORK_DIR}"
         echo "Stash the WORK_DIR to GitHub env so we can clean it up later."
         echo "WORK_DIR=${WORK_DIR}" >> $GITHUB_ENV
-        echo -e "ray:\n    temp_dir: ${WORK_DIR}\n" > ${WORK_DIR}/config.yaml
         echo -e "common:" >> ${WORK_DIR}/config.yaml
         echo -e "    cache_dir: ${CI_CACHE_DIR}" >> ${WORK_DIR}/config.yaml
         echo -e "    numeric: cupy" >> ${WORK_DIR}/config.yaml
@@ -161,8 +160,6 @@ jobs:
         "import aspire; print(aspire.config['common']['cache_dir']); import aspire.downloader; aspire.downloader.emdb_2660()"
     - name: Run
       run: |
-        ASPIREDIR=${{ env.WORK_DIR }} python -c \
-        "import aspire; print(aspire.config['ray']['temp_dir'])"
         ASPIREDIR=${{ env.WORK_DIR }} PYTHONWARNINGS=error python -m pytest --durations=50 --cov=aspire --cov-report=xml
     - name: Upload Coverage to CodeCov
       uses: codecov/codecov-action@v4

--- a/gallery/experiments/experimental_abinitio_pipeline_10028.py
+++ b/gallery/experiments/experimental_abinitio_pipeline_10028.py
@@ -115,7 +115,6 @@ src = src.cache()
 # you may remove this code block and associated variables.
 
 classification_src = src
-custom_averager = None
 if do_cov2d:
     # Use CWF denoising
     cwf_denoiser = DenoiserCov2D(src)
@@ -163,6 +162,7 @@ if interactive:
 logger.info("Begin Orientation Estimation")
 
 # Create a custom orientation estimation object for ``avgs``.
+# This is done to customize the ``n_theta`` value.
 orient_est = CLSync3N(avgs, n_theta=72)
 
 # Create an ``OrientedSource`` class instance that performs orientation

--- a/gallery/experiments/experimental_abinitio_pipeline_10028.py
+++ b/gallery/experiments/experimental_abinitio_pipeline_10028.py
@@ -163,7 +163,7 @@ if interactive:
 logger.info("Begin Orientation Estimation")
 
 # Create a custom orientation estimation object for ``avgs``.
-orient_est = CLSync3N(avgs, n_theta=360)
+orient_est = CLSync3N(avgs, n_theta=72)
 
 # Create an ``OrientedSource`` class instance that performs orientation
 # estimation in a lazy fashion upon request of images or rotations.

--- a/gallery/experiments/experimental_abinitio_pipeline_10028.py
+++ b/gallery/experiments/experimental_abinitio_pipeline_10028.py
@@ -142,7 +142,6 @@ avgs = DefaultClassAvgSource(
     classification_src,
     n_nbor=n_nbor,
     averager_src=src,
-    num_procs=None,  # Automatically configure parallel processing
 )
 # We'll continue our pipeline with the first `n_classes` from `avgs`.
 avgs = avgs[:n_classes]

--- a/gallery/experiments/experimental_abinitio_pipeline_10028.py
+++ b/gallery/experiments/experimental_abinitio_pipeline_10028.py
@@ -144,7 +144,7 @@ avgs = DefaultClassAvgSource(
     averager_src=src,
 )
 # We'll continue our pipeline with the first `n_classes` from `avgs`.
-avgs = avgs[:n_classes]
+avgs = avgs[:n_classes].cache()
 
 # Save off the set of class average images.
 avgs.save("experimental_10028_class_averages.star", overwrite=True)

--- a/gallery/experiments/experimental_abinitio_pipeline_10028.py
+++ b/gallery/experiments/experimental_abinitio_pipeline_10028.py
@@ -28,7 +28,7 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import numpy as np
 
-from aspire.abinitio import CLSyncVoting
+from aspire.abinitio import CLSync3N
 from aspire.denoising import DefaultClassAvgSource, DenoisedSource, DenoiserCov2D
 from aspire.noise import AnisotropicNoiseEstimator
 from aspire.reconstruction import MeanEstimator
@@ -164,7 +164,7 @@ if interactive:
 logger.info("Begin Orientation Estimation")
 
 # Create a custom orientation estimation object for ``avgs``.
-orient_est = CLSyncVoting(avgs, n_theta=72)
+orient_est = CLSync3N(avgs, n_theta=360)
 
 # Create an ``OrientedSource`` class instance that performs orientation
 # estimation in a lazy fashion upon request of images or rotations.

--- a/gallery/experiments/experimental_abinitio_pipeline_10073.py
+++ b/gallery/experiments/experimental_abinitio_pipeline_10073.py
@@ -119,7 +119,7 @@ np.save(
 )
 
 # We'll continue our pipeline with the first `n_classes` from `avgs`.
-avgs = avgs[:n_classes]
+avgs = avgs[:n_classes].cache()
 
 # Save off the set of class average images.
 avgs.save("experimental_10073_class_averages_global.star", overwrite=True)

--- a/gallery/experiments/experimental_abinitio_pipeline_10073.py
+++ b/gallery/experiments/experimental_abinitio_pipeline_10073.py
@@ -95,7 +95,7 @@ logger.info("Begin Class Averaging")
 # Build up the customized components.
 basis = FFBBasis2D(src.L, dtype=src.dtype)
 classifier = RIRClass2D(src, n_nbor=n_nbor, nn_implementation="sklearn")
-averager = BFRAverager2D(basis, src, num_procs=16)
+averager = BFRAverager2D(basis, src)
 quality_function = BandedSNRImageQualityFunction()
 class_selector = GlobalWithRepulsionClassSelector(averager, quality_function)
 

--- a/gallery/experiments/experimental_abinitio_pipeline_10073.py
+++ b/gallery/experiments/experimental_abinitio_pipeline_10073.py
@@ -30,7 +30,7 @@ from pathlib import Path
 
 import numpy as np
 
-from aspire.abinitio import CLSyncVoting
+from aspire.abinitio import CLSync3N
 from aspire.basis import FFBBasis2D
 from aspire.classification import (
     BandedSNRImageQualityFunction,
@@ -135,7 +135,7 @@ avgs.save("experimental_10073_class_averages_global.star", overwrite=True)
 logger.info("Begin Orientation Estimation")
 
 # Create a custom orientation estimation object for ``avgs``.
-orient_est = CLSyncVoting(avgs, n_theta=72)
+orient_est = CLSync3N(avgs, n_theta=360)
 
 # Create an ``OrientedSource`` class instance that performs orientation
 # estimation in a lazy fashion upon request of images or rotations.

--- a/gallery/experiments/experimental_abinitio_pipeline_10073.py
+++ b/gallery/experiments/experimental_abinitio_pipeline_10073.py
@@ -135,7 +135,7 @@ avgs.save("experimental_10073_class_averages_global.star", overwrite=True)
 logger.info("Begin Orientation Estimation")
 
 # Create a custom orientation estimation object for ``avgs``.
-orient_est = CLSync3N(avgs, n_theta=360)
+orient_est = CLSync3N(avgs, n_theta=72)
 
 # Create an ``OrientedSource`` class instance that performs orientation
 # estimation in a lazy fashion upon request of images or rotations.

--- a/gallery/experiments/experimental_abinitio_pipeline_10081.py
+++ b/gallery/experiments/experimental_abinitio_pipeline_10081.py
@@ -91,7 +91,7 @@ logger.info("Begin Class Averaging")
 
 # Now perform classification and averaging for each class.
 # Automatically configure parallel processing
-avgs = DefaultClassAvgSource(src, n_nbor=n_nbor, num_procs=None)
+avgs = DefaultClassAvgSource(src, n_nbor=n_nbor)
 
 # We'll continue our pipeline with the first ``n_classes`` from ``avgs``.
 avgs = avgs[:n_classes]

--- a/gallery/experiments/simulated_abinitio_pipeline.py
+++ b/gallery/experiments/simulated_abinitio_pipeline.py
@@ -111,6 +111,9 @@ src = src.phase_flip()
 aiso_noise_estimator = AnisotropicNoiseEstimator(src)
 src = src.whiten(aiso_noise_estimator)
 
+# Cache to memory for some speedup
+src = src.cache()
+
 # Plot the noise profile for inspection
 if interactive:
     plt.imshow(aiso_noise_estimator.filter.evaluate_grid(img_size))
@@ -119,9 +122,6 @@ if interactive:
 # Peek, what do the whitened images look like...
 if interactive:
     src.images[:10].show()
-
-# Cache to memory for some speedup
-src = src.cache()
 
 # %%
 # Optional: CWF Denoising

--- a/gallery/experiments/simulated_abinitio_pipeline.py
+++ b/gallery/experiments/simulated_abinitio_pipeline.py
@@ -66,7 +66,7 @@ def noise_function(x, y):
     # White
     f1 = noise_variance
     # Violet-ish
-    f2 = noise_variance * (x * x + y * y) / img_size * img_size
+    f2 = noise_variance * (x * x + y * y) / (img_size * img_size)
     return (alpha * f1 + beta * f2) / 2.0
 
 

--- a/gallery/experiments/simulated_abinitio_pipeline.py
+++ b/gallery/experiments/simulated_abinitio_pipeline.py
@@ -160,7 +160,7 @@ avgs = DefaultClassAvgSource(
     averager_src=src,
 )
 # We'll continue our pipeline with the first ``n_classes`` from ``avgs``.
-avgs = avgs[:n_classes]
+avgs = avgs[:n_classes].cache()
 
 if interactive:
     avgs.images[:10].show()

--- a/gallery/experiments/simulated_abinitio_pipeline.py
+++ b/gallery/experiments/simulated_abinitio_pipeline.py
@@ -158,7 +158,6 @@ avgs = DefaultClassAvgSource(
     classification_src,
     n_nbor=n_nbor,
     averager_src=src,
-    num_procs=None,  # Automatically configure parallel processing
 )
 # We'll continue our pipeline with the first ``n_classes`` from ``avgs``.
 avgs = avgs[:n_classes]

--- a/gallery/experiments/simulated_abinitio_pipeline.py
+++ b/gallery/experiments/simulated_abinitio_pipeline.py
@@ -20,7 +20,7 @@ import logging
 import matplotlib.pyplot as plt
 import numpy as np
 
-from aspire.abinitio import CLSyncVoting
+from aspire.abinitio import CLSync3N
 from aspire.denoising import DefaultClassAvgSource, DenoisedSource, DenoiserCov2D
 from aspire.downloader import emdb_2660
 from aspire.noise import AnisotropicNoiseEstimator, CustomNoiseAdder
@@ -184,7 +184,7 @@ indices = avgs.index_map  # Also available from avgs.src.selection_indices[:n_cl
 true_rotations = src.rotations[indices]
 
 # Create a custom orientation estimation object for ``avgs``.
-orient_est = CLSyncVoting(avgs, n_theta=180)
+orient_est = CLSync3N(avgs, n_theta=180)
 
 # Initialize an ``OrientedSource`` class instance that performs orientation
 # estimation in a lazy fashion upon request of images or rotations.

--- a/gallery/tutorials/configuration.py
+++ b/gallery/tutorials/configuration.py
@@ -28,16 +28,16 @@ and common patterns for overriding.
 # Items in this file will take precedence over the default configuration.
 # For other platforms, refer to the `confuse` documentation.
 #
-# As an example, suppose you want to change the ``ray`` ``temp_dir`` variable
+# As an example, suppose you want to change the ``foo_module`` ``temp_dir`` variable
 # when working on a specific machine.
 # By creating ``$HOME/.config/ASPIRE/config.yaml`` with the following contents
 # on that machine, ASPIRE's configuration utility will overload
-# the ``temp_dir`` directory from a ``/tmp/ray`` folder to ``/scratch/tmp/ray``.
+# the ``temp_dir`` directory from a ``/tmp/bar`` folder to ``/scratch/tmp/bar``.
 #
 #     .. code-block:: yaml
 #
-#       ray:
-#         temp_dir: /scratch/tmp/ray
+#       foo_module:
+#         temp_dir: /scratch/tmp/bar
 #
 
 # %%

--- a/gallery/tutorials/configuration.py
+++ b/gallery/tutorials/configuration.py
@@ -23,21 +23,24 @@ and common patterns for overriding.
 # %%
 # System Overrides
 # ----------------
-# From here we can override with a custom config file in your home dir,
-# specifically ``$HOME/.config/ASPIRE/config.yaml`` on most Linux platforms.
+# From here we can override with a persistent custom config file in
+# your home dir, specifically ``$HOME/.config/ASPIRE/config.yaml`` on
+# most Linux platforms.
 # Items in this file will take precedence over the default configuration.
 # For other platforms, refer to the `confuse` documentation.
 #
-# As an example, suppose you want to change the ``foo_module`` ``temp_dir`` variable
-# when working on a specific machine.
+# As an example, suppose you want to change the ``common`` section's
+# ``numeric`` and ``fft`` variables to enable GPU acceleration when
+# working on a specific machine.
 # By creating ``$HOME/.config/ASPIRE/config.yaml`` with the following contents
 # on that machine, ASPIRE's configuration utility will overload
-# the ``temp_dir`` directory from a ``/tmp/bar`` folder to ``/scratch/tmp/bar``.
+# the ``numeric`` and ``fft`` settings.
 #
 #     .. code-block:: yaml
 #
-#       foo_module:
-#         temp_dir: /scratch/tmp/bar
+#       common:
+#         numeric: cupy
+#         fft: cupy
 #
 
 # %%

--- a/gallery/tutorials/tutorials/class_averaging.py
+++ b/gallery/tutorials/tutorials/class_averaging.py
@@ -118,7 +118,6 @@ src.images[:10].show()
 avgs = DebugClassAvgSource(
     src=src,
     n_nbor=10,
-    num_procs=1,  # Change to "auto" if your machine has many processors
 )
 
 # %%
@@ -168,7 +167,6 @@ noisy_src.images[:10].show()
 avgs = DebugClassAvgSource(
     src=noisy_src,
     n_nbor=10,
-    num_procs=1,  # Change to "auto" if your machine has many processors
 )
 
 # %%

--- a/gallery/tutorials/tutorials/orient3d_simulation.py
+++ b/gallery/tutorials/tutorials/orient3d_simulation.py
@@ -119,9 +119,7 @@ assert mean_ang_dist < 10
 # ------------------
 
 # The ground truth offsets from the simulation can be compared to
-# those estimated by the commonlines method above as ``offs_est``.
-
-offs_sim = sim.offsets
+# those estimated by the commonlines method above.
 
 # Calculate Estimation error in pixels for each image.
 offs_diff = np.sqrt(np.sum((oriented_src.offsets - sim.offsets) ** 2, axis=1))

--- a/gallery/tutorials/tutorials/orient3d_simulation.py
+++ b/gallery/tutorials/tutorials/orient3d_simulation.py
@@ -83,15 +83,17 @@ logger.info("Get true rotation angles generated randomly by the simulation objec
 rots_true = sim.rotations
 
 # %%
-# Estimate Orientation and Rotation Angles
-# ----------------------------------------
+# Estimate Orientation
+# --------------------
 
-# Initialize an orientation estimation object and create an ``OrientedSource`` object
-# to perform viewing angle estimation. Here, because of the small image size of the
-# ``Simulation``, we customize the ``CLSyncVoting`` method to use fewer theta values
-# when searching for common-lines between pairs of images. Additionally, since we are
-# processing images with no noise, we opt not to use a ``fuzzy_mask``, an option that
-# improves common-line detection in higher noise regimes.
+# Initialize an orientation estimation object and create an
+# ``OrientedSource`` object to perform viewing angle and image offset
+# estimation. Here, because of the small image size of the
+# ``Simulation``, we customize the ``CLSyncVoting`` method to use
+# fewer theta values when searching for common-lines between pairs of
+# images. Additionally, since we are processing images with no noise,
+# we opt not to use a ``fuzzy_mask``, an option that improves
+# common-line detection in higher noise regimes.
 logger.info(
     "Estimate rotation angles and offsets using synchronization matrix and voting method."
 )

--- a/gallery/tutorials/tutorials/orient3d_simulation.py
+++ b/gallery/tutorials/tutorials/orient3d_simulation.py
@@ -92,10 +92,13 @@ rots_true = sim.rotations
 # when searching for common-lines between pairs of images. Additionally, since we are
 # processing images with no noise, we opt not to use a ``fuzzy_mask``, an option that
 # improves common-line detection in higher noise regimes.
-logger.info("Estimate rotation angles using synchronization matrix and voting method.")
+logger.info(
+    "Estimate rotation angles and offsets using synchronization matrix and voting method."
+)
 orient_est = CLSyncVoting(sim, n_theta=36, mask=False)
 oriented_src = OrientedSource(sim, orient_est)
 rots_est = oriented_src.rotations
+
 
 # %%
 # Mean Angular Distance
@@ -110,3 +113,21 @@ logger.info(
 
 # Basic Check
 assert mean_ang_dist < 10
+
+# %%
+# Offsets Estimation
+# ------------------
+
+# The ground truth offsets from the simulation can be compared to
+# those estimated by the commonlines method above as ``offs_est``.
+
+offs_sim = sim.offsets
+
+# Calculate Estimation error in pixels for each image.
+offs_diff = np.sqrt(np.sum((oriented_src.offsets - sim.offsets) ** 2, axis=1))
+
+# Calculate the mean error in pixels across all images.
+offs_err = offs_diff.mean()
+logger.info(
+    f"Mean offset error in pixels {offs_err}, approx {offs_err/img_size*100:.1f}%"
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
     "cvxpy",
     "finufft==2.3.0",
     "gemmi >= 0.6.5",
-    "grpcio >= 1.54.2",
     "joblib",
     "matplotlib >= 3.2.0",
     "mrcfile",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ dependencies = [
     "psutil",
     "pymanopt",
     "PyWavelets",
-    "ray >= 2.9.2",
     "scipy >= 1.10.0",
     "scikit-learn",
     "scikit-image",

--- a/src/aspire/abinitio/commonline_base.py
+++ b/src/aspire/abinitio/commonline_base.py
@@ -28,8 +28,8 @@ class CLOrient3D:
         full_width=6,
         max_shift=0.15,
         shift_step=1,
-        est_shifts_max_shift=None,
-        est_shift_shift_step=None,
+        offsets_max_shift=None,
+        offsets_shift_step=None,
         mask=True,
     ):
         """

--- a/src/aspire/abinitio/commonline_c2.py
+++ b/src/aspire/abinitio/commonline_c2.py
@@ -161,7 +161,7 @@ class CLSymmetryC2(CLSymmetryC3C4):
                 shifts_1d[1, i, j] = shifts[second_shift]
 
         self.clmatrix = clmatrix
-        self.shifts_1d = shifts_1d
+        self._shifts_1d = shifts_1d
 
     @staticmethod
     def _compute_correlations(a, b):
@@ -230,6 +230,8 @@ class CLSymmetryC2(CLSymmetryC3C4):
         Ris = self._estimate_inplane_rotations(vis, Rijs, Rijgs)
 
         self.rotations = Ris
+
+        return self.rotations
 
     ###########################################
     # Primary Methods                         #

--- a/src/aspire/abinitio/commonline_c3_c4.py
+++ b/src/aspire/abinitio/commonline_c3_c4.py
@@ -117,6 +117,8 @@ class CLSymmetryC3C4(CLOrient3D, SyncVotingMixin):
 
         self.rotations = Ris
 
+        return self.rotations
+
     ###########################################
     # Primary Methods                         #
     ###########################################
@@ -129,7 +131,6 @@ class CLSymmetryC3C4(CLOrient3D, SyncVotingMixin):
         logger.info(f"Estimating relative viewing directions for {self.n_img} images.")
         # Step 1: Detect a single pair of common-lines between each pair of images
         self.build_clmatrix()
-        clmatrix = self.clmatrix
 
         # Step 2: Detect self-common-lines in each image
         sclmatrix = self._self_clmatrix_c3_c4()
@@ -138,7 +139,7 @@ class CLSymmetryC3C4(CLOrient3D, SyncVotingMixin):
         Riis = self._estimate_all_Riis_c3_c4(sclmatrix)
 
         # Step 4: Calculate relative rotations
-        Rijs = self._estimate_all_Rijs_c3_c4(clmatrix)
+        Rijs = self._estimate_all_Rijs_c3_c4(self.clmatrix)
 
         # Step 5: Inner J-synchronization
         vijs, viis = self._local_J_sync_c3_c4(Rijs, Riis)

--- a/src/aspire/abinitio/commonline_sdp.py
+++ b/src/aspire/abinitio/commonline_sdp.py
@@ -33,8 +33,9 @@ class CommonlineSDP(CLOrient3D):
         S = self._construct_S(self.clmatrix)
         A, b = self._sdp_prep()
         gram = self._compute_gram_matrix(S, A, b)
-        rotations = self._deterministic_rounding(gram)
-        self.rotations = rotations
+        self.rotations = self._deterministic_rounding(gram)
+
+        return self.rotations
 
     def _construct_S(self, clmatrix):
         """

--- a/src/aspire/abinitio/commonline_sync.py
+++ b/src/aspire/abinitio/commonline_sync.py
@@ -153,9 +153,7 @@ class CLSyncVoting(CLOrient3D, SyncVotingMixin):
         rotations[:, :, 2] = r3.T
         # Make sure that we got rotations by enforcing R to be
         # a rotation (in case the error is large)
-        rotations = nearest_rotations(rotations)
-
-        self.rotations = rotations
+        self.rotations = nearest_rotations(rotations)
 
     def syncmatrix_vote(self):
         """
@@ -163,8 +161,6 @@ class CLSyncVoting(CLOrient3D, SyncVotingMixin):
 
         A pre-computed common line matrix is required as input.
         """
-        if self.clmatrix is None:
-            self.build_clmatrix()
 
         clmatrix = self.clmatrix
 

--- a/src/aspire/abinitio/commonline_sync3n.py
+++ b/src/aspire/abinitio/commonline_sync3n.py
@@ -181,6 +181,8 @@ class CLSync3N(CLOrient3D, SyncVotingMixin):
         # Yield rotations from S
         self.rotations = self._sync3n_S_to_rot(S, W)
 
+        return self.rotations
+
     #######################
     # Main Sync3N Methods #
     #######################

--- a/src/aspire/classification/averager2d.py
+++ b/src/aspire/classification/averager2d.py
@@ -1,10 +1,8 @@
 import logging
-import warnings
 from abc import ABC, abstractmethod
 
 import numpy as np
 
-from aspire import config
 from aspire.basis import Coef
 from aspire.classification.reddy_chatterji import reddy_chatterji_register
 from aspire.image import Image, ImageStacker, MeanImageStacker

--- a/src/aspire/classification/rir_class2d.py
+++ b/src/aspire/classification/rir_class2d.py
@@ -195,7 +195,7 @@ class RIRClass2D(Class2D):
             # Report some information about reflections
             logger.info(
                 f"Count reflected: {np.sum(self.reflections)}"
-                f" {100 * np.mean(self.reflections) } %"
+                f" {100 * np.mean(self.reflections)} %"
             )
 
         return self.classes, self.reflections, self.distances

--- a/src/aspire/config_default.yaml
+++ b/src/aspire/config_default.yaml
@@ -35,11 +35,3 @@ nufft:
     # NUFFT backends should be one of finufft, cufinufft, pynfft.
     # They will be attempted in order from left to right.
     backends: [cufinufft, finufft, pynfft]
-
-ray:
-    # Ray will default to a OS specific tmp dir.
-    #   By default on linux this is `/tmp/ray`.
-    # If you find your machine has a very small /tmp,
-    #   try setting `temp_dir` to `/dev/shm`
-    #   or some other fast scratch dir.
-    temp_dir: /tmp/ray

--- a/src/aspire/denoising/class_avg.py
+++ b/src/aspire/denoising/class_avg.py
@@ -391,7 +391,6 @@ class DebugClassAvgSource(ClassAvgSource):
         self,
         src,
         n_nbor=10,
-        num_procs=1,  # Change to "auto" if your machine has many processors
         classifier=None,
         class_selector=None,
         averager=None,
@@ -401,9 +400,6 @@ class DebugClassAvgSource(ClassAvgSource):
 
         :param src: Source used for image classification.
         :param n_nbor: Number of nearest neighbors. Default 10.
-        :param num_procs: Number of processors. Default of 1 runs serially.
-            `None` attempts to compute a reasonable value
-            based on available cores and memory.
         :param classifier: `Class2D` classifier instance.
             Default `None` creates `RIRClass2D`.
             See code for parameter details.
@@ -432,7 +428,6 @@ class DebugClassAvgSource(ClassAvgSource):
             averager = BFRAverager2D(
                 self._get_classifier_basis(classifier),
                 src,
-                num_procs=num_procs,
                 dtype=dtype,
             )
 
@@ -450,7 +445,6 @@ class DebugClassAvgSource(ClassAvgSource):
 def DefaultClassAvgSource(
     src,
     n_nbor=50,
-    num_procs=None,
     classifier=None,
     class_selector=None,
     averager=None,
@@ -465,9 +459,6 @@ def DefaultClassAvgSource(
 
     :param src: Source used for image classification.
     :param n_nbor: Number of nearest neighbors. Default 50.
-    :param num_procs: Number of processors. Use 1 to run serially.
-        Default `None` attempts to compute a reasonable value
-        based on available cores and memory.
     :param classifier: `Class2D` classifier instance.
         Default `None` creates `RIRClass2D`.
         See code for parameter details.
@@ -498,7 +489,6 @@ def DefaultClassAvgSource(
     return cls(
         src,
         n_nbor=n_nbor,
-        num_procs=num_procs,
         classifier=classifier,
         class_selector=class_selector,
         averager=averager,
@@ -521,7 +511,6 @@ class ClassAvgSourcev110(ClassAvgSource):
         self,
         src,
         n_nbor=50,
-        num_procs=None,
         classifier=None,
         class_selector=None,
         averager=None,
@@ -532,9 +521,6 @@ class ClassAvgSourcev110(ClassAvgSource):
 
         :param src: Source used for image classification.
         :param n_nbor: Number of nearest neighbors. Default 50.
-        :param num_procs: Number of processors. Use 1 to run serially.
-            Default `None` attempts to compute a reasonable value
-            based on available cores and memory.
         :param classifier: `Class2D` classifier instance.
             Default `None` creates `RIRClass2D`.
             See code for parameter details.
@@ -572,7 +558,6 @@ class ClassAvgSourcev110(ClassAvgSource):
             averager = BFSRAverager2D(
                 composite_basis=basis_2d,
                 src=averager_src,
-                num_procs=num_procs,
                 dtype=dtype,
             )
         elif averager_src is not None:

--- a/src/aspire/denoising/denoised_src.py
+++ b/src/aspire/denoising/denoised_src.py
@@ -46,7 +46,7 @@ class DenoisedSource(ImageSource):
 
         # check for cached images first
         if self._cached_im is not None:
-            logger.info("Loading images from cache")
+            logger.debug("Loading images from cache")
             return self.generation_pipeline.forward(
                 self._cached_im[indices, :, :], indices
             )

--- a/src/aspire/source/coordinates.py
+++ b/src/aspire/source/coordinates.py
@@ -442,7 +442,7 @@ class CoordinateSource(ImageSource, ABC):
         """
         # check for cached images first
         if self._cached_im is not None:
-            logger.info("Loading images from cache")
+            logger.debug("Loading images from cache")
             return self.generation_pipeline.forward(
                 self._cached_im[indices, :, :], indices
             )

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -9,7 +9,7 @@ from collections.abc import Iterable
 import mrcfile
 import numpy as np
 
-from aspire.abinitio import CLOrient3D, CLSyncVoting
+from aspire.abinitio import CLOrient3D, CLSync3N
 from aspire.image import Image, normalize_bg
 from aspire.image.xform import (
     Downsample,
@@ -1525,7 +1525,7 @@ class OrientedSource(IndexedSource):
 
         :param src: Source used for orientation estimation
         :param orientation_estimator: CLOrient3D subclass used for orientation estimation.
-            Default uses the CLSyncVoting method.
+            Default uses the CLSync3N method.
         """
 
         self.src = src
@@ -1549,7 +1549,7 @@ class OrientedSource(IndexedSource):
         self._oriented = False
 
         if orientation_estimator is None:
-            orientation_estimator = CLSyncVoting(src)
+            orientation_estimator = CLSync3N(src)
 
         self.orientation_estimator = orientation_estimator
         if not isinstance(self.orientation_estimator, CLOrient3D):

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -1572,13 +1572,14 @@ class OrientedSource(IndexedSource):
             return
 
         logger.info(
-            f"Estimating rotations for {self.src} using {self.orientation_estimator}."
+            f"Estimating rotations and shifts for {self.src} using {self.orientation_estimator}."
         )
-        self.orientation_estimator.estimate_rotations()
+        self.orientation_estimator.estimate()
 
         # Allow mutability to set rotations.
         self._mutable = True
         self.rotations = self.orientation_estimator.rotations
+        self.shifts = self.orientation_estimator.shifts
         self._mutable = False
 
         self._oriented = True

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -731,7 +731,7 @@ class ImageSource(ABC):
         )
 
     @_as_copy
-    def cache(self):
+    def cache(self, batch_size=512):
         """
         Computes all queued pipeline transformations and stores the
         generated images in an array.  This trades memory for fast
@@ -739,7 +739,11 @@ class ImageSource(ABC):
         queried since it avoids recomputing on-the-fly.
         """
         logger.info("Caching source images")
-        self._cached_im = self.images[:]
+        im = np.empty((len(self), self.L, self.L), self.dtype)
+        for start in trange(0, len(self), batch_size):
+            end = min(start + batch_size, len(self))
+            im[start:end] = self.images[start:end]
+        self._cached_im = Image(im)
         self.generation_pipeline.reset()
 
     @property

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -1579,7 +1579,7 @@ class OrientedSource(IndexedSource):
         # Allow mutability to set rotations.
         self._mutable = True
         self.rotations = self.orientation_estimator.rotations
-        self.shifts = self.orientation_estimator.shifts
+        self.offsets = self.orientation_estimator.shifts
         self._mutable = False
 
         self._oriented = True
@@ -1589,7 +1589,13 @@ class OrientedSource(IndexedSource):
         Remove orientation information passed in by original source.
         """
         _info_removed = False
-        rot_keys = ["_rlnAngleRot", "_rlnAngleTilt", "_rlnAnglePsi"]
+        rot_keys = [
+            "_rlnAngleRot",
+            "_rlnAngleTilt",
+            "_rlnAnglePsi",
+            "_rlnOriginX",
+            "_rlnOriginY",
+        ]
         for key in rot_keys:
             if self.has_metadata(key):
                 del self._metadata[key]
@@ -1612,6 +1618,15 @@ class OrientedSource(IndexedSource):
     def _angles(self):
         self._orient()
         return super()._angles()
+
+    @property
+    def offsets(self):
+        self._orient()
+        return super().offsets
+
+    @IndexedSource.offsets.setter
+    def offsets(self, values):
+        IndexedSource.offsets.fset(self, values)
 
     def save_metadata(self, starfile_filepath, batch_size=512, save_mode=None):
         self._orient()

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -1624,9 +1624,9 @@ class OrientedSource(IndexedSource):
         self._orient()
         return super().offsets
 
-    @IndexedSource.offsets.setter
+    @offsets.setter
     def offsets(self, values):
-        IndexedSource.offsets.fset(self, values)
+        super(__class__, self.__class__).offsets.fset(self, values)
 
     def save_metadata(self, starfile_filepath, batch_size=512, save_mode=None):
         self._orient()

--- a/src/aspire/volume/symmetry_groups.py
+++ b/src/aspire/volume/symmetry_groups.py
@@ -88,7 +88,7 @@ class SymmetryGroup(ABC):
         }
         if symmetry_type not in map_to_sym_group.keys():
             raise ValueError(
-                f"Symmetry type {symmetry_type} not supported. Try: {*map_to_sym_group.keys(),}."
+                f"Symmetry type {symmetry_type} not supported. Try: {*map_to_sym_group.keys(), }."
             )
 
         symmetry_group = map_to_sym_group[symmetry_type]

--- a/tests/test_CtfEstimate.py
+++ b/tests/test_CtfEstimate.py
@@ -84,7 +84,7 @@ def test_estimate_CTF():
                         "Defocus Angle (degrees):"
                         f"\n\tASPIRE= {defocus_ang_degrees:0.2f}*"
                         f'\n\tCTFFIND4= {TEST_OUTPUT["defocus_ang"]:0.2f}*'
-                        f'\n\tError: {abs((TEST_OUTPUT["defocus_ang"]- defocus_ang_degrees)/TEST_OUTPUT["defocus_ang"]) * 100:0.2f}%'
+                        f'\n\tError: {abs((TEST_OUTPUT["defocus_ang"] - defocus_ang_degrees)/TEST_OUTPUT["defocus_ang"]) * 100:0.2f}%'
                     )
 
                 for param in ["cs", "amplitude_contrast", "voltage", "pixel_size"]:

--- a/tests/test_averager2d.py
+++ b/tests/test_averager2d.py
@@ -1,13 +1,9 @@
-import importlib
 import logging
 import os
-import platform
-from importlib.metadata import version
 from unittest import TestCase
 
 import numpy as np
 import pytest
-from packaging.version import parse as parse_version
 
 from aspire.basis import FFBBasis2D
 from aspire.classification import (

--- a/tests/test_class_src.py
+++ b/tests/test_class_src.py
@@ -48,7 +48,6 @@ DTYPES = [
 ]
 CLS_SRCS = [DebugClassAvgSource, DefaultClassAvgSource]
 # For very small problems, it usually isn't worth running in parallel.
-NUM_PROCS = 1
 
 
 BASIS = [
@@ -175,9 +174,7 @@ def test_basic_averaging(class_sim_fixture, test_src_cls, basis, classifier):
 
     cmp_n = 5
 
-    test_src = test_src_cls(
-        src=class_sim_fixture, classifier=classifier, num_procs=NUM_PROCS
-    )
+    test_src = test_src_cls(src=class_sim_fixture, classifier=classifier)
 
     test_imgs = test_src.images[:cmp_n]
 
@@ -295,7 +292,7 @@ QUALITY_FUNCTIONS = [
 def test_global_selector(
     class_sim_fixture, cls_fixture, selector, quality_function, basis
 ):
-    averager = BFRAverager2D(basis, class_sim_fixture, num_procs=NUM_PROCS)
+    averager = BFRAverager2D(basis, class_sim_fixture)
 
     fun = quality_function()
 
@@ -336,9 +333,7 @@ def test_contrast_selector(dtype):
 
 
 def test_avg_src_starfileio(class_sim_fixture, test_src_cls, classifier):
-    src = test_src_cls(
-        src=class_sim_fixture, classifier=classifier, num_procs=NUM_PROCS
-    )
+    src = test_src_cls(src=class_sim_fixture, classifier=classifier)
 
     # Save and load the source as a STAR file.
     # Saving should force classification and selection to occur,

--- a/tests/test_oriented_source.py
+++ b/tests/test_oriented_source.py
@@ -3,7 +3,7 @@ import logging
 import numpy as np
 import pytest
 
-from aspire.abinitio import CLSymmetryC3C4, CLSymmetryCn, CLSyncVoting
+from aspire.abinitio import CLSymmetryC3C4, CLSymmetryCn, CLSync3N, CLSyncVoting
 from aspire.source import OrientedSource, Simulation
 from aspire.volume import CnSymmetricVolume
 
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 ESTIMATOR_SYMMETRY = [
     (CLSyncVoting, None),
+    (CLSync3N, None),
     (CLSymmetryC3C4, "C4"),
     pytest.param((CLSymmetryCn, "C6"), marks=pytest.mark.expensive),
 ]
@@ -80,7 +81,7 @@ def test_default_estimator(src_fixture):
 
     # Instantiate OrientedSource without providing orientation estimator.
     oriented_src = OrientedSource(og_src)
-    assert isinstance(oriented_src.orientation_estimator, CLSyncVoting)
+    assert isinstance(oriented_src.orientation_estimator, CLSync3N)
 
 
 def test_estimator_error(src_fixture):


### PR DESCRIPTION
While adding Sync3N, fixing estimated shifts, and the CUDA implementations I kept track of some updates and other issues to cleanup once those were merged.

- Fix the caching of clmatrix, rotations, shifts in OrentationEstimator (CL base)
- Wrap `estimate_rotation` and `estimate_shifts` into a single `estimate` call
-  Change default CL method to Sync3N
- Adjust experiments towards using Sync3N (retest it still TODO after 1167)
- Implement Josh suggestion to optionally separate CL detection shift params from offset estimation params

I did try changing the tutorial pipeline, but found it takes much longer to run (~10min) so maybe should leave it for now.