### PR TITLE
`grid` and limited `Filter` caching

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -149,15 +149,16 @@ jobs:
         echo "Stash the WORK_DIR to GitHub env so we can clean it up later."
         echo "WORK_DIR=${WORK_DIR}" >> $GITHUB_ENV
         echo -e "common:" >> ${WORK_DIR}/config.yaml
-        echo -e "    cache_dir: ${CI_CACHE_DIR}" >> ${WORK_DIR}/config.yaml
         echo -e "    numeric: cupy" >> ${WORK_DIR}/config.yaml
         echo -e "    fft: cupy\n" >> ${WORK_DIR}/config.yaml
+        echo -e "cache:" >> ${WORK_DIR}/config.yaml
+        echo -e "    cache_dir: ${CI_CACHE_DIR}" >> ${WORK_DIR}/config.yaml
         echo "Log the config: ${WORK_DIR}/config.yaml"
         cat ${WORK_DIR}/config.yaml
     - name: Cache Data
       run: |
         ASPIREDIR=${{ env.WORK_DIR }} python -c \
-        "import aspire; print(aspire.config['common']['cache_dir']); import aspire.downloader; aspire.downloader.emdb_2660()"
+        "import aspire; print(aspire.config['cache']['cache_dir']); import aspire.downloader; aspire.downloader.emdb_2660()"
     - name: Run
       run: |
         ASPIREDIR=${{ env.WORK_DIR }} PYTHONWARNINGS=error python -m pytest --durations=50 --cov=aspire --cov-report=xml

--- a/gallery/tutorials/tutorials/data_downloader.py
+++ b/gallery/tutorials/tutorials/data_downloader.py
@@ -46,7 +46,7 @@ downloader.available_downloads()
 #
 #    .. code-block:: yaml
 #
-#      common:
+#      cache:
 #        cache_dir: /tmp/ASPIRE-data
 #
 # See the `ASPIRE Conguration

