### PR TITLE
Fix SymmetryGroup Warnings

### DIFF
--- a/src/aspire/abinitio/commonline_d2.py
+++ b/src/aspire/abinitio/commonline_d2.py
@@ -81,7 +81,7 @@ class CLSymmetryD2(CLOrient3D):
         # D2 symmetry group.
         # Rearrange in order Identity, about_x, about_y, about_z.
         # This ordering is necessary for reproducing MATLAB code results.
-        self.gs = DnSymmetryGroup(order=2, dtype=self.dtype).matrices[[0, 3, 2, 1]]
+        self.gs = DnSymmetryGroup(order=2).matrices.astype(self.dtype)[[0, 3, 2, 1]]
 
     def estimate_rotations(self):
         """

--- a/src/aspire/abinitio/commonline_d2.py
+++ b/src/aspire/abinitio/commonline_d2.py
@@ -81,7 +81,9 @@ class CLSymmetryD2(CLOrient3D):
         # D2 symmetry group.
         # Rearrange in order Identity, about_x, about_y, about_z.
         # This ordering is necessary for reproducing MATLAB code results.
-        self.gs = DnSymmetryGroup(order=2).matrices.astype(self.dtype)[[0, 3, 2, 1]]
+        self.gs = DnSymmetryGroup(order=2).matrices.astype(self.dtype, copy=False)[
+            [0, 3, 2, 1]
+        ]
 
     def estimate_rotations(self):
         """

--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -732,7 +732,7 @@ class Image:
         ), "Number of rotation matrices must match the number of images"
 
         # Get symmetry rotations from SymmetryGroup.
-        symmetry_rots = SymmetryGroup.parse(symmetry_group, dtype=self.dtype).matrices
+        symmetry_rots = SymmetryGroup.parse(symmetry_group).matrices.astype(self.dtype)
         if len(symmetry_rots) > 1:
             logger.info(f"Boosting with {len(symmetry_rots)} rotational symmetries.")
 

--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -732,7 +732,9 @@ class Image:
         ), "Number of rotation matrices must match the number of images"
 
         # Get symmetry rotations from SymmetryGroup.
-        symmetry_rots = SymmetryGroup.parse(symmetry_group).matrices.astype(self.dtype)
+        symmetry_rots = SymmetryGroup.parse(symmetry_group).matrices.astype(
+            self.dtype, copy=False
+        )
         if len(symmetry_rots) > 1:
             logger.info(f"Boosting with {len(symmetry_rots)} rotational symmetries.")
 

--- a/src/aspire/reconstruction/mean.py
+++ b/src/aspire/reconstruction/mean.py
@@ -54,7 +54,7 @@ class WeightedVolumesEstimator(Estimator):
         """
 
         super().__init__(*args, **kwargs)
-        self.weights = weights.astype(self.src.dtype)
+        self.weights = weights.astype(self.src.dtype, copy=False)
         self.r = self.weights.shape[1]
         assert self.src.n == self.weights.shape[0]
 

--- a/src/aspire/reconstruction/mean.py
+++ b/src/aspire/reconstruction/mean.py
@@ -305,9 +305,10 @@ class MeanEstimator(WeightedVolumesEstimator):
 
     def __init__(self, src, **kwargs):
         # Note, Handle boosting by adjusting weights based on symmetric order.
-        weights = np.ones((src.n, 1)) / np.sqrt(
-            src.n * len(src.symmetry_group.matrices)
+        weights = np.ones((src.n, 1), dtype=src.dtype) / np.sqrt(
+            src.n * len(src.symmetry_group.matrices), dtype=src.dtype
         )
+
         super().__init__(weights, src, **kwargs)
 
     def __getattr__(self, name):

--- a/src/aspire/reconstruction/mean.py
+++ b/src/aspire/reconstruction/mean.py
@@ -96,7 +96,7 @@ class WeightedVolumesEstimator(Estimator):
         # Handle symmetry boosting.
         sym_rots = np.eye(3, dtype=self.dtype)[None]
         if self.boost:
-            sym_rots = self.src.symmetry_group.matrices.astype(self.dtype)
+            sym_rots = self.src.symmetry_group.matrices.astype(self.dtype, copy=False)
 
         for i in range(0, self.src.n, self.batch_size):
             _range = np.arange(i, min(self.src.n, i + self.batch_size), dtype=int)

--- a/src/aspire/reconstruction/mean.py
+++ b/src/aspire/reconstruction/mean.py
@@ -53,9 +53,9 @@ class WeightedVolumesEstimator(Estimator):
         :param weights: Matrix of weights, n x r.
         """
 
-        self.weights = weights
-        self.r = self.weights.shape[1]
         super().__init__(*args, **kwargs)
+        self.weights = weights.astype(self.src.dtype)
+        self.r = self.weights.shape[1]
         assert self.src.n == self.weights.shape[0]
 
     def __getattr__(self, name):
@@ -305,8 +305,8 @@ class MeanEstimator(WeightedVolumesEstimator):
 
     def __init__(self, src, **kwargs):
         # Note, Handle boosting by adjusting weights based on symmetric order.
-        weights = np.ones((src.n, 1), dtype=src.dtype) / np.sqrt(
-            src.n * len(src.symmetry_group.matrices), dtype=src.dtype
+        weights = np.ones((src.n, 1)) / np.sqrt(
+            src.n * len(src.symmetry_group.matrices)
         )
         super().__init__(weights, src, **kwargs)
 

--- a/src/aspire/reconstruction/mean.py
+++ b/src/aspire/reconstruction/mean.py
@@ -96,7 +96,7 @@ class WeightedVolumesEstimator(Estimator):
         # Handle symmetry boosting.
         sym_rots = np.eye(3, dtype=self.dtype)[None]
         if self.boost:
-            sym_rots = self.src.symmetry_group.matrices
+            sym_rots = self.src.symmetry_group.matrices.astype(self.dtype)
 
         for i in range(0, self.src.n, self.batch_size):
             _range = np.arange(i, min(self.src.n, i + self.batch_size), dtype=int)

--- a/src/aspire/reconstruction/mean.py
+++ b/src/aspire/reconstruction/mean.py
@@ -308,7 +308,6 @@ class MeanEstimator(WeightedVolumesEstimator):
         weights = np.ones((src.n, 1), dtype=src.dtype) / np.sqrt(
             src.n * len(src.symmetry_group.matrices), dtype=src.dtype
         )
-
         super().__init__(weights, src, **kwargs)
 
     def __getattr__(self, name):

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -233,7 +233,7 @@ class ImageSource(ABC):
                 f"This source is no longer mutable. Try new_source = source.update(symmetry_group='{value}')."
             )
 
-        self._symmetry_group = SymmetryGroup.parse(value, dtype=self.dtype)
+        self._symmetry_group = SymmetryGroup.parse(value)
         self.set_metadata(["_rlnSymmetryGroup"], str(self.symmetry_group))
 
     def _populate_symmetry_group(self, symmetry_group):
@@ -249,10 +249,9 @@ class ImageSource(ABC):
             else:
                 symmetry_group = SymmetryGroup.parse(
                     symmetry=self.get_metadata(["_rlnSymmetryGroup"])[0],
-                    dtype=self.dtype,
                 )
 
-        self.symmetry_group = symmetry_group or IdentitySymmetryGroup(dtype=self.dtype)
+        self.symmetry_group = symmetry_group or IdentitySymmetryGroup()
 
     def __getitem__(self, indices):
         """

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -419,7 +419,10 @@ class ImageSource(ABC):
     @property
     def offsets(self):
         return np.atleast_2d(
-            self.get_metadata(["_rlnOriginX", "_rlnOriginY"], default_value=0.0)
+            self.get_metadata(
+                ["_rlnOriginX", "_rlnOriginY"],
+                default_value=np.array(0.0, dtype=self.dtype),
+            )
         )
 
     @offsets.setter
@@ -430,7 +433,11 @@ class ImageSource(ABC):
 
     @property
     def amplitudes(self):
-        return np.atleast_1d(self.get_metadata("_rlnAmplitude", default_value=1.0))
+        return np.atleast_1d(
+            self.get_metadata(
+                "_rlnAmplitude", default_value=np.array(1.0, dtype=self.dtype)
+            )
+        )
 
     @amplitudes.setter
     def amplitudes(self, values):

--- a/src/aspire/source/simulation.py
+++ b/src/aspire/source/simulation.py
@@ -413,7 +413,7 @@ class Simulation(ImageSource):
         C = self.C
         vols_c = self.vols - self.mean_true()
 
-        p = np.ones(C, dtype=self.dtype) / C.astype(self.dtype)
+        p = np.full(C, 1 / C, dtype=self.dtype)
         Q, R = qr(vols_c.to_vec().T, mode="economic")
 
         # Rank is at most C-1, so remove last vector

--- a/src/aspire/source/simulation.py
+++ b/src/aspire/source/simulation.py
@@ -413,7 +413,7 @@ class Simulation(ImageSource):
         C = self.C
         vols_c = self.vols - self.mean_true()
 
-        p = np.ones(C) / C
+        p = np.ones(C, dtype=self.dtype) / C.astype(self.dtype)
         Q, R = qr(vols_c.to_vec().T, mode="economic")
 
         # Rank is at most C-1, so remove last vector

--- a/src/aspire/utils/rotation.py
+++ b/src/aspire/utils/rotation.py
@@ -274,9 +274,11 @@ class Rotation:
 
         :return: Rotation object
         """
