### PR TITLE
Another buggy windows MKL package

### DIFF
--- a/environment-win64.yml
+++ b/environment-win64.yml
@@ -11,4 +11,4 @@ dependencies:
   - scipy=1.9.3
   - scikit-learn
   - scikit-image
-  - mkl!=2024.2.*  # possible regression impacts eig solver
+  - mkl=2024.1.*  # possible regression impacts eig solver in later versions up to 2025.0


### PR DESCRIPTION
Looks like MKL 2025.0 for Win64 was released with the same sort of issues 2024.2 had.