--- a/src/aspire/__init__.py
+++ b/src/aspire/__init__.py
@@ -63,8 +63,8 @@ logging.debug(
 logging.debug(f"Resolved config.yaml:\n{aspire.config.dump()}\n")
 
 # Set cache location for ASPIRE example data.
-if not config["common"]["cache_dir"].get():
-    config["common"]["cache_dir"] = pooch.os_cache("ASPIRE-data").as_posix()
+if not config["cache"]["cache_dir"].get():
+    config["cache"]["cache_dir"] = pooch.os_cache("ASPIRE-data").as_posix()
 
 # Implements some code that writes out exceptions to 'aspire.err.log'.
 if config["logging"]["log_exceptions"].get(int):

--- a/src/aspire/config_default.yaml
+++ b/src/aspire/config_default.yaml
@@ -19,7 +19,8 @@ cache:
     # In YAML `null` translates to a limit of `None` in Python,
     # which corresponds to unlimited calls.
     grid_cache_size: null
-    filter_cache_size: null
+    # Using unlimited `filter_cache_size` may cause excessive memory use.
+    filter_cache_size: 2
 
 logging:
     # Set log_dir to a relative or absolute directory

--- a/src/aspire/config_default.yaml
+++ b/src/aspire/config_default.yaml
@@ -5,6 +5,7 @@ common:
     # fft backend to use - one of pyfftw/scipy/cupy/mkl
     fft: scipy
 
+cache:
     # Set cache directory for ASPIRE example data.
     # By default the cache location will be set by pooch.os_cache(),
     # which sets cache based on operating system as follows:
@@ -12,6 +13,13 @@ common:
     # Unix: ~/.cache/<AppName> or the value of the XDG_CACHE_HOME environment variable, if defined.
     # Windows: C:\Users\<user>\AppData\Local\<AppAuthor>\<AppName>\Cache
     cache_dir: ""
+
+    # The following control runtime cache sizes for various components,
+    # where `size` is the number of cached function calls.
+    # In YAML `null` translates to a limit of `None` in Python,
+    # which corresponds to unlimited calls.
+    grid_cache_size: null
+    filter_cache_size: null
 
 logging:
     # Set log_dir to a relative or absolute directory

--- a/src/aspire/downloader/data_fetcher.py
+++ b/src/aspire/downloader/data_fetcher.py
@@ -16,7 +16,7 @@ _data_fetcher = pooch.create(
     # folder operating system dependent, set by `pooch.os_cache`.
     # Pooch uses appdirs (https://github.com/ActiveState/appdirs) to
     # select an appropriate directory for the cache on each platform.
-    path=config["common"]["cache_dir"].as_filename(),
+    path=config["cache"]["cache_dir"].as_filename(),
     # The remote data is on Zenodo, `base_url` is a required param,
     # even though we override using individual urls in the registry.
     base_url="https://zenodo.org/communities/computationalcryoem/",

--- a/src/aspire/operators/filters.py
+++ b/src/aspire/operators/filters.py
@@ -112,7 +112,7 @@ class Filter:
         """
         return ScaledFilter(self, c)
 
-    @lru_cache(maxsize=config["cache"]["filter_cache_size"].get())
+    @lru_cache(maxsize=config["cache"]["filter_cache_size"].get())  # noqa: B019
     def evaluate_grid(self, L, *args, dtype=np.float32, **kwargs):
         """
         Generates a two dimensional grid with prescribed dtype,
@@ -205,7 +205,7 @@ class PowerFilter(Filter):
     def _evaluate(self, omega):
         return self._filter.evaluate(omega) ** self._power
 
-    @lru_cache(maxsize=config["cache"]["filter_cache_size"].get())
+    @lru_cache(maxsize=config["cache"]["filter_cache_size"].get())  # noqa: B019
     def evaluate_grid(self, L, *args, dtype=np.float32, **kwargs):
         """
         Calls the provided filter's evaluate_grid method in case there is an optimization.

--- a/src/aspire/operators/filters.py
+++ b/src/aspire/operators/filters.py
@@ -205,6 +205,7 @@ class PowerFilter(Filter):
     def _evaluate(self, omega):
         return self._filter.evaluate(omega) ** self._power
 
+    @lru_cache(maxsize=config["cache"]["filter_cache_size"].get())
     def evaluate_grid(self, L, *args, dtype=np.float32, **kwargs):
         """
         Calls the provided filter's evaluate_grid method in case there is an optimization.
@@ -355,6 +356,7 @@ class ArrayFilter(Filter):
 
         return result
 
+    # No need to cache ArrayFilter
     def evaluate_grid(self, L, *args, dtype=np.float32, **kwargs):
         """
         Optimized evaluate_grid method for ArrayFilter.

--- a/src/aspire/operators/filters.py
+++ b/src/aspire/operators/filters.py
@@ -1,9 +1,11 @@
 import inspect
 import logging
+from functools import lru_cache
 
 import numpy as np
 from scipy.interpolate import RegularGridInterpolator
 
+from aspire import config
 from aspire.utils import grid_2d, voltage_to_wavelength
 
 logger = logging.getLogger(__name__)
@@ -110,6 +112,7 @@ class Filter:
         """
         return ScaledFilter(self, c)
 
+    @lru_cache(maxsize=config["cache"]["filter_cache_size"].get())
     def evaluate_grid(self, L, *args, dtype=np.float32, **kwargs):
         """
         Generates a two dimensional grid with prescribed dtype,

--- a/src/aspire/utils/coor_trans.py
+++ b/src/aspire/utils/coor_trans.py
@@ -4,6 +4,7 @@ General purpose math functions, mostly geometric in nature.
 
 import logging
 import math
+from functools import cache
 
 import numpy as np
 from numpy.linalg import norm
@@ -83,6 +84,7 @@ def _mgrid_slice(n, shifted, normalized):
     return slice(start, end, num_points)
 
 
+@cache
 def grid_1d(n, shifted=False, normalized=True, dtype=np.float32):
     """
     Generate one dimensional grid.
@@ -98,6 +100,7 @@ def grid_1d(n, shifted=False, normalized=True, dtype=np.float32):
     return {"x": x, "r": r}
 
 
+@cache
 def grid_2d(n, shifted=False, normalized=True, indexing="yx", dtype=np.float32):
     """
     Generate two dimensional grid.
@@ -124,6 +127,7 @@ def grid_2d(n, shifted=False, normalized=True, indexing="yx", dtype=np.float32):
     return {"x": x, "y": y, "phi": phi, "r": r}
 
 
+@cache
 def grid_3d(n, shifted=False, normalized=True, indexing="zyx", dtype=np.float32):
     """
     Generate three dimensional grid.

--- a/src/aspire/utils/coor_trans.py
+++ b/src/aspire/utils/coor_trans.py
@@ -4,12 +4,13 @@ General purpose math functions, mostly geometric in nature.
 
 import logging
 import math
-from functools import cache
+from functools import lru_cache
 
 import numpy as np
 from numpy.linalg import norm
 from scipy.linalg import svd
 
+from aspire import config
 from aspire.numeric import xp
 from aspire.utils.random import Random
 from aspire.utils.rotation import Rotation
@@ -84,7 +85,7 @@ def _mgrid_slice(n, shifted, normalized):
     return slice(start, end, num_points)
 
 
-@cache
+@lru_cache(maxsize=config["cache"]["grid_cache_size"].get())
 def grid_1d(n, shifted=False, normalized=True, dtype=np.float32):
     """
     Generate one dimensional grid.
@@ -100,7 +101,7 @@ def grid_1d(n, shifted=False, normalized=True, dtype=np.float32):
     return {"x": x, "r": r}
 
 
-@cache
+@lru_cache(maxsize=config["cache"]["grid_cache_size"].get())
 def grid_2d(n, shifted=False, normalized=True, indexing="yx", dtype=np.float32):
     """
     Generate two dimensional grid.
@@ -127,7 +128,7 @@ def grid_2d(n, shifted=False, normalized=True, indexing="yx", dtype=np.float32):
     return {"x": x, "y": y, "phi": phi, "r": r}
 
 
-@cache
+@lru_cache(maxsize=config["cache"]["grid_cache_size"].get())
 def grid_3d(n, shifted=False, normalized=True, indexing="zyx", dtype=np.float32):
     """
     Generate three dimensional grid.

--- a/src/aspire/utils/misc.py
+++ b/src/aspire/utils/misc.py
@@ -170,15 +170,15 @@ def gaussian_2d(size, mu=(0, 0), sigma=(1, 1), indexing="yx", dtype=np.float64):
     # Construct centered mesh
     g = grid_2d(size, shifted=False, normalized=False, indexing=indexing, dtype=dtype)
 
+    X, Y = g["x"], g["y"]
+
     if indexing == "yx":
         mu, sigma = mu[::-1], sigma[::-1]
-        g["x"], g["y"] = g["y"], g["x"]
+        X, Y = Y, X
     elif indexing != "xy":
         raise ValueError("Indexing must be `yx` or `xy`.")
 
-    p = (g["x"] - mu[0]) ** 2 / (2 * sigma[0] ** 2) + (g["y"] - mu[1]) ** 2 / (
-        2 * sigma[1] ** 2
-    )
+    p = (X - mu[0]) ** 2 / (2 * sigma[0] ** 2) + (Y - mu[1]) ** 2 / (2 * sigma[1] ** 2)
 
     return np.exp(-p).astype(dtype, copy=False)
 
@@ -216,16 +216,18 @@ def gaussian_3d(size, mu=(0, 0, 0), sigma=(1, 1, 1), indexing="zyx", dtype=np.fl
     # Construct centered mesh
     g = grid_3d(size, shifted=False, normalized=False, indexing=indexing, dtype=dtype)
 
+    X, Y, Z = g["x"], g["y"], g["z"]
+
     if indexing == "zyx":
         mu, sigma = mu[::-1], sigma[::-1]
-        g["x"], g["y"], g["z"] = g["z"], g["y"], g["x"]
+        X, Y, Z = Z, Y, X
     elif indexing != "xyz":
         raise ValueError("Indexing must be `zyx` or `xyz`.")
 
     p = (
-        (g["x"] - mu[0]) ** 2 / (2 * sigma[0] ** 2)
-        + (g["y"] - mu[1]) ** 2 / (2 * sigma[1] ** 2)
-        + (g["z"] - mu[2]) ** 2 / (2 * sigma[2] ** 2)
+        (X - mu[0]) ** 2 / (2 * sigma[0] ** 2)
+        + (Y - mu[1]) ** 2 / (2 * sigma[1] ** 2)
+        + (Z - mu[2]) ** 2 / (2 * sigma[2] ** 2)
     )
 
     return np.exp(-p).astype(dtype, copy=False)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -287,8 +287,8 @@ def test_gaussian_scalar_param():
     g_3d = gaussian_3d(L, mu_3d, sigma_3d)
     g_3d_scalar = gaussian_3d(L, mu_3d, sigma)
 
-    assert np.allclose(g_2d, g_2d_scalar)
-    assert np.allclose(g_3d, g_3d_scalar)
+    np.testing.assert_allclose(g_2d, g_2d_scalar)
+    np.testing.assert_allclose(g_3d, g_3d_scalar)
 
 
 @pytest.mark.parametrize("L", [29, 30])


### PR DESCRIPTION
This PR is considering some basic caching that is available using the standard Python library in 3.9+.  It should compliment the more sophisticated caching we do in (Basis etc) classes.

The general scheme employed here is i) to allow caching control via our configuration ii) to employ caching in a way that has minimal impact to memory footprint.

Closes #37 