-        if isinstance(angles, float):
-            dtype = np.float64
-        dtype = dtype or getattr(angles, "dtype", np.float32)
+        dtype = dtype or (
+            np.float64
+            if isinstance(angles, float)
+            else getattr(angles, "dtype", np.float32)
+        )
         axes = ["x", "y", "z"]
         if axis.lower() not in axes:
             raise ValueError("`axis` must be 'x', 'y', or 'z'.")

--- a/src/aspire/utils/rotation.py
+++ b/src/aspire/utils/rotation.py
@@ -274,6 +274,8 @@ class Rotation:
 
         :return: Rotation object
         """
+        if isinstance(angles, float):
+            dtype = np.float64
         dtype = dtype or getattr(angles, "dtype", np.float32)
         axes = ["x", "y", "z"]
         if axis.lower() not in axes:

--- a/src/aspire/volume/symmetry_groups.py
+++ b/src/aspire/volume/symmetry_groups.py
@@ -107,7 +107,7 @@ class SymmetryGroup(ABC):
         """Copy of the SymmetryGroup object, cast to a specified dtype."""
         kwargs = {"dtype": dtype}
 
-        if hasattr(self, "order"):
+        if hasattr(self, "order") and self.order > 1:
             kwargs["order"] = self.order
 
         return self.__class__(**kwargs)

--- a/src/aspire/volume/symmetry_groups.py
+++ b/src/aspire/volume/symmetry_groups.py
@@ -17,6 +17,7 @@ class SymmetryGroup(ABC):
         """
         Abstract class for symmetry groups.
         """
+        self.dtype = np.float64
         self.rotations = self.generate_rotations()
 
     @abstractmethod
@@ -123,7 +124,9 @@ class CnSymmetryGroup(SymmetryGroup):
 
         :return: Rotation object containing the Cn symmetry group and the identity.
         """
-        angles = 2 * np.pi * np.arange(self.order) / self.order
+        angles = (2 * np.pi * np.arange(self.order) / self.order).astype(
+            self.dtype, copy=False
+        )
         return Rotation.about_axis("z", angles)
 
 
@@ -173,11 +176,14 @@ class DnSymmetryGroup(SymmetryGroup):
         """
 
         # Rotations to induce cyclic symmetry
-        angles = 2 * np.pi * np.arange(self.order) / self.order
+        angles = (2 * np.pi * np.arange(self.order) / self.order).astype(
+            self.dtype, copy=False
+        )
         rot_z = Rotation.about_axis("z", angles).matrices
 
         # Perpendicular rotation to induce dihedral symmetry
-        rot_perp = Rotation.about_axis("y", np.pi).matrices
+        pi = np.array(np.pi, dtype=self.dtype)
+        rot_perp = Rotation.about_axis("y", pi).matrices
 
         # Full set of rotations.
         rots = np.concatenate((rot_z, rot_z @ rot_perp[0]))
@@ -216,18 +222,18 @@ class TSymmetryGroup(SymmetryGroup):
         """
         # C3 rotation vectors, ie. angle * axis.
         axes_C3 = np.array(
-            [[1, 1, 1], [-1, -1, 1], [1, -1, -1], [-1, 1, -1]], dtype=np.float64
+            [[1, 1, 1], [-1, -1, 1], [1, -1, -1], [-1, 1, -1]], dtype=self.dtype
         )
         axes_C3 /= np.linalg.norm(axes_C3, axis=-1)[..., np.newaxis]
-        angles_C3 = np.array([2 * np.pi / 3, 4 * np.pi / 3], dtype=np.float64)
+        angles_C3 = np.array([2 * np.pi / 3, 4 * np.pi / 3], dtype=self.dtype)
         rot_vecs_C3 = np.concatenate([angle * axes_C3 for angle in angles_C3])
 
         # C2 rotation vectors.
-        axes_C2 = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=np.float64)
+        axes_C2 = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=self.dtype)
         rot_vecs_C2 = np.pi * axes_C2
 
         # The full set of rotation vectors inducing tetrahedral symmetry.
-        rot_vec_I = np.zeros((1, 3), dtype=np.float64)
+        rot_vec_I = np.zeros((1, 3), dtype=self.dtype)
         rot_vecs = np.concatenate((rot_vec_I, rot_vecs_C3, rot_vecs_C2))
 
         # Return rotations.
@@ -266,34 +272,34 @@ class OSymmetryGroup(SymmetryGroup):
         """
 
         # C4 rotation vectors, ie angle * axis
-        axes_C4 = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=np.float64)
-        angles_C4 = np.array([np.pi / 2, np.pi, 3 * np.pi / 2], dtype=np.float64)
+        axes_C4 = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=self.dtype)
+        angles_C4 = np.array([np.pi / 2, np.pi, 3 * np.pi / 2], dtype=self.dtype)
         rot_vecs_C4 = np.array(
             [angle * axes_C4 for angle in angles_C4],
-            dtype=np.float64,
+            dtype=self.dtype,
         ).reshape((9, 3))
 
         # C3 rotation vectors
         axes_C3 = np.array(
-            [[1, 1, 1], [-1, 1, 1], [1, -1, 1], [1, 1, -1]], dtype=np.float64
+            [[1, 1, 1], [-1, 1, 1], [1, -1, 1], [1, 1, -1]], dtype=self.dtype
         )
         axes_C3 /= np.linalg.norm(axes_C3, axis=-1)[..., np.newaxis]
-        angles_C3 = np.array([2 * np.pi / 3, 4 * np.pi / 3], dtype=np.float64)
+        angles_C3 = np.array([2 * np.pi / 3, 4 * np.pi / 3], dtype=self.dtype)
         rot_vecs_C3 = np.array(
             [angle * axes_C3 for angle in angles_C3],
-            dtype=np.float64,
+            dtype=self.dtype,
         ).reshape((8, 3))
 
         # C2 rotation vectors
         axes_C2 = np.array(
             [[1, 1, 0], [-1, 1, 0], [1, 0, 1], [-1, 0, 1], [0, 1, 1], [0, -1, 1]],
-            dtype=np.float64,
+            dtype=self.dtype,
         )
         axes_C2 /= np.linalg.norm(axes_C2, axis=-1)[..., np.newaxis]
         rot_vecs_C2 = np.pi * axes_C2
 
         # The full set of rotation vectors inducing octahedral symmetry.
-        rot_vec_I = np.zeros((1, 3), dtype=np.float64)
+        rot_vec_I = np.zeros((1, 3), dtype=self.dtype)
         rot_vecs = np.concatenate((rot_vec_I, rot_vecs_C4, rot_vecs_C3, rot_vecs_C2))
 
         # Return rotations.

--- a/src/aspire/volume/symmetry_groups.py
+++ b/src/aspire/volume/symmetry_groups.py
@@ -1,5 +1,4 @@
 import logging
-import warnings
 from abc import ABC, abstractmethod, abstractproperty
 
 import numpy as np

--- a/src/aspire/volume/symmetry_groups.py
+++ b/src/aspire/volume/symmetry_groups.py
@@ -14,11 +14,10 @@ class SymmetryGroup(ABC):
     Base class for symmetry groups.
     """
 
-    def __init__(self, dtype):
+    def __init__(self):
         """
-        :param dtype: Numpy dtype to be used for rotation matrices.
+        Abstract class for symmetry groups.
         """
-        self.dtype = np.dtype(dtype)
         self.rotations = self.generate_rotations()
 
     @abstractmethod
@@ -47,30 +46,19 @@ class SymmetryGroup(ABC):
         return f"{self.to_string}"
 
     @staticmethod
