### PR TITLE
Default Class Averager Updates

### DIFF
--- a/docs/source/class_source.rst
+++ b/docs/source/class_source.rst
@@ -49,8 +49,8 @@ required component and assign them here for complete control.
 
 """"""""""
 
-While that allows for full customization, two helper classes are
-provided that supply defaults as a jumping off point.  Both of these
+While that allows for full customization, helper classes are
+provided that supply defaults as a jumping off point.  These
 helper sources only require an input ``Source`` to be instantiated.
 They can still be fully customized, but they are intended to start
 with sensible defaults, so users only need to instantiate the specific
@@ -61,6 +61,7 @@ components they wish to configure.
    classDiagram
       ClassAvgSource <|-- DebugClassAvgSource
       ClassAvgSource <|-- DefaultClassAvgSource
+      ClassAvgSource <|-- LegacyClassAvgSource
       class DebugClassAvgSource{
 	 src: ImageSource
 	 classifier: RIRClass2D
@@ -68,11 +69,19 @@ components they wish to configure.
 	 averager: BFRAverager2D
 	 +images()
       }
+      class LegacyClassAvgSource{
+	 src: ImageSource
+	 classifier: RIRClass2D
+	 class_selector: GlobalVarianceClassSelector
+	 averager: BFRAverager2D
+	 +images()
+      }
       class DefaultClassAvgSource{
-	 version="0.11.0"
+	 version="0.13.2"
 	 src: ImageSource
 	 classifier: RIRClass2D
 	 class_selector: NeighborVarianceWithRepulsionClassSelector
+	 quality_function: BandedSNRImageQualityFunction
 	 averager: BFSRAverager2D
 	 +images()
       }
@@ -86,7 +95,7 @@ mappings etc.
 
 ``DefaultClassAvgSource`` applies the most sensible defaults available
 in the current ASPIRE release.  ``DefaultClassAvgSource`` takes a
-version string, such as ``0.11.0`` which will return a specific
+version string, such as ``0.13.2`` which will return a specific
 configuration.  This version should allow users to perform a similar
 experiment across releases as ASPIRE implements improved methods.
 When a version is not provided, ``DefaultClassAvgSource`` defaults to
@@ -160,6 +169,7 @@ can reduce pipeline run times by an order of magnitude.
        ClassSelector <|-- TopClassSelector
        ClassSelector <|-- RandomClassSelector
        ClassSelector <|-- NeighborVarianceClassSelector
+       ClassSelector <|-- GlobalVarianceClassSelector
        ClassSelector <|-- DistanceClassSelector
        ClassSelector o-- GreedyClassRepulsionMixin
 

--- a/gallery/experiments/experimental_abinitio_pipeline_10028.py
+++ b/gallery/experiments/experimental_abinitio_pipeline_10028.py
@@ -146,7 +146,7 @@ avgs = ClassAvgSourceLegacy(
 avgs = avgs[:n_classes].cache()
 
 # Save off the set of class average images.
-avgs.save("experimental_10028_class_averages.star", overwrite=True)
+avgs.save("experimental_10028_class_averages.star")
 
 if interactive:
     avgs.images[:10].show()

--- a/gallery/experiments/experimental_abinitio_pipeline_10028.py
+++ b/gallery/experiments/experimental_abinitio_pipeline_10028.py
@@ -29,7 +29,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from aspire.abinitio import CLSync3N
-from aspire.denoising import DefaultClassAvgSource, DenoisedSource, DenoiserCov2D
+from aspire.denoising import ClassAvgSourceLegacy, DenoisedSource, DenoiserCov2D
 from aspire.noise import AnisotropicNoiseEstimator
 from aspire.reconstruction import MeanEstimator
 from aspire.source import OrientedSource, RelionSource
@@ -137,7 +137,7 @@ logger.info("Begin Class Averaging")
 # Now perform classification and averaging for each class.
 # This also demonstrates the potential to use a different source for classification and averaging.
 
-avgs = DefaultClassAvgSource(
+avgs = ClassAvgSourceLegacy(
     classification_src,
     n_nbor=n_nbor,
     averager_src=src,

--- a/gallery/experiments/experimental_abinitio_pipeline_10028.py
+++ b/gallery/experiments/experimental_abinitio_pipeline_10028.py
@@ -29,7 +29,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from aspire.abinitio import CLSync3N
-from aspire.denoising import ClassAvgSourceLegacy, DenoisedSource, DenoiserCov2D
+from aspire.denoising import DenoisedSource, DenoiserCov2D, LegacyClassAvgSource
 from aspire.noise import AnisotropicNoiseEstimator
 from aspire.reconstruction import MeanEstimator
 from aspire.source import OrientedSource, RelionSource
@@ -137,7 +137,7 @@ logger.info("Begin Class Averaging")
 # Now perform classification and averaging for each class.
 # This also demonstrates the potential to use a different source for classification and averaging.
 
-avgs = ClassAvgSourceLegacy(
+avgs = LegacyClassAvgSource(
     classification_src,
     n_nbor=n_nbor,
     averager_src=src,

--- a/gallery/experiments/experimental_abinitio_pipeline_10073.py
+++ b/gallery/experiments/experimental_abinitio_pipeline_10073.py
@@ -122,7 +122,7 @@ np.save(
 avgs = avgs[:n_classes].cache()
 
 # Save off the set of class average images.
-avgs.save("experimental_10073_class_averages_global.star", overwrite=True)
+avgs.save("experimental_10073_class_averages_global.star")
 
 
 # %%

--- a/gallery/experiments/experimental_abinitio_pipeline_10081.py
+++ b/gallery/experiments/experimental_abinitio_pipeline_10081.py
@@ -97,7 +97,7 @@ avgs = ClassAvgSourceLegacy(src, n_nbor=n_nbor)
 avgs = avgs[:n_classes]
 
 # Save off the set of class average images.
-avgs.save("experimental_10081_class_averages.star", overwrite=True)
+avgs.save("experimental_10081_class_averages.star")
 
 # %%
 # Common Line Estimation

--- a/gallery/experiments/experimental_abinitio_pipeline_10081.py
+++ b/gallery/experiments/experimental_abinitio_pipeline_10081.py
@@ -26,7 +26,7 @@ import logging
 from pathlib import Path
 
 from aspire.abinitio import CLSymmetryC3C4
-from aspire.denoising import DefaultClassAvgSource
+from aspire.denoising import ClassAvgSourceLegacy
 from aspire.noise import AnisotropicNoiseEstimator
 from aspire.reconstruction import MeanEstimator
 from aspire.source import OrientedSource, RelionSource
@@ -91,7 +91,7 @@ logger.info("Begin Class Averaging")
 
 # Now perform classification and averaging for each class.
 # Automatically configure parallel processing
-avgs = DefaultClassAvgSource(src, n_nbor=n_nbor)
+avgs = ClassAvgSourceLegacy(src, n_nbor=n_nbor)
 
 # We'll continue our pipeline with the first ``n_classes`` from ``avgs``.
 avgs = avgs[:n_classes]

--- a/gallery/experiments/experimental_abinitio_pipeline_10081.py
+++ b/gallery/experiments/experimental_abinitio_pipeline_10081.py
@@ -26,7 +26,7 @@ import logging
 from pathlib import Path
 
 from aspire.abinitio import CLSymmetryC3C4
-from aspire.denoising import ClassAvgSourceLegacy
+from aspire.denoising import LegacyClassAvgSource
 from aspire.noise import AnisotropicNoiseEstimator
 from aspire.reconstruction import MeanEstimator
 from aspire.source import OrientedSource, RelionSource
@@ -91,7 +91,7 @@ logger.info("Begin Class Averaging")
 
 # Now perform classification and averaging for each class.
 # Automatically configure parallel processing
-avgs = ClassAvgSourceLegacy(src, n_nbor=n_nbor)
+avgs = LegacyClassAvgSource(src, n_nbor=n_nbor)
 
 # We'll continue our pipeline with the first ``n_classes`` from ``avgs``.
 avgs = avgs[:n_classes]

--- a/gallery/experiments/simulated_abinitio_pipeline.py
+++ b/gallery/experiments/simulated_abinitio_pipeline.py
@@ -166,7 +166,7 @@ if interactive:
     avgs.images[:10].show()
 
 # Save off the set of class average images.
-avgs.save("simulated_abinitio_pipeline_class_averages.star", overwrite=True)
+avgs.save("simulated_abinitio_pipeline_class_averages.star")
 
 # %%
 # Common Line Estimation

--- a/src/aspire/classification/__init__.py
+++ b/src/aspire/classification/__init__.py
@@ -16,6 +16,7 @@ from .class_selection import (
     ClassSelector,
     DistanceClassSelector,
     GlobalClassSelector,
+    GlobalVarianceClassSelector,
     GlobalWithRepulsionClassSelector,
     NeighborVarianceClassSelector,
     NeighborVarianceWithRepulsionClassSelector,

--- a/src/aspire/classification/class_selection.py
+++ b/src/aspire/classification/class_selection.py
@@ -647,3 +647,29 @@ class RampWeightedVarianceImageQualityFunction(
     """
     Computes the variance of pixels after weighting with Ramp function.
     """
+
+
+class GlobalVarianceClassSelector(GlobalClassSelector):
+    """
+    GlobalClassSelector with VarianceImageQualityFunction.
+
+    Computes per image variance for all images provided by
+    `averager`, and selects for highest variance.
+
+    Requires aligning the entire set of class averages.
+    """
+
+    def __init__(self, averager, heap_size_limit_bytes=2e9):
+        """
+        See `GlobalClassSelector` and `VarianceImageQualityFunction`
+        for additional documentation.
+
+        :param averager: An Averager2D subclass.
+        :param heap_size_limit_bytes: Max heap size in Bytes.
+            Defaults 2GB, 0 will disable.
+        """
+        super().__init__(
+            averager=averager,
+            quality_function=VarianceImageQualityFunction(),
+            heap_size_limit_bytes=heap_size_limit_bytes,
+        )

--- a/src/aspire/classification/class_selection.py
+++ b/src/aspire/classification/class_selection.py
@@ -217,6 +217,10 @@ class _HeapItem:
         :param index: Image index
         :param image: Image object
         """
