### PR TITLE
Correct CTFFilter formula/units

### DIFF
--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -399,3 +399,36 @@ def test_array_filter_dtype_passthrough(dtype):
     filt_vals = filt.evaluate_grid(L, dtype=dtype)
 
     assert filt_vals.dtype == dtype
+
+
+def test_ctf_reference():
+    """
+    Test CTFFilter against a MATLAB reference.
+    """
+    fltr = CTFFilter(
+        pixel_size=4.56,
+        voltage=200,
+        defocus_u=10000,
+        defocus_v=15000,
+        defocus_ang=1.23,
+        Cs=2.0,
+        alpha=0.1,
+    )
+    h = fltr.evaluate_grid(5)
+
+    # Compare with MATLAB.  Note DF converted to nm
+    # >> n=5; V=200; DF1=1000; DF2=1500; theta=1.23; Cs=2.0; A=0.1; pxA=4.56;
+    # >> ref_h=cryo_CTF_Relion(n,V,DF1,DF2,theta,Cs,pxA,A)
+    ref_h = np.array(
+        [
+            [-0.6152, 0.0299, -0.5638, 0.9327, 0.9736],
+            [-0.9865, 0.2598, -0.7543, 0.9383, 0.1733],
+            [-0.1876, -0.9918, -0.1000, -0.9918, -0.1876],
+            [0.1733, 0.9383, -0.7543, 0.2598, -0.9865],
+            [0.9736, 0.9327, -0.5638, 0.0299, -0.6152],
+        ]
+    )
+
+    # Test we're within 1%.
+    #   There are minor differences in the formulas for wavelength and grids.
+    np.testing.assert_allclose(h, ref_h, rtol=0.01)


### PR DESCRIPTION
Looks like we had some errors in our CTFFilter formula.  Because this is mainly tested tautologically, multiple errors slipped by.

To confirm error wrt MATLAB and test I performed the following:

- Created a simulation data set with CTF in Python
- Saved the dataset (as a STARfile)
- Read the STARfile in MATLAB
- Ran MATLABs phaseflip
- Loaded the MATLAB result mrcs back into Python
- Compared Python phase_flip with the MATLAB result
- Compared loading the STAR file in Python then phase_flipping and compare with MATLAB result

I am considering adding the hard coded reference test of CTFFilter.evaluate_grid (say at 5px) so this is less likely to happen again.  While I prefer less hard coded tests, clearly testing our formula against our own formula is not enough 😇 .  Can discuss other options at our next dev meeting.