-    def parse(symmetry, dtype):
+    def parse(symmetry):
         """
-        Takes a SymmetryGroup instance or a string, ie. 'C1', 'C7', 'D3', 'T', 'O', and returns a concrete
-        SymmetryGroup object with the specified dtype.
+        Takes a SymmetryGroup instance or a string, ie. 'C1', 'C7', 'D3', 'T', 'O',
+        and returns a concrete SymmetryGroup object.
 
         :param symmetry: A string (or SymmetryGroup instance) indicating the symmetry of a molecule.
-        :param dtype: dtype for rotation matrices.
         :return: Concrete SymmetryGroup object.
         """
 
         if symmetry is None:
-            return IdentitySymmetryGroup(dtype=dtype)
+            return IdentitySymmetryGroup()
 
         if isinstance(symmetry, SymmetryGroup):
-            if symmetry.dtype != dtype:
-                warnings.warn(
-                    f"Recasting SymmetryGroup with dtype {dtype}.",
-                    category=UserWarning,
-                    stacklevel=2,
-                )
-                group_kwargs = dict(dtype=dtype)
-                if getattr(symmetry, "order", False) and symmetry.order > 1:
-                    group_kwargs["order"] = symmetry.order
-                symmetry = symmetry.__class__(**group_kwargs)
             return symmetry
 
         if not isinstance(symmetry, str):
@@ -78,9 +66,10 @@ class SymmetryGroup(ABC):
                 f"`symmetry` must be a string or `SymmetryGroup` instance. Found {type(symmetry)}"
             )
 
+        # Parse symmetry provided as a string.
         symmetry = symmetry.upper()
         if symmetry == "C1":
-            return IdentitySymmetryGroup(dtype=dtype)
+            return IdentitySymmetryGroup()
 
         symmetry_type = symmetry[0]
         symmetric_order = symmetry[1:]
@@ -97,20 +86,11 @@ class SymmetryGroup(ABC):
             )
 
         symmetry_group = map_to_sym_group[symmetry_type]
-        group_kwargs = dict(dtype=dtype)
+        group_kwargs = dict()
         if symmetric_order:
             group_kwargs["order"] = int(symmetric_order)
 
         return symmetry_group(**group_kwargs)
-
-    def astype(self, dtype):
-        """Copy of the SymmetryGroup object, cast to a specified dtype."""
-        kwargs = {"dtype": dtype}
-
-        if hasattr(self, "order") and self.order > 1:
-            kwargs["order"] = self.order
-
-        return self.__class__(**kwargs)
 
 
 class CnSymmetryGroup(SymmetryGroup):
@@ -118,18 +98,17 @@ class CnSymmetryGroup(SymmetryGroup):
     Cyclic symmetry group.
     """
 
-    def __init__(self, order, dtype):
+    def __init__(self, order):
         """
         `CnSymmetryGroup` instance that serves up a `Rotation` object
         containing rotation matrices of the symmetry group (including
         the identity) accessed via the `matrices` attribute.
 
         :param order: The cyclic order for the symmetry group (int).
-        :param dtype: Numpy dtype to be used for rotation matrices.
         """
 
         self.order = int(order)
-        super().__init__(dtype=dtype)
+        super().__init__()
 
     @property
     def to_string(self):
@@ -146,7 +125,7 @@ class CnSymmetryGroup(SymmetryGroup):
         :return: Rotation object containing the Cn symmetry group and the identity.
         """
         angles = 2 * np.pi * np.arange(self.order) / self.order
-        return Rotation.about_axis("z", angles, dtype=self.dtype)
+        return Rotation.about_axis("z", angles, dtype=np.float64)
 
 
 class IdentitySymmetryGroup(CnSymmetryGroup):
@@ -154,15 +133,13 @@ class IdentitySymmetryGroup(CnSymmetryGroup):
     The identity symmetry group.
     """
 
-    def __init__(self, dtype):
+    def __init__(self):
         """
         `IdentitySymmetryGroup` instance that serves up a `Rotation` object
         containing the identity matrix.
-
-        :param dtype: Numpy dtype to be used for rotation matrices.
         """
 
-        super().__init__(order=1, dtype=dtype)
+        super().__init__(order=1)
 
 
 class DnSymmetryGroup(SymmetryGroup):
@@ -170,7 +147,7 @@ class DnSymmetryGroup(SymmetryGroup):
     Dihedral symmetry group.
     """
 
-    def __init__(self, order, dtype):
+    def __init__(self, order):
         """
         `DnSymmetryGroup` instance that serves up a `Rotation` object
         containing rotation matrices of the symmetry group (including
@@ -178,11 +155,10 @@ class DnSymmetryGroup(SymmetryGroup):
         is the chiral dihedral symmetry group which does contain reflections.
 
         :param order: The cyclic order for the symmetry group (int).
-        :param dtype: Numpy dtype to be used for rotation matrices.
         """
 
         self.order = int(order)
-        super().__init__(dtype=dtype)
+        super().__init__()
 
     @property
     def to_string(self):
@@ -197,14 +173,14 @@ class DnSymmetryGroup(SymmetryGroup):
         :return: Rotation object containing the Dn symmetry group and the identity.
         """
         # Rotations to induce cyclic symmetry
-        angles = 2 * np.pi * np.arange(self.order, dtype=self.dtype) / self.order
+        angles = 2 * np.pi * np.arange(self.order) / self.order
         rot_z = Rotation.about_axis("z", angles).matrices
 
         # Perpendicular rotation to induce dihedral symmetry
-        rot_perp = Rotation.about_axis("y", np.pi, dtype=self.dtype).matrices
+        rot_perp = Rotation.about_axis("y", np.pi).matrices
 
         # Full set of rotations.
-        rots = np.concatenate((rot_z, rot_z @ rot_perp[0]), dtype=self.dtype)
+        rots = np.concatenate((rot_z, rot_z @ rot_perp[0]))
 
         return Rotation(rots)
 
@@ -214,17 +190,15 @@ class TSymmetryGroup(SymmetryGroup):
     Tetrahedral symmetry group.
     """
 
-    def __init__(self, dtype):
+    def __init__(self):
         """
         `TSymmetryGroup` instance that serves up a `Rotation` object
         containing rotation matrices of the symmetry group (including the
         Identity) accessed via the `matrices` attribute. Note, this is the
         chiral tetrahedral symmetry group which does not contain reflections.
-
-        :param dtype: Numpy dtype to be used for rotation matrices.
         """
 
-        super().__init__(dtype=dtype)
+        super().__init__()
 
     @property
     def to_string(self):
@@ -241,27 +215,21 @@ class TSymmetryGroup(SymmetryGroup):
         :return: Rotation object containing the tetrahedral symmetry group and the identity.
         """
         # C3 rotation vectors, ie. angle * axis.
-        axes_C3 = np.array(
-            [[1, 1, 1], [-1, -1, 1], [1, -1, -1], [-1, 1, -1]], dtype=self.dtype
-        )
+        axes_C3 = np.array([[1, 1, 1], [-1, -1, 1], [1, -1, -1], [-1, 1, -1]], dtype=np.float64)
         axes_C3 /= np.linalg.norm(axes_C3, axis=-1)[..., np.newaxis]
-        angles_C3 = np.array([2 * np.pi / 3, 4 * np.pi / 3], dtype=self.dtype)
-        rot_vecs_C3 = np.concatenate(
-            [angle * axes_C3 for angle in angles_C3], dtype=self.dtype
-        )
+        angles_C3 = np.array([2 * np.pi / 3, 4 * np.pi / 3], dtype=np.float64)
+        rot_vecs_C3 = np.concatenate([angle * axes_C3 for angle in angles_C3])
 
         # C2 rotation vectors.
-        axes_C2 = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=self.dtype)
+        axes_C2 = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=np.float64)
         rot_vecs_C2 = np.pi * axes_C2
 
         # The full set of rotation vectors inducing tetrahedral symmetry.
-        rot_vec_I = np.zeros((1, 3), dtype=self.dtype)
-        rot_vecs = np.concatenate(
-            (rot_vec_I, rot_vecs_C3, rot_vecs_C2), dtype=self.dtype
-        )
+        rot_vec_I = np.zeros((1, 3))
+        rot_vecs = np.concatenate((rot_vec_I, rot_vecs_C3, rot_vecs_C2))
 
         # Return rotations.
-        return Rotation.from_rotvec(rot_vecs, dtype=self.dtype)
+        return Rotation.from_rotvec(rot_vecs)
 
 
 class OSymmetryGroup(SymmetryGroup):
@@ -269,16 +237,14 @@ class OSymmetryGroup(SymmetryGroup):
     Octahedral symmetry group.
     """
 
-    def __init__(self, dtype):
+    def __init__(self):
         """
         `OSymmetryGroup` instance that serves up a `Rotation` object
         containing rotation matrices of the symmetry group (including the
         Identity) accessed via the `matrices` attribute. Note, this is the
         chiral octahedral symmetry group which does not contain reflections.
-
-        :param dtype: Numpy dtype to be used for rotation matrices.
         """
