### PR TITLE
Legacy Isotropic Whitening

### DIFF
--- a/gallery/tutorials/tutorials/cov3d_simulation.py
+++ b/gallery/tutorials/tutorials/cov3d_simulation.py
@@ -56,7 +56,7 @@ num_vols = sim.C
 basis = FBBasis3D(img_size)
 
 # Estimate the noise variance. This is needed for the covariance estimation step below.
-noise_estimator = WhiteNoiseEstimator(sim, batchSize=500)
+noise_estimator = WhiteNoiseEstimator(sim, batch_size=500)
 noise_variance = noise_estimator.estimate()
 print(f"Noise Variance = {noise_variance}")
 

--- a/src/aspire/commands/cov3d.py
+++ b/src/aspire/commands/cov3d.py
@@ -55,7 +55,7 @@ def cov3d(
     mean_estimator = MeanEstimator(source, basis, batch_size=8192)
     mean_est = mean_estimator.estimate()
 
-    noise_estimator = WhiteNoiseEstimator(source, batchSize=500)
+    noise_estimator = WhiteNoiseEstimator(source, batch_size=500)
     # Estimate the noise variance. This is needed for the covariance estimation step below.
     noise_variance = noise_estimator.estimate()
     logger.info(f"Noise Variance = {noise_variance}")

--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -473,7 +473,7 @@ class Image:
             if L % 2 == 1:
                 pp[k - j - 1 : k + j, k - j - 1 : k + j] = xp.asarray(proj)
             else:
-                pp[k - j - 2 : k + j, k - j - 1 : k + j - 1] = xp.asarray(proj)
+                pp[k - j - 1 : k + j - 1, k - j - 1 : k + j - 1] = xp.asarray(proj)
 
             # Take the Fourier Transform of the padded image.
             fp = fft.centered_fft2(pp)

--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -426,6 +426,7 @@ class Image:
         the instance `dtype`.
 
         :param psd: PSD as computed by `LegacyNoiseEstimator`.
+            `psd` in this case is shape (2 * self.src.L - 1, 2 * self.src.L - 1).
         :param delta: Threshold used to determine which frequencies to whiten
             and which to set to zero. By default all `sqrt(psd)` values
             less than `delta` are zeroed out in the whitening filter.
@@ -435,6 +436,11 @@ class Image:
         L_half = L // 2
         K = psd.shape[-1]
         k = int(np.ceil(K / 2))
+
+        # Check PSD
+        shp = (2 * L - 1, 2 * L - 1)
+        if psd.shape != shp:
+            raise RuntimeError(f"Incorrect PSD shape {psd.shape}, expectect {shp}.")
 
         # Create result array
         res = np.empty((n, L, L), dtype=self.dtype)

--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -445,13 +445,13 @@ class Image:
         fltr = fltr / xp.linalg.norm(fltr)
 
         # Error checking
-        if (err := xp.linalg.norm(fltr.imag)) < 10 * delta:
+        if (err := xp.linalg.norm(fltr.imag)) > 10 * delta:
             raise RuntimeError(
                 f"Whitening filter has non trivial imaginary component {err}."
             )
         err_ud = xp.linalg.norm(fltr - xp.flipud(fltr))
         err_lr = xp.linalg.norm(fltr - xp.fliplr(fltr))
-        if (err_ud < 10 * delta) or (err_lr < 10 * delta):
+        if (err_ud > 10 * delta) or (err_lr > 10 * delta):
             raise RuntimeError(
                 f"Whitening filter has non trivial symmetry lr {err_lr}, ud {err_ud}."
             )

--- a/src/aspire/image/xform.py
+++ b/src/aspire/image/xform.py
@@ -223,10 +223,10 @@ class LegacyWhiten(Xform):
         """
         Initialize LegacyWhiten Xform.
 
-        :param psd: PSD (as computed by LegacyNoiseEstimator)
+        :param psd: PSD (as computed by LegacyNoiseEstimator).
         :param delta: Threshold used to determine which frequencies to whiten
-            and which to set to zero. By default all sqrt(PSD) values in the `noise_estimate`
-            less than eps(self.dtype) are zeroed out in the whitening filter.
+            and which to set to zero. By default all `sqrt(psd)` values
+            less than `delta` are zeroed out in the whitening filter.
         """
 
         self.psd = psd
@@ -236,6 +236,8 @@ class LegacyWhiten(Xform):
     def _forward(self, im, indices):
         """
         Apply the legacy MATLAB whitening transformation to `im`.
+
+        The tranform is applied to all of `im`, `indices` are unused.
         """
         return im.legacy_whiten(self.psd, self.delta)
 

--- a/src/aspire/image/xform.py
+++ b/src/aspire/image/xform.py
@@ -214,6 +214,35 @@ class Downsample(LinearXform):
         return f"Downsample (Resolution {self.resolution})"
 
 
+class LegacyWhiten(Xform):
+    """
+    A Xform that implements MATLAB legacy whitening.
+    """
+
+    def __init__(self, psd, delta):
+        """
+        Initialize LegacyWhiten Xform.
+
+        :param psd: PSD (as computed by LegacyNoiseEstimator)
+        :param delta: Threshold used to determine which frequencies to whiten
+            and which to set to zero. By default all sqrt(PSD) values in the `noise_estimate`
+            less than eps(self.dtype) are zeroed out in the whitening filter.
+        """
+
+        self.psd = psd
+        self.delta = delta
+        super().__init__()
+
+    def _forward(self, im, indices):
+        """
+        Apply the legacy MATLAB whitening transformation to `im`.
+        """
+        return im.legacy_whiten(self.psd, self.delta)
+
+    def __str__(self):
+        return "Legacy Whitening Xform."
+
+
 class FilterXform(SymmetricXform):
     """
     A `Xform` that applies a single `Filter` object to a stack of 2D images (as an Image object).

--- a/src/aspire/noise/__init__.py
+++ b/src/aspire/noise/__init__.py
@@ -2,6 +2,7 @@ from .noise import (
     AnisotropicNoiseEstimator,
     BlueNoiseAdder,
     CustomNoiseAdder,
+    IsotropicNoiseEstimator,
     NoiseAdder,
     NoiseEstimator,
     PinkNoiseAdder,

--- a/src/aspire/noise/__init__.py
+++ b/src/aspire/noise/__init__.py
@@ -2,7 +2,7 @@ from .noise import (
     AnisotropicNoiseEstimator,
     BlueNoiseAdder,
     CustomNoiseAdder,
-    IsotropicNoiseEstimator,
+    LegacyNoiseEstimator,
     NoiseAdder,
     NoiseEstimator,
     PinkNoiseAdder,

--- a/src/aspire/noise/noise.py
+++ b/src/aspire/noise/noise.py
@@ -409,7 +409,7 @@ class LegacyNoiseEstimator(NoiseEstimator):
         )
         max_d_pixels = round(self.max_d * self.src.L)
 
-        psd = self.estimate_power_spectrum_distribution_2d(
+        psd = self._estimate_power_spectrum_distribution_2d(
             self.src.images,
             samples_idx,
             max_d_pixels,
@@ -419,7 +419,7 @@ class LegacyNoiseEstimator(NoiseEstimator):
         return psd
 
     @staticmethod
-    def estimate_power_spectrum_distribution_1d(
+    def _estimate_power_spectrum_distribution_1d(
         images, samples_idx, max_d=None, batch_size=512
     ):
         """
@@ -538,7 +538,7 @@ class LegacyNoiseEstimator(NoiseEstimator):
         return R, x, cnt
 
     @staticmethod
-    def estimate_power_spectrum_distribution_2d(
+    def _estimate_power_spectrum_distribution_2d(
         images, samples_idx, max_d=None, batch_size=512
     ):
         """
@@ -576,7 +576,7 @@ class LegacyNoiseEstimator(NoiseEstimator):
             )
         max_d = int(min(max_d, L - 1))
 
-        R, x, _ = LegacyNoiseEstimator.estimate_power_spectrum_distribution_1d(
+        R, x, _ = LegacyNoiseEstimator._estimate_power_spectrum_distribution_1d(
             images=images, samples_idx=samples_idx, max_d=max_d, batch_size=batch_size
         )
         _R = xp.asarray(R)  # Migrate to GPU for assignments below

--- a/src/aspire/noise/noise.py
+++ b/src/aspire/noise/noise.py
@@ -13,7 +13,7 @@ from aspire.operators import (
     PowerFilter,
     ScalarFilter,
 )
-from aspire.utils import grid_2d, randn, trange
+from aspire.utils import gaussian_window, grid_2d, randn, trange
 
 logger = logging.getLogger(__name__)
 
@@ -488,22 +488,6 @@ class IsotropicNoiseEstimator(NoiseEstimator):
         return R, x, cnt
 
     @staticmethod
-    def gwindow(L, max_d, alpha=3.0):
-        """
-        Create a 2D gaussian window used for 2D power spectrum estimation.
-
-        Given `L` retuns a `(2L-1, 2L-1)` Gaussian window where
-        `max_d` is the width of the Gaussian and `alpha` is the
-        reciprical of the standard deviation of the Gaussian window.
-        See Harris 78.
-        """
-
-        X, Y = np.mgrid[-(L - 1) : L, -(L - 1) : L]  # -(L-1) to (L-1) inclusive
-        W = np.exp(-alpha * (X**2 + Y**2) / (2 * max_d**2))
-
-        return W
-
-    @staticmethod
     def epsdS(images, samples_idx, max_d=None):
         """
         Estimate the 2D isotropic power spectrum of `images`.
@@ -543,7 +527,7 @@ class IsotropicNoiseEstimator(NoiseEstimator):
         # Window te 2D autocorrelation and Fourier transform it to get the power
         # spectrum. Always use the Gaussian window, as it has positive Fourier
         # transform.
-        w = IsotropicNoiseEstimator.gwindow(L, max_d)
+        w = gaussian_window(L, max_d)
         P2 = fft.centered_fft2(R2 * w)
         if (err := np.linalg.norm(P2.imag) / np.linalg.norm(P2)) > 1e-12:
             logger.warning(f"Large imaginary components in P2 {err}.")

--- a/src/aspire/noise/noise.py
+++ b/src/aspire/noise/noise.py
@@ -363,7 +363,9 @@ class LegacyNoiseEstimator(NoiseEstimator):
 
     def __init__(self, src, bg_radius=None, max_d=None):
         """
-        Given an `ImageSource`, constructs
+        Given an `ImageSource`, prepares for estimation of noise spectrum.
+
+        Estimate is delayed and computed on first access of `filter` attribute.
 
         :param src: A `ImageSource` object.
         :param bg_radius: The radius of the disk whose complement is used to estimate the noise.

--- a/src/aspire/noise/noise.py
+++ b/src/aspire/noise/noise.py
@@ -497,7 +497,7 @@ class LegacyNoiseEstimator(NoiseEstimator):
         ):
             end = min(n_img, start + batch_size)
             count = end - start
-            # Mask off unused pixels
+            # Pack masked `sample_idx` pixels from `images` batch into `samples`
             samples[:count, samples_idx] = images[start:end].asnumpy()[:, samples_idx]
             # Optimization note: We could also compute the noise
             # energy estimate used later at this time to avoid looping

--- a/src/aspire/noise/noise.py
+++ b/src/aspire/noise/noise.py
@@ -401,7 +401,9 @@ class LegacyNoiseEstimator(NoiseEstimator):
         :return: The estimated noise variance of the images in the Source used to create this estimator.
         """
         # Setup parameters
-        samples_idx = grid_2d(self.src.L, normalized=True)["r"] >= self.bg_radius
+        samples_idx = grid_2d(self.src.L, normalized=False)["r"] >= (
+            self.bg_radius * self.src.L
+        )
         max_d_pixels = round(self.max_d * self.src.L)
 
         psd = self.epsdS(self.src.images, samples_idx, max_d_pixels)[0]

--- a/src/aspire/noise/noise.py
+++ b/src/aspire/noise/noise.py
@@ -488,17 +488,10 @@ class LegacyNoiseEstimator(NoiseEstimator):
         fmask_padded = fft.rfft2(mask_padded[0])
         n_mask_pairs = fft.irfft2(fmask_padded * fmask_padded.conj(), s=mask_padded.shape[1:])
         n_mask_pairs = n_mask_pairs[: max_d + 1, : max_d + 1]  # crop
-        breakpoint()
         n_mask_pairs = xp.round(n_mask_pairs)
-
-        # Values of isotropic autocorrelation function
-        # R[i] is value of ACF at distance x[i]
-        R = xp.zeros(len(corrs))
 
         samples = xp.zeros((batch_size, L, L))
         mask_padded[0, :, :] = 0  # reset mask_padded
-        corrs = corrs.flatten()
-        corrcount = corrcount.flatten()
         for start in trange(
             0, n_img, batch_size, desc="Processing image autocorrelations"
         ):
@@ -527,6 +520,8 @@ class LegacyNoiseEstimator(NoiseEstimator):
                 corrs[idx] = corrs[idx] + s[d]
                 corrcount[idx] = corrcount[idx] + _n_mask_pairs[d]
 
+        # Values of isotropic autocorrelation function
+        # R[i] is value of ACF at distance x[i]
         # Remove distances which had no samples
         idx = xp.where(corrcount != 0)
         R = corrs[idx] / corrcount[idx]

--- a/src/aspire/noise/noise.py
+++ b/src/aspire/noise/noise.py
@@ -376,8 +376,7 @@ class IsotropicNoiseEstimator(NoiseEstimator):
         :return: The estimated noise variance of the images in the Source used to create this estimator.
         TODO: How's this initial estimate of variance different from the 'estimate' method?
         """
-
-        return noise_psd_est
+        pass
 
     @staticmethod
     def epsdR(images, samples_idx, max_d=None):
@@ -408,8 +407,8 @@ class IsotropicNoiseEstimator(NoiseEstimator):
         # Compute distances
         # Note grid_2d['r'] is not used because we always want zero centered integer grid,
         #   yielding integer dists (radius**2) values.
-        J, I = np.mgrid[0 : max_d + 1, 0 : max_d + 1]
-        dists = I * I + J * J
+        X, Y = np.mgrid[0 : max_d + 1, 0 : max_d + 1]
+        dists = X * X + Y * Y
         dsquare = np.sort(np.unique(dists[dists <= max_d**2]))
         x = np.sqrt(dsquare)  # actual distance
 
@@ -517,8 +516,8 @@ class IsotropicNoiseEstimator(NoiseEstimator):
         # power spectrum.
         R2 = np.zeros((2 * L - 1, 2 * L - 1), dtype=np.float64)
 
-        J, I = np.mgrid[-L + 1 : L, -L + 1 : L]
-        dists2 = I * I + J * J
+        X, Y = np.mgrid[-L + 1 : L, -L + 1 : L]
+        dists2 = X * X + Y * Y
         dsquare2 = np.sort(np.unique(dists2[dists2 <= max_d**2]))
         for i, d in enumerate(dsquare2):
             idx = dists2 == d

--- a/src/aspire/noise/noise.py
+++ b/src/aspire/noise/noise.py
@@ -485,7 +485,7 @@ class LegacyNoiseEstimator(NoiseEstimator):
             # energy estimate used later at this time to avoid looping
             # over images twice.
 
-            # Compute non-preiodic autocorrelation
+            # Compute non-periodic autocorrelation
             tmp[:L, :L] = samples  # pad
             ftmp = fft.fft2(tmp)
             # MATLAB code internally detects conj sym and implicitly casts,

--- a/src/aspire/noise/noise.py
+++ b/src/aspire/noise/noise.py
@@ -457,23 +457,23 @@ class LegacyNoiseEstimator(NoiseEstimator):
         # Note grid_2d['r'] is not used because we want an integer grid directly;
         #   yields integer dists (radius**2) values.
         X, Y = xp.mgrid[0 : max_d + 1, 0 : max_d + 1]
-        dists = X * X + Y * Y
-        dsquare = xp.sort(xp.unique(dists[dists <= max_d**2]))
-        x = xp.sqrt(dsquare)  # actual distances
+        dsquare = X * X + Y * Y
+        uniq_dsquare = xp.sort(xp.unique(dsquare[dsquare <= max_d**2]))
+        x = xp.sqrt(uniq_dsquare)  # actual distances
 
         # corrs[i] is the sum of all x[j]x[j+d] where d = x[i]
-        corrs = xp.zeros_like(dsquare, dtype=np.float64)
+        corrs = xp.zeros_like(uniq_dsquare, dtype=np.float64)
         # corrcount[i] is the number of pairs summed in corr[i]
-        corrcount = xp.zeros_like(dsquare, dtype=np.int64)
+        corrcount = xp.zeros_like(uniq_dsquare, dtype=np.int64)
 
-        # distmap maps [i,j] to k where dsquare[k] = i**2 + j**2.
+        # distmap maps [i,j] to k where uniq_dsquare[k] = i**2 + j**2.
         #   -1 indicates distance is larger than max_d
-        distmap = xp.full(shape=dists.shape, fill_value=-1)
+        distmap = xp.full(shape=dsquare.shape, fill_value=-1)
 
         # This differs from the MATLAB code, avoids `bisect`.
-        for i, d in enumerate(dsquare):
-            inds = dists == d  # locations having distance `d`
-            distmap[inds] = i  # assign index into dsquare `i`
+        for i, d in enumerate(uniq_dsquare):
+            inds = dsquare == d  # locations having distance `d`
+            distmap[inds] = i  # assign index into uniq_dsquare `i`
         # From here on, distmap will be accessed with flat indices
         distmap = distmap.flatten()
         valid_dists = xp.argwhere(distmap != -1)
@@ -589,10 +589,10 @@ class LegacyNoiseEstimator(NoiseEstimator):
         R2 = xp.zeros((2 * L - 1, 2 * L - 1), dtype=np.float64)
 
         X, Y = xp.mgrid[-L + 1 : L, -L + 1 : L]
-        dists2 = X * X + Y * Y
-        dsquare2 = xp.sort(xp.unique(dists2[dists2 <= max_d**2]))
-        for i, d in enumerate(dsquare2):
-            idx = dists2 == d
+        dists = X * X + Y * Y
+        uniq_dsquare = xp.sort(xp.unique(dists[dists <= max_d**2]))
+        for i, d in enumerate(uniq_dsquare):
+            idx = dists == d
             R2[idx] = _R[i]
 
         # Window the 2D autocorrelation and Fourier transform it to get the power

--- a/src/aspire/noise/noise.py
+++ b/src/aspire/noise/noise.py
@@ -401,7 +401,7 @@ class LegacyNoiseEstimator(NoiseEstimator):
         :return: The estimated noise variance of the images in the Source used to create this estimator.
         """
         # Setup parameters
-        samples_idx = grid_2d(self.src.L, normalized=False)["r"] >= (
+        samples_idx = grid_2d(self.src.L, normalized=False, shifted=True)["r"] >= (
             self.bg_radius * self.src.L
         )
         max_d_pixels = round(self.max_d * self.src.L)

--- a/src/aspire/noise/noise.py
+++ b/src/aspire/noise/noise.py
@@ -227,7 +227,7 @@ class NoiseEstimator:
     Noise Estimator base class.
     """
 
-    def __init__(self, src, bgRadius=1, batchSize=512):
+    def __init__(self, src, bgRadius=1, batch_size=512):
         """
         Any additional args/kwargs are passed on to the Source's 'images' method
 
@@ -235,12 +235,12 @@ class NoiseEstimator:
         :param bgRadius: The radius of the disk whose complement is used to estimate the noise.
             Radius is relative proportion, where `1` represents
             the radius of disc inscribing a `(src.L, src.L)` image.
-        :param batchSize:  The size of the batches in which to compute the variance estimate.
+        :param batch_size:  The size of the batches in which to compute the variance estimate.
         """
         self.src = src
         self.dtype = self.src.dtype
         self.bgRadius = bgRadius
-        self.batchSize = batchSize
+        self.batch_size = batch_size
 
     @cached_property
     def filter(self):
@@ -283,7 +283,7 @@ class WhiteNoiseEstimator(NoiseEstimator):
         """
         :return: The estimated noise power spectral distribution (PSD) of the images in the form of a filter object.
         """
-        logger.info(f"Determining Noise variance in batches of {self.batchSize}")
+        logger.info(f"Determining Noise variance in batches of {self.batch_size}")
         noise_variance = self._estimate_noise_variance()
         logger.info(f"Noise variance = {noise_variance}")
         return ScalarFilter(dim=2, value=noise_variance)
@@ -299,8 +299,8 @@ class WhiteNoiseEstimator(NoiseEstimator):
 
         first_moment = 0
         second_moment = 0
-        for i in trange(0, self.src.n, self.batchSize):
-            images = self.src.images[i : i + self.batchSize].asnumpy()
+        for i in trange(0, self.src.n, self.batch_size):
+            images = self.src.images[i : i + self.batch_size].asnumpy()
             images_masked = images * mask
 
             _denominator = self.src.n * np.sum(mask)
@@ -341,8 +341,8 @@ class AnisotropicNoiseEstimator(NoiseEstimator):
 
         mean_est = 0
         noise_psd_est = np.zeros((self.src.L, self.src.L)).astype(self.src.dtype)
-        for i in trange(0, self.src.n, self.batchSize):
-            images = self.src.images[i : i + self.batchSize].asnumpy()
+        for i in trange(0, self.src.n, self.batch_size):
+            images = self.src.images[i : i + self.batch_size].asnumpy()
             images_masked = images * mask
 
             _denominator = self.src.n * np.sum(mask)
@@ -377,7 +377,7 @@ class LegacyNoiseEstimator(NoiseEstimator):
         if bgRadius is None:
             bgRadius = (np.floor(src.L / 2) - 1) / src.L
 
-        super().__init__(src=src, bgRadius=bgRadius, batchSize=1)
+        super().__init__(src=src, bgRadius=bgRadius, batch_size=1)
 
         self.max_d = max_d
         if self.max_d is None:

--- a/src/aspire/noise/noise.py
+++ b/src/aspire/noise/noise.py
@@ -227,19 +227,19 @@ class NoiseEstimator:
     Noise Estimator base class.
     """
 
-    def __init__(self, src, bgRadius=1, batch_size=512):
+    def __init__(self, src, bg_radius=1, batch_size=512):
         """
         Any additional args/kwargs are passed on to the Source's 'images' method
 
         :param src: A Source object which can give us images on demand
-        :param bgRadius: The radius of the disk whose complement is used to estimate the noise.
+        :param bg_radius: The radius of the disk whose complement is used to estimate the noise.
             Radius is relative proportion, where `1` represents
             the radius of disc inscribing a `(src.L, src.L)` image.
         :param batch_size:  The size of the batches in which to compute the variance estimate.
         """
         self.src = src
         self.dtype = self.src.dtype
-        self.bgRadius = bgRadius
+        self.bg_radius = bg_radius
         self.batch_size = batch_size
 
     @cached_property
@@ -295,7 +295,7 @@ class WhiteNoiseEstimator(NoiseEstimator):
         """
         # Run estimate using saved parameters
         g2d = grid_2d(self.src.L, indexing="yx", dtype=self.dtype)
-        mask = g2d["r"] >= self.bgRadius
+        mask = g2d["r"] >= self.bg_radius
 
         first_moment = 0
         second_moment = 0
@@ -337,7 +337,7 @@ class AnisotropicNoiseEstimator(NoiseEstimator):
         """
         # Run estimate using saved parameters
         g2d = grid_2d(self.src.L, indexing="yx", dtype=self.dtype)
-        mask = g2d["r"] >= self.bgRadius
+        mask = g2d["r"] >= self.bg_radius
 
         mean_est = 0
         noise_psd_est = np.zeros((self.src.L, self.src.L)).astype(self.src.dtype)
@@ -361,12 +361,12 @@ class LegacyNoiseEstimator(NoiseEstimator):
     Isotropic noise estimator ported from MATLAB `cryo_noise_estimation`.
     """
 
-    def __init__(self, src, bgRadius=None, max_d=None):
+    def __init__(self, src, bg_radius=None, max_d=None):
         """
         Given an `ImageSource`, constructs
 
         :param src: A `ImageSource` object.
-        :param bgRadius: The radius of the disk whose complement is used to estimate the noise.
+        :param bg_radius: The radius of the disk whose complement is used to estimate the noise.
             Radius is relative proportion, where `1` represents
             the radius of disc inscribing a `(src.L, src.L)` image.
             Default of `None` uses `(np.floor(src.L / 2) - 1) / L`
@@ -374,10 +374,10 @@ class LegacyNoiseEstimator(NoiseEstimator):
             Default of `None` uses `np.floor(src.L/3) / L`.
         """
 
-        if bgRadius is None:
-            bgRadius = (np.floor(src.L / 2) - 1) / src.L
+        if bg_radius is None:
+            bg_radius = (np.floor(src.L / 2) - 1) / src.L
 
-        super().__init__(src=src, bgRadius=bgRadius, batch_size=1)
+        super().__init__(src=src, bg_radius=bg_radius, batch_size=1)
 
         self.max_d = max_d
         if self.max_d is None:
@@ -401,7 +401,7 @@ class LegacyNoiseEstimator(NoiseEstimator):
         :return: The estimated noise variance of the images in the Source used to create this estimator.
         """
         # Setup parameters
-        samples_idx = grid_2d(self.src.L, normalized=True)["r"] >= self.bgRadius
+        samples_idx = grid_2d(self.src.L, normalized=True)["r"] >= self.bg_radius
         max_d_pixels = round(self.max_d * self.src.L)
 
         psd = self.epsdS(self.src.images, samples_idx, max_d_pixels)[0]

--- a/src/aspire/noise/noise.py
+++ b/src/aspire/noise/noise.py
@@ -356,11 +356,9 @@ class AnisotropicNoiseEstimator(NoiseEstimator):
         return noise_psd_est
 
 
-class IsotropicNoiseEstimator(NoiseEstimator):
+class LegacyNoiseEstimator(NoiseEstimator):
     """
-    Isotropic Noise Estimator.
-
-    Ported from MATLAB `cryo_noise_estimation`.
+    Isotropic noise estimator ported from MATLAB `cryo_noise_estimation`.
     """
 
     def __init__(self, src, bgRadius=None, max_d=None):
@@ -541,7 +539,7 @@ class IsotropicNoiseEstimator(NoiseEstimator):
         n_img = images.n_images
         L = samples_idx.shape[-1]
 
-        R, x, _ = IsotropicNoiseEstimator.epsdR(
+        R, x, _ = LegacyNoiseEstimator.epsdR(
             images=images, samples_idx=samples_idx, max_d=max_d
         )
 

--- a/src/aspire/noise/noise.py
+++ b/src/aspire/noise/noise.py
@@ -406,16 +406,20 @@ class LegacyNoiseEstimator(NoiseEstimator):
         )
         max_d_pixels = round(self.max_d * self.src.L)
 
-        psd = self.epsdS(self.src.images, samples_idx, max_d_pixels)[0]
+        psd = self.estimate_power_spectrum_distribution_2d(
+            self.src.images, samples_idx, max_d_pixels
+        )[0]
 
         return psd
 
     @staticmethod
-    def epsdR(images, samples_idx, max_d=None):
+    def estimate_power_spectrum_distribution_1d(images, samples_idx, max_d=None):
         """
         Estimate the 1D isotropic autocorrelation function of `images`.
         The samples to use in each image are given by `samples_idx` mask.
         The correlation is computed up to a maximal distance of `max_d`.
+
+        Port of MATLAB `cryo_epsdR`.
 
         :param images: `Image` instance
         :param samples_idx: Boolean mask shaped `(L,L)`.
@@ -517,11 +521,13 @@ class LegacyNoiseEstimator(NoiseEstimator):
         return R, x, cnt
 
     @staticmethod
-    def epsdS(images, samples_idx, max_d=None):
+    def estimate_power_spectrum_distribution_2d(images, samples_idx, max_d=None):
         """
         Estimate the 2D isotropic power spectrum of `images`.
         The samples to use in each image are given by `samples_idx` mask.
         The correlation is computed up to a maximal distance of `max_d`.
+
+        Port of MATLAB `cryo_epsdS`.
 
         :param images: Images instance
         :param samples_idx: Boolean mask shaped (L,L).
@@ -549,7 +555,7 @@ class LegacyNoiseEstimator(NoiseEstimator):
             )
         max_d = int(min(max_d, L - 1))
 
-        R, x, _ = LegacyNoiseEstimator.epsdR(
+        R, x, _ = LegacyNoiseEstimator.estimate_power_spectrum_distribution_1d(
             images=images, samples_idx=samples_idx, max_d=max_d
         )
         _R = xp.asarray(R)  # Migrate to GPU for assignments below

--- a/src/aspire/noise/noise.py
+++ b/src/aspire/noise/noise.py
@@ -486,7 +486,9 @@ class LegacyNoiseEstimator(NoiseEstimator):
         # MATLAB code internally detects/implicitly casts,
         #   we explicitly call rfft2/irfft2.
         fmask_padded = fft.rfft2(mask_padded[0])
-        n_mask_pairs = fft.irfft2(fmask_padded * fmask_padded.conj(), s=mask_padded.shape[1:])
+        n_mask_pairs = fft.irfft2(
+            fmask_padded * fmask_padded.conj(), s=mask_padded.shape[1:]
+        )
         n_mask_pairs = n_mask_pairs[: max_d + 1, : max_d + 1]  # crop
         n_mask_pairs = xp.round(n_mask_pairs)
 

--- a/src/aspire/numeric/base_fft.py
+++ b/src/aspire/numeric/base_fft.py
@@ -42,6 +42,15 @@ class FFT:
     def ifftshift(self, x, axes=None):
         raise NotImplementedError("subclasses must implement this")
 
+    def dct(self, x, **kwargs):
+        raise NotImplementedError("subclasses must implement this")
+
+    def idct(self, x, **kwargs):
+        raise NotImplementedError("subclasses must implement this")
+
+    def rfftfreq(self, x, **kwargs):
+        raise NotImplementedError("subclasses must implement this")
+
     def centered_ifft(self, x, axis=-1, workers=-1):
         x = self.ifftshift(x, axes=axis)
         x = self.ifft(x, axis=axis, workers=workers)

--- a/src/aspire/numeric/base_fft.py
+++ b/src/aspire/numeric/base_fft.py
@@ -18,6 +18,18 @@ class FFT:
     def ifft2(self, x, axes=(-2, -1), workers=-1):
         raise NotImplementedError("subclasses must implement this")
 
+    def rfft(self, x, axis=-1, workers=-1):
+        raise NotImplementedError("subclasses must implement this")
+
+    def irfft(self, x, axis=-1, workers=-1):
+        raise NotImplementedError("subclasses must implement this")
+
+    def rfft2(self, x, axes=(-2, -1), workers=-1):
+        raise NotImplementedError("subclasses must implement this")
+
+    def irfft2(self, x, axes=(-2, -1), workers=-1):
+        raise NotImplementedError("subclasses must implement this")
+
     def fftn(self, x, axes=None, workers=-1):
         raise NotImplementedError("subclasses must implement this")
 

--- a/src/aspire/numeric/cupy_fft.py
+++ b/src/aspire/numeric/cupy_fft.py
@@ -111,3 +111,11 @@ class CupyFFT(FFT):
     @_preserve_host
     def rfft(self, x, **kwargs):
         return cufft.rfft(x, **kwargs)
+
+    @_preserve_host
+    def irfft2(self, x, **kwargs):
+        return cufft.irfft2(x, **kwargs)
+
+    @_preserve_host
+    def rfft2(self, x, **kwargs):
+        return cufft.rfft2(x, **kwargs)

--- a/src/aspire/numeric/mkl_fft.py
+++ b/src/aspire/numeric/mkl_fft.py
@@ -1,5 +1,6 @@
 import mkl_fft
 import numpy as np
+import scipy as sp
 
 from aspire.numeric.base_fft import FFT
 
@@ -55,3 +56,26 @@ class MKLFFT(FFT):
     def ifftshift(self, x, axes=None):
         # N/A in mkl_fft, use np
         return np.fft.ifftshift(x, axes=axes)
+
+    def rfft(self, x, **kwargs):
+        return mkl_fft._numpy_fft.rfft(x, **kwargs)
+
+    def irfft(self, x, **kwargs):
+        return mkl_fft._numpy_fft.irfft(x, **kwargs)
+
+    def rfft2(self, x, **kwargs):
+        return mkl_fft._numpy_fft.rfft2(x, **kwargs)
+
+    def irfft2(self, x, **kwargs):
+        return mkl_fft._numpy_fft.irfft2(x, **kwargs)
+
+    # These are not currently exposed in mkl_fft,
+    #   fall back to scipy.
+    def dct(self, x, **kwargs):
+        return sp.fft.dct(x, **kwargs)
+
+    def idct(self, x, **kwargs):
+        return sp.fft.idct(x, **kwargs)
+
+    def rfftfreq(self, x, **kwargs):
+        return sp.fft.rfftfreq(x, **kwargs)

--- a/src/aspire/numeric/pyfftw_fft.py
+++ b/src/aspire/numeric/pyfftw_fft.py
@@ -154,6 +154,18 @@ class PyfftwFFT(FFT):
 
         return b
 
+    def rfft(self, x, **kwargs):
+        return pyfftw.interfaces.numpy_fft.rfft(x, **kwargs)
+
+    def irfft(self, x, **kwargs):
+        return pyfftw.interfaces.numpy_fft.irfft(x, **kwargs)
+
+    def rfft2(self, x, **kwargs):
+        return pyfftw.interfaces.numpy_fft.rfft2(x, **kwargs)
+
+    def irfft2(self, x, **kwargs):
+        return pyfftw.interfaces.numpy_fft.irfft2(x, **kwargs)
+
     def fftshift(self, a, axes=None):
         return scipy_fft.fftshift(a, axes=axes)
 
@@ -165,3 +177,6 @@ class PyfftwFFT(FFT):
 
     def idct(self, x, **kwargs):
         return scipy_fft.idct(x, **kwargs)
+
+    def rfftfreq(self, x, **kwargs):
+        return scipy_fft.rfftfreq(x, **kwargs)

--- a/src/aspire/numeric/scipy_fft.py
+++ b/src/aspire/numeric/scipy_fft.py
@@ -48,3 +48,9 @@ class ScipyFFT(FFT):
 
     def rfft(self, x, **kwargs):
         return sp.fft.rfft(x, **kwargs)
+
+    def irfft2(self, x, **kwargs):
+        return sp.fft.irfft2(x, **kwargs)
+
+    def rfft2(self, x, **kwargs):
+        return sp.fft.rfft2(x, **kwargs)

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -1412,7 +1412,7 @@ class ImageSource(ABC):
             support_radius_proportion = support_radius / (self.L // 2)
 
         est = WhiteNoiseEstimator(
-            src=self, bgRadius=support_radius_proportion, batchSize=batch_size
+            src=self, bgRadius=support_radius_proportion, batch_size=batch_size
         )
 
         return est.estimate()

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -833,8 +833,9 @@ class ImageSource(ABC):
         :param noise_response: Noise response is provided either
             directly as an array, or a `LegacyNoiseEstimator` instance.
         :param delta: Threshold used to determine which frequencies to whiten
-            and which to set to zero. By default all sqrt(PSD) values in the `noise_estimate`
-            less than eps(self.dtype) are zeroed out in the whitening filter.
+            and which to set to zero. By default all `sqrt(psd)` values
+            less than `delta` are zeroed out in the whitening filter.
+            Default of `None` yields `np.finfo(np.float32).eps`.
         """
 
         if noise_response is None:
@@ -855,7 +856,7 @@ class ImageSource(ABC):
         if delta is None:
             delta = np.finfo(np.float32).eps
 
-        logger.info("Adding LegacyWhiten Filter Xform to end of generation pipeline")
+        logger.info("Adding LegacyWhiten Filter Xform to end of generation pipeline.")
         self.generation_pipeline.add_xform(LegacyWhiten(psd, delta))
 
     @_as_copy

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -826,7 +826,7 @@ class ImageSource(ABC):
         self.generation_pipeline.add_xform(FilterXform(whiten_filter))
 
     @_as_copy
-    def legacy_whiten(self, noise_response=None, delta=None):
+    def legacy_whiten(self, noise_response=None, delta=None, batch_size=512):
         """
         Reproduce the legacy MATLAB whitening process.
 
@@ -840,7 +840,7 @@ class ImageSource(ABC):
 
         if noise_response is None:
             logger.info("Computing noise response.")
-            psd = LegacyNoiseEstimator(self).filter.xfer_fn_array
+            psd = LegacyNoiseEstimator(self, batch_size=batch_size).filter.xfer_fn_array
         elif isinstance(noise_response, LegacyNoiseEstimator):
             psd = noise_response.filter.xfer_fn_array
         elif isinstance(noise_response, np.ndarray):

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -48,7 +48,6 @@ class _ImageAccessor:
         self.fun = fun
         self.n_images = n_images
 
-
     def __getitem__(self, indices):
         """
         ImageAccessor can be indexed via Python slice object, 1-D NumPy array, list, or a single integer,

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -1412,7 +1412,7 @@ class ImageSource(ABC):
             support_radius_proportion = support_radius / (self.L // 2)
 
         est = WhiteNoiseEstimator(
-            src=self, bgRadius=support_radius_proportion, batch_size=batch_size
+            src=self, bg_radius=support_radius_proportion, batch_size=batch_size
         )
 
         return est.estimate()

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -39,20 +39,21 @@ class _ImageAccessor:
     Helper class for accessing images from an ImageSource as slices via the `src.images[start:stop:step]` API.
     """
 
-    def __init__(self, fun, num_imgs):
+    def __init__(self, fun, n_images):
         """
         :param fun: The private image-accessing method specific to the ImageSource associated with this ImageAccessor.
                     Generally _images() but can be substituted with a custom method.
-        :param num_imgs: The max number of images that this ImageAccessor can load (generally ImageSource.n).
+        :param n_images: The max number of images that this ImageAccessor can load (generally ImageSource.n).
         """
         self.fun = fun
-        self.num_imgs = num_imgs
+        self.n_images = n_images
+
 
     def __getitem__(self, indices):
         """
         ImageAccessor can be indexed via Python slice object, 1-D NumPy array, list, or a single integer,
         corresponding to the indices of the requested images. By default, slices default to a start of 0,
-        an end of self.num_imgs, and a step of 1.
+        an end of self.n_images, and a step of 1.
 
         :return: An Image object containing the requested images.
         """
@@ -71,11 +72,11 @@ class _ImageAccessor:
             if start < 0 and stop is None:
                 # slice(-10, None, None) -> slice(-10, *0* ,1)
                 stop = 0
-            # All other cases, limit to num_imgs
-            #   slice(s, None, None) -> slice(s, num_imgs, 1)
-            #   slice(s, 10**10, None) -> slice(0, num_imgs, 1)
-            elif not stop or stop > self.num_imgs:
-                stop = self.num_imgs
+            # All other cases, limit to n_images
+            #   slice(s, None, None) -> slice(s, n_images, 1)
+            #   slice(s, 10**10, None) -> slice(0, n_images, 1)
+            elif not stop or stop > self.n_images:
+                stop = self.n_images
 
             if not step:
                 step = 1
@@ -92,12 +93,12 @@ class _ImageAccessor:
             raise KeyError("Only one-dimensional indexing is allowed for images.")
 
         # final check for out-of-range indices
-        out_of_range = indices >= self.num_imgs
+        out_of_range = indices >= self.n_images
         if out_of_range.any():
             raise KeyError(f"Out-of-range indices: {list(indices[out_of_range])}")
 
         # check for negative indices and flip to positive
-        indices = indices % self.num_imgs
+        indices = indices % self.n_images
 
         return self.fun(indices)
 
@@ -262,7 +263,7 @@ class ImageSource(ABC):
 
         :param indices: Requested indices as a Python slice object,
             1-D NumPy array, list, or a single integer. Slices default
-            to a start of 0, an end of self.num_imgs, and a step of 1.
+            to a start of 0, an end of self.n_images, and a step of 1.
             See _ImageAccessor.
         :return: Source composed of the images and metadata at `indices`.
         """
@@ -388,7 +389,7 @@ class ImageSource(ABC):
             raise TypeError("`n` must be an integer")
         n = int(n)
 
-        self._img_accessor.num_imgs = n
+        self._img_accessor.n_images = n
         self._n = n
 
     @property

--- a/src/aspire/utils/__init__.py
+++ b/src/aspire/utils/__init__.py
@@ -24,6 +24,7 @@ from .misc import (  # isort:skip
     gaussian_1d,
     gaussian_2d,
     gaussian_3d,
+    gaussian_window,
     importlib_path,
     inverse_r,
     J_conjugate,

--- a/src/aspire/utils/misc.py
+++ b/src/aspire/utils/misc.py
@@ -359,7 +359,7 @@ def fuzzy_mask(L, dtype, r0=None, risetime=None):
     return m
 
 
-def gaussian_window(L, max_d, alpha=3.0):
+def gaussian_window(L, max_d, alpha=3.0, dtype=np.float64):
     """
     Create a 2D gaussian window used for 2D power spectrum estimation.
 
@@ -369,7 +369,7 @@ def gaussian_window(L, max_d, alpha=3.0):
     See Harris 78.
 
     When `alpha=1`, this function should be equivalent to
-    `gaussian_2d(L=2*L-1, sigma=max_d)`.
+    `gaussian_2d(size=2*L-1, sigma=max_d)`.
 
     :param L: Number of radial pixels
     :param max_d: Width of Gaussian (stddev)
@@ -378,6 +378,8 @@ def gaussian_window(L, max_d, alpha=3.0):
     """
 
     X, Y = np.mgrid[-(L - 1) : L, -(L - 1) : L]  # -(L-1) to (L-1) inclusive
+    X = X.astype(dtype, copy=False)
+    Y = Y.astype(dtype, copy=False)
     W = np.exp(-alpha * (X**2 + Y**2) / (2 * max_d**2))
 
     return W

--- a/src/aspire/utils/misc.py
+++ b/src/aspire/utils/misc.py
@@ -359,6 +359,30 @@ def fuzzy_mask(L, dtype, r0=None, risetime=None):
     return m
 
 
+def gaussian_window(L, max_d, alpha=3.0):
+    """
+    Create a 2D gaussian window used for 2D power spectrum estimation.
+
+    Given `L` retuns a `(2L-1, 2L-1)` array where
+    `max_d` is the width of the Gaussian and `alpha` is the
+    reciprical of the standard deviation of the Gaussian window.
+    See Harris 78.
+
+    When `alpha=1`, this function should be equivalent to
+    `gaussian_2d(L=2*L-1, sigma=max_d)`.
+
+    :param L: Number of radial pixels
+    :param max_d: Width of Gaussian (stddev)
+    :param alpha: Reciprical of stddev of window
+    :return: Numpy array with shape `(2L-1, 2L-1)`x
+    """
+
+    X, Y = np.mgrid[-(L - 1) : L, -(L - 1) : L]  # -(L-1) to (L-1) inclusive
+    W = np.exp(-alpha * (X**2 + Y**2) / (2 * max_d**2))
+
+    return W
+
+
 def all_pairs(n, return_map=False):
     """
     All pairs indexing (i,j) for i<j and a pairs-to-linear index mapping.

--- a/src/aspire/utils/misc.py
+++ b/src/aspire/utils/misc.py
@@ -368,19 +368,13 @@ def gaussian_window(L, max_d, alpha=3.0, dtype=np.float64):
     reciprical of the standard deviation of the Gaussian window.
     See Harris 78.
 
-    When `alpha=1`, this function should be equivalent to
-    `gaussian_2d(size=2*L-1, sigma=max_d)`.
-
     :param L: Number of radial pixels
     :param max_d: Width of Gaussian (stddev)
     :param alpha: Reciprical of stddev of window
     :return: Numpy array with shape `(2L-1, 2L-1)`x
     """
 
-    X, Y = np.mgrid[-(L - 1) : L, -(L - 1) : L]  # -(L-1) to (L-1) inclusive
-    X = X.astype(dtype, copy=False)
-    Y = Y.astype(dtype, copy=False)
-    W = np.exp(-alpha * (X**2 + Y**2) / (2 * max_d**2))
+    W = gaussian_2d(size=2 * L - 1, sigma=max_d / np.sqrt(alpha), dtype=dtype)
 
     return W
 

--- a/tests/test_anisotropic_noise.py
+++ b/tests/test_anisotropic_noise.py
@@ -36,7 +36,7 @@ class SimTestCase(TestCase):
         pass
 
     def testAnisotropicNoisePSD(self):
-        noise_estimator = AnisotropicNoiseEstimator(self.sim, batchSize=512)
+        noise_estimator = AnisotropicNoiseEstimator(self.sim, batch_size=512)
         noise_psd = noise_estimator._estimate_noise_psd()
         self.assertTrue(
             np.allclose(
@@ -128,7 +128,7 @@ class SimTestCase(TestCase):
         )
 
     def testAnisotropicNoiseVariance(self):
-        noise_estimator = AnisotropicNoiseEstimator(self.sim, batchSize=512)
+        noise_estimator = AnisotropicNoiseEstimator(self.sim, batch_size=512)
         noise_variance = noise_estimator.estimate()
         self.assertTrue(
             np.allclose(
@@ -154,9 +154,9 @@ class SimTestCase(TestCase):
         wht_noise = np.random.randn(1024, 128, 128).astype(self.dtype)
         src = ArrayImageSource(wht_noise)
 
-        wht_noise_estimator = WhiteNoiseEstimator(src, batchSize=512)
+        wht_noise_estimator = WhiteNoiseEstimator(src, batch_size=512)
         wht_noise_variance = wht_noise_estimator.estimate()
-        noise_estimator = AnisotropicNoiseEstimator(src, batchSize=512)
+        noise_estimator = AnisotropicNoiseEstimator(src, batch_size=512)
         noise_variance = noise_estimator.estimate()
 
         self.assertTrue(np.allclose(noise_variance, wht_noise_variance))

--- a/tests/test_anisotropic_noise.py
+++ b/tests/test_anisotropic_noise.py
@@ -37,7 +37,7 @@ class SimTestCase(TestCase):
 
     def testAnisotropicNoisePSD(self):
         noise_estimator = AnisotropicNoiseEstimator(self.sim, batchSize=512)
-        noise_psd = noise_estimator.estimate_noise_psd()
+        noise_psd = noise_estimator._estimate_noise_psd()
         self.assertTrue(
             np.allclose(
                 noise_psd,

--- a/tests/test_noise.py
+++ b/tests/test_noise.py
@@ -9,7 +9,7 @@ from aspire.noise import (
     AnisotropicNoiseEstimator,
     BlueNoiseAdder,
     CustomNoiseAdder,
-    IsotropicNoiseEstimator,
+    LegacyNoiseEstimator,
     PinkNoiseAdder,
     WhiteNoiseAdder,
     WhiteNoiseEstimator,
@@ -29,7 +29,7 @@ DTYPES = [np.float32, np.float64]
 VARS = [0.1] + [
     pytest.param(10 ** (-x), marks=pytest.mark.expensive) for x in range(2, 5)
 ]
-NOISE_ESTIMATORS = [AnisotropicNoiseEstimator, IsotropicNoiseEstimator]
+NOISE_ESTIMATORS = [AnisotropicNoiseEstimator, LegacyNoiseEstimator]
 
 
 def _noise_function(x, y):


### PR DESCRIPTION
This PR implements the legacy pre-whitening code from MATLAB.

Also includes two other cleanups. First, some of the `Filter` methods (`_create_filter`) are simplified/reconciled and enforced with `abc`. Second, the `ImageAccessor` image count attribute is changed from `num_images` to `n_images`.  This allows an `ImageAccessor` to be passed in place of an `Image` stack in the static methods (`epsdR`, `epsdS`) I've ported in this PR, but is otherwise mostly an internal change.