+        # Numpy scalar deprecation
+        if isinstance(value, np.ndarray) and value.ndim > 0:
+            value = value.item()
+
         self.value = float(value)
         self.index = int(index)
         self.image = image
@@ -323,6 +327,10 @@ class GlobalClassSelector(ClassSelector):
     def _select(self, classes, reflections, distances):
         for i, im in enumerate(self.averager.average(classes, reflections)):
             quality_score = self._quality_function(im)
+
+            # Numpy scalar deprecation
+            if isinstance(quality_score, np.ndarray) and quality_score.ndim > 0:
+                quality_score = quality_score.item()
 
             # Assign in global quality score array
             self._quality_scores[i] = quality_score
@@ -512,7 +520,7 @@ class VarianceImageQualityFunction(ImageQualityFunction):
 
         :return: Pixel variance.
         """
-        return np.var(img)
+        return np.var(img).item()
 
 
 class BandedSNRImageQualityFunction(ImageQualityFunction):
@@ -547,7 +555,7 @@ class BandedSNRImageQualityFunction(ImageQualityFunction):
                 f"Band of ({outer_band_start}, {outer_band_end}) empty for image size {L}, adjust band boundaries."
             )
 
-        return np.var(img[center_mask]) / np.var(img[outer_mask])
+        return (np.var(img[center_mask]) / np.var(img[outer_mask])).item()
 
 
 class BandpassImageQualityFunction(ImageQualityFunction):

--- a/src/aspire/denoising/__init__.py
+++ b/src/aspire/denoising/__init__.py
@@ -1,5 +1,5 @@
 from .adaptive_support import adaptive_support
-from .class_avg import ClassAvgSource, DebugClassAvgSource, DefaultClassAvgSource
+from .class_avg import ClassAvgSource, DebugClassAvgSource, DefaultClassAvgSource, ClassAvgSourceLegacy
 
 # isort: off
 from .denoiser import Denoiser

--- a/src/aspire/denoising/__init__.py
+++ b/src/aspire/denoising/__init__.py
@@ -1,5 +1,10 @@
 from .adaptive_support import adaptive_support
-from .class_avg import ClassAvgSource, DebugClassAvgSource, DefaultClassAvgSource, ClassAvgSourceLegacy
+from .class_avg import (
+    ClassAvgSource,
+    DebugClassAvgSource,
+    DefaultClassAvgSource,
+    LegacyClassAvgSource,
+)
 
 # isort: off
 from .denoiser import Denoiser

--- a/src/aspire/denoising/class_avg.py
+++ b/src/aspire/denoising/class_avg.py
@@ -466,7 +466,7 @@ class LegacyClassAvgSource(ClassAvgSource):
         averager_src=None,
     ):
         """