-        super().__init__(dtype=dtype)
+        super().__init__()
 
         self._symmetry_group = self.generate_rotations()
 
@@ -298,35 +264,31 @@ class OSymmetryGroup(SymmetryGroup):
         """
 
         # C4 rotation vectors, ie angle * axis
-        axes_C4 = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=self.dtype)
-        angles_C4 = np.array([np.pi / 2, np.pi, 3 * np.pi / 2], dtype=self.dtype)
+        axes_C4 = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=np.float64)
+        angles_C4 = np.array([np.pi / 2, np.pi, 3 * np.pi / 2], dtype=np.float64)
         rot_vecs_C4 = np.array(
-            [angle * axes_C4 for angle in angles_C4], dtype=self.dtype
+            [angle * axes_C4 for angle in angles_C4], dtype=np.float64,
         ).reshape((9, 3))
 
         # C3 rotation vectors
-        axes_C3 = np.array(
-            [[1, 1, 1], [-1, 1, 1], [1, -1, 1], [1, 1, -1]], dtype=self.dtype
-        )
+        axes_C3 = np.array([[1, 1, 1], [-1, 1, 1], [1, -1, 1], [1, 1, -1]], dtype=np.float64)
         axes_C3 /= np.linalg.norm(axes_C3, axis=-1)[..., np.newaxis]
-        angles_C3 = np.array([2 * np.pi / 3, 4 * np.pi / 3], dtype=self.dtype)
+        angles_C3 = np.array([2 * np.pi / 3, 4 * np.pi / 3], dtype=np.float64)
         rot_vecs_C3 = np.array(
-            [angle * axes_C3 for angle in angles_C3], dtype=self.dtype
+            [angle * axes_C3 for angle in angles_C3], dtype=np.float64,
         ).reshape((8, 3))
 
         # C2 rotation vectors
         axes_C2 = np.array(
             [[1, 1, 0], [-1, 1, 0], [1, 0, 1], [-1, 0, 1], [0, 1, 1], [0, -1, 1]],
-            dtype=self.dtype,
+            dtype=np.float64,
         )
         axes_C2 /= np.linalg.norm(axes_C2, axis=-1)[..., np.newaxis]
         rot_vecs_C2 = np.pi * axes_C2
 
         # The full set of rotation vectors inducing octahedral symmetry.
-        rot_vec_I = np.zeros((1, 3), dtype=self.dtype)
-        rot_vecs = np.concatenate(
-            (rot_vec_I, rot_vecs_C4, rot_vecs_C3, rot_vecs_C2), dtype=self.dtype
-        )
+        rot_vec_I = np.zeros((1, 3))
+        rot_vecs = np.concatenate((rot_vec_I, rot_vecs_C4, rot_vecs_C3, rot_vecs_C2))
 
         # Return rotations.
-        return Rotation.from_rotvec(rot_vecs, dtype=self.dtype)
+        return Rotation.from_rotvec(rot_vecs)

--- a/src/aspire/volume/symmetry_groups.py
+++ b/src/aspire/volume/symmetry_groups.py
@@ -124,8 +124,8 @@ class CnSymmetryGroup(SymmetryGroup):
 
         :return: Rotation object containing the Cn symmetry group and the identity.
         """
-        angles = np.linspace(0, 2 * np.pi, self.order, endpoint=False, dtype=self.dtype)
-        return Rotation.about_axis("z", angles)
+        angles = np.linspace(0, 2 * np.pi, self.order, endpoint=False)
+        return Rotation.about_axis("z", angles, dtype=self.dtype)
 
 
 class IdentitySymmetryGroup(CnSymmetryGroup):
@@ -174,12 +174,11 @@ class DnSymmetryGroup(SymmetryGroup):
         """
 
         # Rotations to induce cyclic symmetry
-        angles = np.linspace(0, 2 * np.pi, self.order, endpoint=False, dtype=self.dtype)
-        rot_z = Rotation.about_axis("z", angles).matrices
+        angles = np.linspace(0, 2 * np.pi, self.order, endpoint=False)
+        rot_z = Rotation.about_axis("z", angles, dtype=self.dtype).matrices
 
         # Perpendicular rotation to induce dihedral symmetry
-        pi = np.array(np.pi, dtype=self.dtype)
-        rot_perp = Rotation.about_axis("y", pi).matrices
+        rot_perp = Rotation.about_axis("y", np.pi, dtype=self.dtype).matrices
 
         # Full set of rotations.
         rots = np.concatenate((rot_z, rot_z @ rot_perp[0]))
@@ -218,22 +217,22 @@ class TSymmetryGroup(SymmetryGroup):
         """
         # C3 rotation vectors, ie. angle * axis.
         axes_C3 = np.array(
-            [[1, 1, 1], [-1, -1, 1], [1, -1, -1], [-1, 1, -1]], dtype=self.dtype
+            [[1.0, 1.0, 1.0], [-1.0, -1.0, 1.0], [1.0, -1.0, -1.0], [-1.0, 1.0, -1.0]],
         )
         axes_C3 /= np.linalg.norm(axes_C3, axis=-1)[..., np.newaxis]
-        angles_C3 = np.array([2 * np.pi / 3, 4 * np.pi / 3], dtype=self.dtype)
+        angles_C3 = np.array([2 * np.pi / 3, 4 * np.pi / 3])
         rot_vecs_C3 = np.concatenate([angle * axes_C3 for angle in angles_C3])
 
         # C2 rotation vectors.
-        axes_C2 = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=self.dtype)
+        axes_C2 = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
         rot_vecs_C2 = np.pi * axes_C2
 
         # The full set of rotation vectors inducing tetrahedral symmetry.
-        rot_vec_I = np.zeros((1, 3), dtype=self.dtype)
+        rot_vec_I = np.zeros((1, 3))
         rot_vecs = np.concatenate((rot_vec_I, rot_vecs_C3, rot_vecs_C2))
 
         # Return rotations.
-        return Rotation.from_rotvec(rot_vecs)
+        return Rotation.from_rotvec(rot_vecs, dtype=self.dtype)
 
 
 class OSymmetryGroup(SymmetryGroup):
@@ -268,35 +267,39 @@ class OSymmetryGroup(SymmetryGroup):
         """
 
         # C4 rotation vectors, ie angle * axis
-        axes_C4 = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=self.dtype)
-        angles_C4 = np.array([np.pi / 2, np.pi, 3 * np.pi / 2], dtype=self.dtype)
+        axes_C4 = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+        angles_C4 = np.array([np.pi / 2, np.pi, 3 * np.pi / 2])
         rot_vecs_C4 = np.array(
             [angle * axes_C4 for angle in angles_C4],
-            dtype=self.dtype,
         ).reshape((9, 3))
 
         # C3 rotation vectors
         axes_C3 = np.array(
-            [[1, 1, 1], [-1, 1, 1], [1, -1, 1], [1, 1, -1]], dtype=self.dtype
+            [[1.0, 1.0, 1.0], [-1.0, 1.0, 1.0], [1.0, -1.0, 1.0], [1.0, 1.0, -1.0]]
         )
         axes_C3 /= np.linalg.norm(axes_C3, axis=-1)[..., np.newaxis]
-        angles_C3 = np.array([2 * np.pi / 3, 4 * np.pi / 3], dtype=self.dtype)
+        angles_C3 = np.array([2 * np.pi / 3, 4 * np.pi / 3])
         rot_vecs_C3 = np.array(
             [angle * axes_C3 for angle in angles_C3],
-            dtype=self.dtype,
         ).reshape((8, 3))
 
         # C2 rotation vectors
         axes_C2 = np.array(
-            [[1, 1, 0], [-1, 1, 0], [1, 0, 1], [-1, 0, 1], [0, 1, 1], [0, -1, 1]],
-            dtype=self.dtype,
+            [
+                [1.0, 1.0, 0.0],
+                [-1.0, 1.0, 0.0],
+                [1.0, 0.0, 1.0],
+                [-1.0, 0.0, 1.0],
+                [0.0, 1.0, 1.0],
+                [0.0, -1.0, 1.0],
+            ],
         )
         axes_C2 /= np.linalg.norm(axes_C2, axis=-1)[..., np.newaxis]
         rot_vecs_C2 = np.pi * axes_C2
 
         # The full set of rotation vectors inducing octahedral symmetry.
-        rot_vec_I = np.zeros((1, 3), dtype=self.dtype)
+        rot_vec_I = np.zeros((1, 3))
         rot_vecs = np.concatenate((rot_vec_I, rot_vecs_C4, rot_vecs_C3, rot_vecs_C2))
 
         # Return rotations.
-        return Rotation.from_rotvec(rot_vecs)
+        return Rotation.from_rotvec(rot_vecs, dtype=self.dtype)

--- a/src/aspire/volume/symmetry_groups.py
+++ b/src/aspire/volume/symmetry_groups.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from abc import ABC, abstractmethod, abstractproperty
 
 import numpy as np
@@ -61,7 +62,11 @@ class SymmetryGroup(ABC):
 
         if isinstance(symmetry, SymmetryGroup):
             if symmetry.dtype != dtype:
-                logger.warning(f"Recasting SymmetryGroup with dtype {dtype}.")
+                warnings.warn(
+                    f"Recasting SymmetryGroup with dtype {dtype}.",
+                    category=UserWarning,
+                    stacklevel=2,
+                )
                 group_kwargs = dict(dtype=dtype)
                 if getattr(symmetry, "order", False) and symmetry.order > 1:
                     group_kwargs["order"] = symmetry.order
@@ -97,6 +102,10 @@ class SymmetryGroup(ABC):
             group_kwargs["order"] = int(symmetric_order)
 
         return symmetry_group(**group_kwargs)
+
+    def astype(self, dtype):
+        """Copy of the SymmetryGroup object, cast to a specified dtype."""
+        return SymmetryGroup.parse(self.to_string, dtype)
 
 
 class CnSymmetryGroup(SymmetryGroup):

--- a/src/aspire/volume/symmetry_groups.py
+++ b/src/aspire/volume/symmetry_groups.py
@@ -172,12 +172,13 @@ class DnSymmetryGroup(SymmetryGroup):
 
         :return: Rotation object containing the Dn symmetry group and the identity.
         """
