### PR TITLE
try excluding mkl 2024.2.2 from windows

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -77,7 +77,7 @@ jobs:
           - os: macOS-latest
             backend: accelerate
           - os: windows-2019
-            backend: default
+            backend: win64
 
     steps:
     - uses: actions/checkout@v4

--- a/environment-win64.yml
+++ b/environment-win64.yml
@@ -11,4 +11,4 @@ dependencies:
   - scipy=1.9.3
   - scikit-learn
   - scikit-image
-  - mkl!=2024.2.2  # possible regression impacts eig solver
+  - mkl!=2024.2.*  # possible regression impacts eig solver

--- a/environment-win64.yml
+++ b/environment-win64.yml
@@ -1,0 +1,14 @@
+name: 'aspire'
+
+channels:
+  - conda-forge
+  - defaults
+
+dependencies:
+  - pip
+  - python=3.9
+  - numpy=1.23.5
+  - scipy=1.9.3
+  - scikit-learn
+  - scikit-image
+  - mkl!=2024.2.2  # possible regression impacts eig solver


### PR DESCRIPTION
It appears the recently released 2024.2.2 mkl and blas libraries may have a regression on windows that impacts our CI job.

Let's try to get the win CI back on track then can investigate more as needed.

Kicking off all the conda jobs 🚀 