-        Instantiates ClassAvgSourcev132 with the following parameters.
+        Instantiates `ClassAvgSource` with the following parameters.
 
         :param src: Source used for image classification.
         :param n_nbor: Number of nearest neighbors. Default 50.
@@ -474,14 +474,15 @@ class LegacyClassAvgSource(ClassAvgSource):
             Default `None` creates `RIRClass2D`.
             See code for parameter details.
         :param class_selector: `ClassSelector` instance.
-            Default `None` creates `NeighborVarianceWithRepulsionClassSelector`.
+            Default `None` creates `GlobalVarianceClassSelector`.
         :param averager: `Averager2D` instance.
             Default `None` ceates `BFRAverager2D` instance.
             See code for parameter details.
-        :param averager_src: Optionally explicitly assign source
-            to BFSRAverager2D during initialization.
-            Raises error when combined with an explicit `averager`
-            argument.
+        :param averager_src: Optionally explicitly assign source to
+            `BFRAverager2D` during initialization.  Allows users to
+             provide distinct sources for classification and
+             averaging.  Raises error when combined with an explicit
+             `averager` argument.
 
         :return: ClassAvgSource instance.
         """
@@ -548,18 +549,19 @@ def DefaultClassAvgSource(
         See code for parameter details.
     :param class_selector: `ClassSelector` instance.
     :param averager: `Averager2D` instance.
-    :param averager_src: Optionally explicitly assign source
-        to `averager` during initialization.
-        Raises error when combined with an explicit `averager`
-        argument.
+    :param averager_src: Optionally explicitly assign source to
+        `averager` during initialization.  Allows users to
+         provide distinct sources for classification and
+         averaging.  Raises error when combined with an explicit
+         `averager` argument.
     :param version: Optionally selects a versioned `DefaultClassAvgSource`.
         Defaults to latest available.
     :return: ClassAvgSource instance.
     """
 
     _versions = {
-        None: ClassAvgSourcev110,
-        "latest": ClassAvgSourcev110,
+        None: ClassAvgSourcev132,
+        "latest": ClassAvgSourcev132,
         "0.13.2": ClassAvgSourcev132,
         "0.11.0": ClassAvgSourcev110,
     }