+
         # Rotations to induce cyclic symmetry
         angles = 2 * np.pi * np.arange(self.order) / self.order
-        rot_z = Rotation.about_axis("z", angles).matrices
+        rot_z = Rotation.about_axis("z", angles, dtype=np.float64).matrices
 
         # Perpendicular rotation to induce dihedral symmetry
-        rot_perp = Rotation.about_axis("y", np.pi).matrices
+        rot_perp = Rotation.about_axis("y", np.pi, dtype=np.float64).matrices
 
         # Full set of rotations.
         rots = np.concatenate((rot_z, rot_z @ rot_perp[0]))
@@ -215,7 +216,9 @@ class TSymmetryGroup(SymmetryGroup):
         :return: Rotation object containing the tetrahedral symmetry group and the identity.
         """
         # C3 rotation vectors, ie. angle * axis.
-        axes_C3 = np.array([[1, 1, 1], [-1, -1, 1], [1, -1, -1], [-1, 1, -1]], dtype=np.float64)
+        axes_C3 = np.array(
+            [[1, 1, 1], [-1, -1, 1], [1, -1, -1], [-1, 1, -1]], dtype=np.float64
+        )
         axes_C3 /= np.linalg.norm(axes_C3, axis=-1)[..., np.newaxis]
         angles_C3 = np.array([2 * np.pi / 3, 4 * np.pi / 3], dtype=np.float64)
         rot_vecs_C3 = np.concatenate([angle * axes_C3 for angle in angles_C3])
@@ -225,7 +228,7 @@ class TSymmetryGroup(SymmetryGroup):
         rot_vecs_C2 = np.pi * axes_C2
 
         # The full set of rotation vectors inducing tetrahedral symmetry.
-        rot_vec_I = np.zeros((1, 3))
+        rot_vec_I = np.zeros((1, 3), dtype=np.float64)
         rot_vecs = np.concatenate((rot_vec_I, rot_vecs_C3, rot_vecs_C2))
 
         # Return rotations.
@@ -267,15 +270,19 @@ class OSymmetryGroup(SymmetryGroup):
         axes_C4 = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=np.float64)
         angles_C4 = np.array([np.pi / 2, np.pi, 3 * np.pi / 2], dtype=np.float64)
         rot_vecs_C4 = np.array(
-            [angle * axes_C4 for angle in angles_C4], dtype=np.float64,
+            [angle * axes_C4 for angle in angles_C4],
+            dtype=np.float64,
         ).reshape((9, 3))
 
         # C3 rotation vectors
-        axes_C3 = np.array([[1, 1, 1], [-1, 1, 1], [1, -1, 1], [1, 1, -1]], dtype=np.float64)
+        axes_C3 = np.array(
+            [[1, 1, 1], [-1, 1, 1], [1, -1, 1], [1, 1, -1]], dtype=np.float64
+        )
         axes_C3 /= np.linalg.norm(axes_C3, axis=-1)[..., np.newaxis]
         angles_C3 = np.array([2 * np.pi / 3, 4 * np.pi / 3], dtype=np.float64)
         rot_vecs_C3 = np.array(
-            [angle * axes_C3 for angle in angles_C3], dtype=np.float64,
+            [angle * axes_C3 for angle in angles_C3],
+            dtype=np.float64,
         ).reshape((8, 3))
 
         # C2 rotation vectors
@@ -287,7 +294,7 @@ class OSymmetryGroup(SymmetryGroup):
         rot_vecs_C2 = np.pi * axes_C2
 
         # The full set of rotation vectors inducing octahedral symmetry.
-        rot_vec_I = np.zeros((1, 3))
+        rot_vec_I = np.zeros((1, 3), dtype=np.float64)
         rot_vecs = np.concatenate((rot_vec_I, rot_vecs_C4, rot_vecs_C3, rot_vecs_C2))
 
         # Return rotations.

--- a/src/aspire/volume/symmetry_groups.py
+++ b/src/aspire/volume/symmetry_groups.py
@@ -105,7 +105,12 @@ class SymmetryGroup(ABC):
 
     def astype(self, dtype):
         """Copy of the SymmetryGroup object, cast to a specified dtype."""
-        return SymmetryGroup.parse(self.to_string, dtype)
+        kwargs = {"dtype": dtype}
+
+        if hasattr(self, "order"):
+            kwargs["order"] = self.order
+
+        return self.__class__(**kwargs)
 
 
 class CnSymmetryGroup(SymmetryGroup):

--- a/src/aspire/volume/symmetry_groups.py
+++ b/src/aspire/volume/symmetry_groups.py
@@ -124,7 +124,7 @@ class CnSymmetryGroup(SymmetryGroup):
         :return: Rotation object containing the Cn symmetry group and the identity.
         """
         angles = 2 * np.pi * np.arange(self.order) / self.order
-        return Rotation.about_axis("z", angles, dtype=np.float64)
+        return Rotation.about_axis("z", angles)
 
 
 class IdentitySymmetryGroup(CnSymmetryGroup):
@@ -174,10 +174,10 @@ class DnSymmetryGroup(SymmetryGroup):
 
         # Rotations to induce cyclic symmetry
         angles = 2 * np.pi * np.arange(self.order) / self.order
-        rot_z = Rotation.about_axis("z", angles, dtype=np.float64).matrices
+        rot_z = Rotation.about_axis("z", angles).matrices
 
         # Perpendicular rotation to induce dihedral symmetry
-        rot_perp = Rotation.about_axis("y", np.pi, dtype=np.float64).matrices
+        rot_perp = Rotation.about_axis("y", np.pi).matrices
 
         # Full set of rotations.
         rots = np.concatenate((rot_z, rot_z @ rot_perp[0]))

--- a/src/aspire/volume/symmetry_groups.py
+++ b/src/aspire/volume/symmetry_groups.py
@@ -124,9 +124,7 @@ class CnSymmetryGroup(SymmetryGroup):
 
         :return: Rotation object containing the Cn symmetry group and the identity.
         """
-        angles = (2 * np.pi * np.arange(self.order) / self.order).astype(
-            self.dtype, copy=False
-        )
+        angles = np.linspace(0, 2 * np.pi, self.order, endpoint=False, dtype=self.dtype)
         return Rotation.about_axis("z", angles)
 
 
@@ -176,9 +174,7 @@ class DnSymmetryGroup(SymmetryGroup):
         """
 
         # Rotations to induce cyclic symmetry
-        angles = (2 * np.pi * np.arange(self.order) / self.order).astype(
-            self.dtype, copy=False
-        )
+        angles = np.linspace(0, 2 * np.pi, self.order, endpoint=False, dtype=self.dtype)
         rot_z = Rotation.about_axis("z", angles).matrices
 
         # Perpendicular rotation to induce dihedral symmetry