@@ -611,10 +613,11 @@ class ClassAvgSourcev132(ClassAvgSource):
         :param averager: `Averager2D` instance.
             Default `None` ceates `BFRAverager2D` instance.
             See code for parameter details.
-        :param averager_src: Optionally explicitly assign source
-            to BFSRAverager2D during initialization.
-            Raises error when combined with an explicit `averager`
-            argument.
+        :param averager_src: Optionally explicitly assign source to
+            `averager` during initialization.  Allows users to
+             provide distinct sources for classification and
+             averaging.  Raises error when combined with an explicit
+             `averager` argument.
 
         :return: ClassAvgSource instance.
         """

--- a/src/aspire/denoising/class_avg.py
+++ b/src/aspire/denoising/class_avg.py
@@ -10,11 +10,11 @@ from aspire.classification import (
     BFSRAverager2D,
     Class2D,
     ClassSelector,
-    GlobalClassSelector,
+    GlobalVarianceClassSelector,
+    GlobalWithRepulsionClassSelector,
     NeighborVarianceWithRepulsionClassSelector,
     RIRClass2D,
     TopClassSelector,
-    VarianceImageQualityFunction,
 )
 from aspire.image import Image
 from aspire.source import ImageSource
@@ -445,7 +445,7 @@ class DebugClassAvgSource(ClassAvgSource):
         )
 
 
-class ClassAvgSourceLegacy(ClassAvgSource):
+class LegacyClassAvgSource(ClassAvgSource):
     """
     Source for denoised 2D images using class average methods.
 
@@ -515,7 +515,7 @@ class ClassAvgSourceLegacy(ClassAvgSource):
             )
 
         if class_selector is None:
-            class_selector = NeighborVarianceWithRepulsionClassSelector()
+            class_selector = GlobalVarianceClassSelector(averager=averager)
 
         super().__init__(
             src=src,

--- a/tests/test_class_src.py
+++ b/tests/test_class_src.py
@@ -29,6 +29,7 @@ from aspire.denoising import (
     DefaultClassAvgSource,
     LegacyClassAvgSource,
 )
+from aspire.denoising.class_avg import ClassAvgSourcev110
 from aspire.image import Image
 from aspire.source import RelionSource, Simulation
 from aspire.utils import Rotation
@@ -50,7 +51,12 @@ DTYPES = [
     np.float64,
     pytest.param(np.float32, marks=pytest.mark.expensive),
 ]
-CLS_SRCS = [DebugClassAvgSource, DefaultClassAvgSource, LegacyClassAvgSource]
+CLS_SRCS = [
+    DebugClassAvgSource,
+    DefaultClassAvgSource,
+    LegacyClassAvgSource,
+    ClassAvgSourcev110,
+]
 
 
 BASIS = [

--- a/tests/test_class_src.py
+++ b/tests/test_class_src.py
@@ -24,7 +24,11 @@ from aspire.classification import (
     VarianceImageQualityFunction,
 )
 from aspire.classification.class_selection import _HeapItem
-from aspire.denoising import DebugClassAvgSource, DefaultClassAvgSource
+from aspire.denoising import (
+    ClassAvgSourceLegacy,
+    DebugClassAvgSource,
+    DefaultClassAvgSource,
+)
 from aspire.image import Image
 from aspire.source import RelionSource, Simulation
 from aspire.utils import Rotation
@@ -46,8 +50,7 @@ DTYPES = [
     np.float64,
     pytest.param(np.float32, marks=pytest.mark.expensive),
 ]
-CLS_SRCS = [DebugClassAvgSource, DefaultClassAvgSource]
-# For very small problems, it usually isn't worth running in parallel.
+CLS_SRCS = [DebugClassAvgSource, DefaultClassAvgSource, ClassAvgSourceLegacy]
 
 
 BASIS = [

--- a/tests/test_class_src.py
+++ b/tests/test_class_src.py
@@ -25,9 +25,9 @@ from aspire.classification import (
 )
 from aspire.classification.class_selection import _HeapItem
 from aspire.denoising import (
-    ClassAvgSourceLegacy,
     DebugClassAvgSource,
     DefaultClassAvgSource,
+    LegacyClassAvgSource,
 )
 from aspire.image import Image
 from aspire.source import RelionSource, Simulation
@@ -50,7 +50,7 @@ DTYPES = [
     np.float64,
     pytest.param(np.float32, marks=pytest.mark.expensive),
 ]
-CLS_SRCS = [DebugClassAvgSource, DefaultClassAvgSource, ClassAvgSourceLegacy]
+CLS_SRCS = [DebugClassAvgSource, DefaultClassAvgSource, LegacyClassAvgSource]
 
 
 BASIS = [


### PR DESCRIPTION
As discussed in the dev meeting, this changes the `DefaultClassAvgSource` to use only brute force rotations.  Additionally I made a configuration most like what we see in legacy MATLAB paper descriptions and used in the 10028 experiment example.

- Adds `ClassAvgSourcev132` which defaults to BFR.
- Updates `DefaultClassAvgSource` towards 0.13.2
- Adds `GlobalVarianceClassSelector` class
- Adds `LegacyClassAvgSource` using the `GlobalVarianceClassSelector` with BFR.
- Updates class source documentation
- Updates experiment examples