--- a/src/aspire/volume/volume.py
+++ b/src/aspire/volume/volume.py
@@ -150,7 +150,7 @@ class Volume:
         return self.__class__(
             self.asnumpy().astype(dtype, copy=copy),
             pixel_size=self.pixel_size,
-            symmetry_group=self.symmetry_group,
+            symmetry_group=self.symmetry_group.astype(dtype),
         )
 
     def _check_key_dims(self, key):

--- a/src/aspire/volume/volume.py
+++ b/src/aspire/volume/volume.py
@@ -150,7 +150,7 @@ class Volume:
         return self.__class__(
             self.asnumpy().astype(dtype, copy=copy),
             pixel_size=self.pixel_size,
-            symmetry_group=self.symmetry_group.astype(dtype),
+            symmetry_group=self.symmetry_group,
         )
 
     def _check_key_dims(self, key):
@@ -185,7 +185,7 @@ class Volume:
 
         :param value: A `SymmetryGroup` instance or string indicating symmetry, ie. "C5", "D7", "T", etc.
         """
-        self._symmetry_group = SymmetryGroup.parse(value, dtype=self.dtype)
+        self._symmetry_group = SymmetryGroup.parse(value)
 
     def _symmetry_group_warning(self, stacklevel):
         """
@@ -228,7 +228,7 @@ class Volume:
 
         if any([axes_altering_transformation, incompat_syms, arbitrary_array]):
             self._symmetry_group_warning(stacklevel=stacklevel)
-            result_symmetry = IdentitySymmetryGroup(dtype=self.dtype)
+            result_symmetry = IdentitySymmetryGroup()
 
         return result_symmetry
 

--- a/src/aspire/volume/volume_synthesis.py
+++ b/src/aspire/volume/volume_synthesis.py
@@ -207,7 +207,7 @@ class CnSymmetricVolume(GaussianBlobsVolume):
             )
 
     def _set_symmetry_group(self):
-        self._symmetry_group = CnSymmetryGroup(order=self.order, dtype=self.dtype)
+        self._symmetry_group = CnSymmetryGroup(order=self.order)
 
     @property
     def n_blobs(self):
@@ -220,7 +220,7 @@ class DnSymmetricVolume(CnSymmetricVolume):
     """
 
     def _set_symmetry_group(self):
-        self._symmetry_group = DnSymmetryGroup(order=self.order, dtype=self.dtype)
+        self._symmetry_group = DnSymmetryGroup(order=self.order)
 
     @property
     def n_blobs(self):
@@ -233,7 +233,7 @@ class TSymmetricVolume(GaussianBlobsVolume):
     """
 
     def _set_symmetry_group(self):
-        self._symmetry_group = TSymmetryGroup(dtype=self.dtype)
+        self._symmetry_group = TSymmetryGroup()
 
     @property
     def n_blobs(self):
@@ -246,7 +246,7 @@ class OSymmetricVolume(GaussianBlobsVolume):
     """
 
     def _set_symmetry_group(self):
-        self._symmetry_group = OSymmetryGroup(dtype=self.dtype)
+        self._symmetry_group = OSymmetryGroup()
 
     @property
     def n_blobs(self):
@@ -270,7 +270,7 @@ class AsymmetricVolume(CnSymmetricVolume):
             )
 
     def _set_symmetry_group(self):
-        self._symmetry_group = IdentitySymmetryGroup(dtype=self.dtype)
+        self._symmetry_group = IdentitySymmetryGroup()
 
     def _symmetrize_gaussians(self, Q, D, mu):
         return Q, D, mu

--- a/src/aspire/volume/volume_synthesis.py
+++ b/src/aspire/volume/volume_synthesis.py
@@ -126,7 +126,7 @@ class GaussianBlobsVolume(SyntheticVolumeBase):
         """
         Called to add symmetry to Volumes by generating for each Gaussian blob duplicates in symmetric positions.
         """
-        rots = self.symmetry_group.matrices.astype(self.dtype)
+        rots = self.symmetry_group.matrices.astype(self.dtype, copy=False)
 
         Q_rot = np.zeros(shape=(self.n_blobs, 3, 3)).astype(self.dtype)
         D_sym = np.zeros(shape=(self.n_blobs, 3, 3)).astype(self.dtype)

--- a/src/aspire/volume/volume_synthesis.py
+++ b/src/aspire/volume/volume_synthesis.py
@@ -126,7 +126,7 @@ class GaussianBlobsVolume(SyntheticVolumeBase):
         """
         Called to add symmetry to Volumes by generating for each Gaussian blob duplicates in symmetric positions.
         """
-        rots = self.symmetry_group.matrices
+        rots = self.symmetry_group.matrices.astype(self.dtype)
 
         Q_rot = np.zeros(shape=(self.n_blobs, 3, 3)).astype(self.dtype)
         D_sym = np.zeros(shape=(self.n_blobs, 3, 3)).astype(self.dtype)

--- a/tests/test_array_image_source.py
+++ b/tests/test_array_image_source.py
@@ -5,6 +5,7 @@ import tempfile
 from unittest import TestCase
 
 import numpy as np
+import pytest
 from pytest import raises
 
 from aspire.basis import FBBasis3D
@@ -242,3 +243,21 @@ class ImageTestCase(TestCase):
             # Test the content matched when loaded
             src2 = RelionSource(star_path)
             np.testing.assert_allclose(src.images[:], src2.images[:])
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_dtype_passthrough(dtype):
+    """
+    Test dtypes are passed appropriately to metadata.
+    """
+    n_ims = 10
+    res = 32
+    ims = np.ones((n_ims, res, res), dtype=dtype)
+
+    src = ArrayImageSource(ims)
+
+    # Check dtypes
+    np.testing.assert_equal(src.dtype, dtype)
+    np.testing.assert_equal(src.images[:].dtype, dtype)
+    np.testing.assert_equal(src.amplitudes.dtype, dtype)
+    np.testing.assert_equal(src.offsets.dtype, dtype)

--- a/tests/test_bot_align.py
+++ b/tests/test_bot_align.py
@@ -74,10 +74,10 @@ def vol_data_fixture(snr, dtype):
     L = v.resolution
     shape = (L, L, L)
     ns_std = np.sqrt(norm(v) ** 2 / (L**3 * snr)).astype(v.dtype)
-    reference_vol = v + normal(0, ns_std, shape)
+    reference_vol = v + normal(0, ns_std, shape).astype(dtype, copy=False)
     r = Rotation.generate_random_rotations(1, dtype=v.dtype, seed=1234)
     R_true = r.matrices[0]
-    test_vol = v.rotate(r) + normal(0, ns_std, shape)
+    test_vol = v.rotate(r) + normal(0, ns_std, shape).astype(dtype, copy=False)
 
     return reference_vol, test_vol, R_true
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -338,7 +338,7 @@ def test_backproject_symmetry_group(dtype):
     assert isinstance(vol.symmetry_group, CnSymmetryGroup)
 
     # Symmetry from instance.
-    vol = im.backproject(rots, symmetry_group=CnSymmetryGroup(order=3, dtype=dtype))
+    vol = im.backproject(rots, symmetry_group=CnSymmetryGroup(order=3))
     assert isinstance(vol.symmetry_group, CnSymmetryGroup)
 
 

--- a/tests/test_mean_estimator_boosting.py
+++ b/tests/test_mean_estimator_boosting.py
@@ -148,7 +148,7 @@ def test_boost_flag(source, estimated_volume):
     """Manually boost a source and reconstruct without boosting."""
     ims = source.projections[:]
     rots = source.rotations
-    sym_rots = source.symmetry_group.matrices.astype(dtype=source.dtype)
+    sym_rots = source.symmetry_group.matrices.astype(dtype=source.dtype, copy=False)
     sym_order = len(sym_rots)
 
     # Manually boosted images and rotations.

--- a/tests/test_mean_estimator_boosting.py
+++ b/tests/test_mean_estimator_boosting.py
@@ -148,7 +148,7 @@ def test_boost_flag(source, estimated_volume):
     """Manually boost a source and reconstruct without boosting."""
     ims = source.projections[:]
     rots = source.rotations
-    sym_rots = source.symmetry_group.matrices
+    sym_rots = source.symmetry_group.matrices.astype(dtype=source.dtype)
     sym_order = len(sym_rots)
 
     # Manually boosted images and rotations.

--- a/tests/test_mean_estimator_boosting.py
+++ b/tests/test_mean_estimator_boosting.py
@@ -148,7 +148,7 @@ def test_boost_flag(source, estimated_volume):
     """Manually boost a source and reconstruct without boosting."""
     ims = source.projections[:]
     rots = source.rotations
-    sym_rots = source.symmetry_group.matrices.astype(dtype=source.dtype, copy=False)
+    sym_rots = source.symmetry_group.matrices.astype(dtype=source.dtype)
     sym_order = len(sym_rots)
 
     # Manually boosted images and rotations.

--- a/tests/test_orient_d2.py
+++ b/tests/test_orient_d2.py
@@ -405,7 +405,7 @@ def g_sync_d2(rots, rots_gt):
     n_img = len(rots)
     dtype = rots.dtype
 
-    rots_symm = DnSymmetryGroup(2, dtype).matrices
+    rots_symm = DnSymmetryGroup(2).matrices.astype(dtype)
     order = len(rots_symm)
 
     A_g = np.zeros((n_img, n_img), dtype=complex)

--- a/tests/test_orient_d2.py
+++ b/tests/test_orient_d2.py
@@ -405,7 +405,7 @@ def g_sync_d2(rots, rots_gt):
     n_img = len(rots)
     dtype = rots.dtype
 
-    rots_symm = DnSymmetryGroup(2).matrices.astype(dtype)
+    rots_symm = DnSymmetryGroup(2).matrices.astype(dtype, copy=False)
     order = len(rots_symm)
 
     A_g = np.zeros((n_img, n_img), dtype=complex)

--- a/tests/test_rotation.py
+++ b/tests/test_rotation.py
@@ -143,6 +143,18 @@ def test_dtype(dtype, rot_obj):
     assert dtype == rot_obj.dtype
 
 
+def test_about_axis_dtype(dtype):
+    angles = np.random.uniform(0, 2 * np.pi, 10).astype(dtype, copy=False)
+    rots = Rotation.about_axis("x", angles).matrices
+    np.testing.assert_equal(rots.dtype, dtype)
+
+
+def test_about_axis_float_dtype():
+    angle = np.pi
+    rot = Rotation.about_axis("y", angle).matrices
+    np.testing.assert_equal(rot.dtype, np.float64)
+
+
 def test_from_rotvec(rot_obj):
     # Build random rotation vectors.
     axis = np.array([1, 0, 0], dtype=rot_obj.dtype)

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -400,7 +400,6 @@ class SimTestCase(TestCase):
 
     def testSimulationVolCoords(self):
         coords, norms, inners = self.sim.vol_coords()
-
         np.testing.assert_allclose([4.72837704, -4.72837709], coords, atol=1e-4)
         np.testing.assert_allclose([8.20515764e-07, 1.17550184e-06], norms, atol=1e-4)
         np.testing.assert_allclose(

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -400,6 +400,7 @@ class SimTestCase(TestCase):
 
     def testSimulationVolCoords(self):
         coords, norms, inners = self.sim.vol_coords()
+
         np.testing.assert_allclose([4.72837704, -4.72837709], coords, atol=1e-4)
         np.testing.assert_allclose([8.20515764e-07, 1.17550184e-06], norms, atol=1e-4)
         np.testing.assert_allclose(
@@ -494,7 +495,9 @@ class SimTestCase(TestCase):
         np.testing.assert_allclose(result, covar[:, :, 4, 4, 4, 4], atol=1e-4)
 
     def testSimulationEvalMean(self):
-        mean_est = Volume(np.load(os.path.join(DATA_DIR, "mean_8_8_8.npy")))
+        mean_est = Volume(
+            np.load(os.path.join(DATA_DIR, "mean_8_8_8.npy")), dtype=self.dtype
+        )
         result = self.sim.eval_mean(mean_est)
 
         np.testing.assert_allclose(result["err"], 2.664116055950763, atol=1e-4)
@@ -510,14 +513,17 @@ class SimTestCase(TestCase):
         np.testing.assert_allclose(result["corr"], 0.8405347287741631, atol=1e-4)
 
     def testSimulationEvalCoords(self):
-        mean_est = Volume(np.load(os.path.join(DATA_DIR, "mean_8_8_8.npy")))
+        mean_est = Volume(
+            np.load(os.path.join(DATA_DIR, "mean_8_8_8.npy")), dtype=self.dtype
+        )
         eigs_est = Volume(
-            np.load(os.path.join(DATA_DIR, "eigs_est_8_8_8_1.npy"))[..., 0]
+            np.load(os.path.join(DATA_DIR, "eigs_est_8_8_8_1.npy"))[..., 0],
+            dtype=self.dtype,
         )
 
         clustered_coords_est = np.load(
             os.path.join(DATA_DIR, "clustered_coords_est.npy")
-        )
+        ).astype(dtype=self.dtype)
 
         result = self.sim.eval_coords(mean_est, eigs_est, clustered_coords_est)
 
@@ -551,6 +557,8 @@ class SimTestCase(TestCase):
                 0.11048937,
                 0.11048937,
             ],
+            rtol=1e-05,
+            atol=1e-08,
         )
 
         np.testing.assert_allclose(

--- a/tests/test_symmetry_groups.py
+++ b/tests/test_symmetry_groups.py
@@ -80,6 +80,20 @@ def test_group_rotations(group_fixture):
     assert isinstance(rotations, Rotation)
 
 
+def test_astype(group_fixture):
+    """Test `astype` returns correct SymmetryGroup with correct dtype."""
+    sym_group_singles = group_fixture.astype(np.float32)
+    sym_group_doubles = group_fixture.astype(np.float64)
+
+    # Check that astype returns the correct SymmetryGroup
+    np.testing.assert_equal(sym_group_singles, group_fixture)
+    np.testing.assert_equal(sym_group_doubles, group_fixture)
+
+    # Check that we have specified dtype
+    np.testing.assert_equal(sym_group_singles.dtype, np.float32)
+    np.testing.assert_equal(sym_group_doubles.dtype, np.float64)
+
+
 def test_parser_identity():
     result = SymmetryGroup.parse("C1", dtype=np.float32)
     assert isinstance(result, IdentitySymmetryGroup)
@@ -92,16 +106,15 @@ def test_parser_with_group(group_fixture):
     assert result.dtype == group_fixture.dtype
 
 
-def test_parser_dtype_casting(group_fixture, caplog):
+def test_parser_dtype_casting(group_fixture):
     """Test that dtype gets re-cast and warns."""
     dtype = np.float32
     if group_fixture.dtype == np.float32:
         dtype = np.float64
 
-    caplog.clear()
     msg = f"Recasting SymmetryGroup with dtype {dtype}."
-    _ = SymmetryGroup.parse(group_fixture, dtype)
-    assert msg in caplog.text
+    with pytest.warns(UserWarning, match=msg):
+        _ = SymmetryGroup.parse(group_fixture, dtype)
 
 
 def test_parser_error():

--- a/tests/test_symmetry_groups.py
+++ b/tests/test_symmetry_groups.py
@@ -86,8 +86,8 @@ def test_astype(group_fixture):
     sym_group_doubles = group_fixture.astype(np.float64)
 
     # Check that astype returns the correct SymmetryGroup
-    np.testing.assert_equal(sym_group_singles, group_fixture)
-    np.testing.assert_equal(sym_group_doubles, group_fixture)
+    np.testing.assert_equal(str(sym_group_singles), str(group_fixture))
+    np.testing.assert_equal(str(sym_group_doubles), str(group_fixture))
 
     # Check that we have specified dtype
     np.testing.assert_equal(sym_group_singles.dtype, np.float32)

--- a/tests/test_synthetic_volume.py
+++ b/tests/test_synthetic_volume.py
@@ -114,6 +114,12 @@ def test_volume_generate(vol_fixture):
         np.testing.assert_approx_equal(v.pixel_size, PXSZ)
 
 
+def test_dtype_passthrough(vol_fixture, dtype_fixture):
+    """Test Volume are generated with correct dtype."""
+    vol = vol_fixture.generate()
+    np.testing.assert_equal(vol._data.dtype, dtype_fixture)
+
+
 def test_simulation_init(vol_fixture):
     """Test that a Simulation initializes provided a synthetic Volume."""
     _ = Simulation(L=vol_fixture.L, vols=vol_fixture.generate())
@@ -135,12 +141,12 @@ def test_compact_support(vol_fixture):
 
 # Supress expected warnings due to rotation of symmetric volume.
 @pytest.mark.filterwarnings("ignore:`symmetry_group` attribute is being set to `C1`")
-def test_volume_symmetry(vol_fixture):
+def test_volume_symmetry(vol_fixture, dtype_fixture):
     """Test that volumes have intended symmetry."""
     vol = vol_fixture.generate()
 
     # Rotations in symmetry group, excluding the Identity.
-    rots = vol_fixture.symmetry_group.matrices[1:]
+    rots = vol_fixture.symmetry_group.matrices[1:].astype(dtype_fixture)
 
     for rot in rots:
         # Rotate volume by an element of the symmetric group.

--- a/tests/test_synthetic_volume.py
+++ b/tests/test_synthetic_volume.py
@@ -146,7 +146,7 @@ def test_volume_symmetry(vol_fixture, dtype_fixture):
     vol = vol_fixture.generate()
 
     # Rotations in symmetry group, excluding the Identity.
-    rots = vol_fixture.symmetry_group.matrices[1:].astype(dtype_fixture, copy=False)
+    rots = vol_fixture.symmetry_group.matrices[1:].astype(dtype_fixture)
 
     for rot in rots:
         # Rotate volume by an element of the symmetric group.

--- a/tests/test_synthetic_volume.py
+++ b/tests/test_synthetic_volume.py
@@ -146,7 +146,7 @@ def test_volume_symmetry(vol_fixture, dtype_fixture):
     vol = vol_fixture.generate()
 
     # Rotations in symmetry group, excluding the Identity.
-    rots = vol_fixture.symmetry_group.matrices[1:].astype(dtype_fixture)
+    rots = vol_fixture.symmetry_group.matrices[1:].astype(dtype_fixture, copy=False)
 
     for rot in rots:
         # Rotate volume by an element of the symmetric group.

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -821,7 +821,7 @@ def test_project_broadcast(dtype):
 # SYM_GROUP_PARAMS consists of (initializing method, string representation).
 # Testing just the basic cases of setting the symmetry group from
 # a SymmetryGroup instance, a string, and the default.
-SYM_GROUP_PARAMS = [(TSymmetryGroup(np.float32), "T"), ("D2", "D2"), (None, "C1")]
+SYM_GROUP_PARAMS = [(TSymmetryGroup(), "T"), ("D2", "D2"), (None, "C1")]
 
 
 @pytest.mark.parametrize("sym_group, sym_string", SYM_GROUP_PARAMS)

--- a/tests/test_weighted_mean_estimator.py
+++ b/tests/test_weighted_mean_estimator.py
@@ -43,6 +43,11 @@ def dtype(request):
     return request.param
 
 
+@pytest.fixture(params=DTYPE, ids=lambda x: f"weights_dtype={x}", scope="module")
+def weights_dtype(request):
+    return request.param
+
+
 @pytest.fixture(scope="module")
 def sim(L, dtype):
     sim = Simulation(
@@ -67,11 +72,13 @@ def basis(L, dtype):
 
 
 @pytest.fixture(scope="module")
-def weights(sim):
+def weights(sim, weights_dtype):
     # Construct simple test weights;
     # one uniform positive and negative weighted volume respectively.
     r = 2  # Number of weighted volumes
-    weights = np.ones((sim.n, r), dtype=sim.dtype) / np.sqrt(sim.n, dtype=sim.dtype)
+    weights = np.ones((sim.n, r), dtype=weights_dtype) / np.sqrt(
+        sim.n, dtype=weights_dtype
+    )
     weights[:, 1] *= -1  # negate second weight vector
 
     return weights

--- a/tests/test_weighted_mean_estimator.py
+++ b/tests/test_weighted_mean_estimator.py
@@ -76,8 +76,8 @@ def weights(sim, weights_dtype):
     # Construct simple test weights;
     # one uniform positive and negative weighted volume respectively.
     r = 2  # Number of weighted volumes
-    weights = np.ones((sim.n, r), dtype=weights_dtype) / np.sqrt(
-        sim.n, dtype=weights_dtype
+    weights = np.full(
+        (sim.n, r), 1 / np.sqrt(sim.n, dtype=weights_dtype), dtype=weights_dtype
     )
     weights[:, 1] *= -1  # negate second weight vector
 

--- a/tests/test_weighted_mean_estimator.py
+++ b/tests/test_weighted_mean_estimator.py
@@ -71,7 +71,7 @@ def weights(sim):
     # Construct simple test weights;
     # one uniform positive and negative weighted volume respectively.
     r = 2  # Number of weighted volumes
-    weights = np.ones((sim.n, r)) / np.sqrt(sim.n)
+    weights = np.ones((sim.n, r), dtype=sim.dtype) / np.sqrt(sim.n, dtype=sim.dtype)
     weights[:, 1] *= -1  # negate second weight vector
 
     return weights

--- a/tests/test_weighted_mean_estimator.py
+++ b/tests/test_weighted_mean_estimator.py
@@ -76,9 +76,7 @@ def weights(sim, weights_dtype):
     # Construct simple test weights;
     # one uniform positive and negative weighted volume respectively.
     r = 2  # Number of weighted volumes
-    weights = np.full(
-        (sim.n, r), 1 / np.sqrt(sim.n, dtype=weights_dtype), dtype=weights_dtype
-    )
+    weights = np.full((sim.n, r), 1 / np.sqrt(sim.n), dtype=weights_dtype)
     weights[:, 1] *= -1  # negate second weight vector
 
     return weights


### PR DESCRIPTION
The `SymmetryGroup.parse()` method was logging quite a few   warning messages about recasting dtype as detailed in #1234. Turns out our testing suite was also logging a lot of these warnings as well.

In this PR I convert from using the logger to using the `warnings` module. This way any warnings of this type will be caught by CI.

After changing to `warnings` this is the list of warnings from our test suite:
```
tests/test_dirac_basis.py: 2 warnings
tests/test_mean_estimator.py: 16 warnings
tests/test_mean_estimator_boosting.py: 4 warnings
tests/test_array_image_source.py: 4 warnings
tests/test_weighted_mean_estimator.py: 32 warnings
/Users/carmichael/Work/ASPIRE-python.fix_sym_warnings/src/aspire/image/image.py:735:
UserWarning: Recasting SymmetryGroup
ith dtype float64.
    symmetry_rots = SymmetryGroup parse (symmetry_group, dtype=self.dtype) matrices

tests/test_dirac_basis.py: 2 warnings 
tests/test_bot_align.py: 4 warnings 
tests/test_mean_estimator.py: 16 warnings
tests/test_mean_estimator_boosting.py: 4 warnings
tests/test_array_image_source.py: 4 warnings
tests/test_simulation.py: 4 warnings 
tests/test_volume.py: 4 warnings
tests/test_weighted_mean_estimator.py: 32 warnings
tests/test_rotation.py: 1 warning
/Users/carmichael/Work/ASPIRE-python.fix_sym_warnings/src/aspire/volume/volume.py:188: UserWarning: Recasting SymmetryGroup
with dtype float64.
    self._symmetry_group = SymmetryGroup.parse(value, dtype=self.dtype)

tests/test_dirac_basis.py: 2 warnings
tests/test_mean_estimator.py: 16 warnings
tests/test_mean_estimator_boosting.py: 11 warnings
tests/test_array_image_source.py: 4 warnings 
tests/ test_volume.py: 2 warnings
tests/test_weighted_mean_estimator.py: 32 warnings
/Users/carmichael/Work/ASPIRE-python.fix_sym_warnings/src/aspire/volume/volume.py:188: UserWarning: Recasting SymmetryGroup
with dtype float32.
    self._symmetry_group = SymmetryGroup. parse(value, dtype=self.dtype)
```

Basically, this warning was emitted anytime an `Image` or `Volume` was instantiated using data that had a different dtype than `self.dtype` (`self` being the object handling the creation of `Volume`/`Image`). In some cases, we were explicitly mixing dtypes in our tests. In other cases, we were not properly dtype-ing arrays in our code.

Here is the list of changes covered in this PR:

- [x] Change `SymmetryGoup.parse()` logger.warning to `warnings.warn` and adapt the unit test to catch the warnings.
- [x] `MeanEstimator` `weights` attribute was always in doubles due to `np.ones` and `np.sqrt` not being dtyped. Added dtyping.
- [x] Fix `Volume.astype()` to return `Volume` with properly dtyped symmetry group. I accomplished this by adding `SymmetryGroup.astype()` with an associated unit test.
- [x] `test_bot_align.py` was using `np.random.normal` without dtyping to create a volume. This would create mixed dtypes when the test ran in singles. Added dtyping.
- [x] `test_mean_estimator.py` was providing a `weights` array that was not dtyped. Added dtyping.
- [x] `ArrayImageSource` was always instantiating with `offsets` and `amplitudes` in doubles if they weren't provided. This caused mixed dtypes during mean estimation as certain arrays are scaled by `amplitudes`. Added dtypes to default `offset` and `amplitude` values and added a unit test to check these dtypes.
- [x] `Simulation.eigs()` was always returning doubles. Added dtyping.
- [x] A few test arrays in `test_simulation.py` were not dtyped. Added dtyping and adjusted the `np.testing.assert_allclose` tolerance to match `np.allclose` defaults.