### PR TITLE
Docs Cache Patch

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -298,10 +298,9 @@ jobs:
           echo "    cache_dir: .github_cache/ASPIRE-data" >> config.yaml
       - name: Build Sphinx docs
         run: |
-          export ASPIREDIR=.
           make distclean
           sphinx-apidoc -f -o ./source ../src -H Modules
-          make html
+          ASPIREDIR=. make html
         working-directory: ./docs
       - name: Archive Sphinx docs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -300,7 +300,7 @@ jobs:
         run: |
           make distclean
           sphinx-apidoc -f -o ./source ../src -H Modules
-          ASPIREDIR=. make html
+          ASPIREDIR=. make html SPHINXOPTS="-v"
         working-directory: ./docs
       - name: Archive Sphinx docs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -300,7 +300,7 @@ jobs:
         run: |
           make distclean
           sphinx-apidoc -f -o ./source ../src -H Modules
-          ASPIREDIR=${{ github.workspace }} make html SPHINXOPTS="-v"
+          ASPIREDIR=${{ github.workspace }} make html
         working-directory: ./docs
       - name: Archive Sphinx docs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -298,9 +298,10 @@ jobs:
           echo "    cache_dir: .github_cache/ASPIRE-data" >> config.yaml
       - name: Build Sphinx docs
         run: |
+          export ASPIREDIR=..
           make distclean
           sphinx-apidoc -f -o ./source ../src -H Modules
-          ASPIREDIR=${{ github.workspace }} make html
+          make html
         working-directory: ./docs
       - name: Archive Sphinx docs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -300,7 +300,7 @@ jobs:
         run: |
           make distclean
           sphinx-apidoc -f -o ./source ../src -H Modules
-          ASPIREDIR=. make html SPHINXOPTS="-v"
+          ASPIREDIR=${{ github.workspace }} make html SPHINXOPTS="-v"
         working-directory: ./docs
       - name: Archive Sphinx docs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -308,6 +308,16 @@ jobs:
           name: sphinx-docs
           path: docs/build
           retention-days: 7
+      - name: Validate Cache Directory Hash
+	run: |
+	  echo "Computing hash for .github_cache/ASPIRE-data..."
+	  new_hash=$(ls -1 .github_cache/ASPIRE-data/** | md5sum)
+	  echo "Hash from data-cache job: ${{ needs.data-cache.outputs.cache_hash }}"
+	  echo "Computed hash now: $new_hash"
+	  if [ "${{ needs.data-cache.outputs.cache_hash }}" != "$new_hash" ]; then
+	    echo "Error: Cache directory hash has changed!"
+	    exit 1
+	  fi
 
   osx_arm:
     needs: [check, data-cache]

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -309,15 +309,15 @@ jobs:
           path: docs/build
           retention-days: 7
       - name: Validate Cache Directory Hash
-	run: |
-	  echo "Computing hash for .github_cache/ASPIRE-data..."
-	  new_hash=$(ls -1 .github_cache/ASPIRE-data/** | md5sum)
-	  echo "Hash from data-cache job: ${{ needs.data-cache.outputs.cache_hash }}"
-	  echo "Computed hash now: $new_hash"
-	  if [ "${{ needs.data-cache.outputs.cache_hash }}" != "$new_hash" ]; then
-	    echo "Error: Cache directory hash has changed!"
-	    exit 1
-	  fi
+        run: |
+          echo "Computing hash for .github_cache/ASPIRE-data..."
+          new_hash=$(ls -1 .github_cache/ASPIRE-data/** | md5sum)
+          echo "Hash from data-cache job: ${{ needs.data-cache.outputs.cache_hash }}"
+          echo "Computed hash now: $new_hash"
+          if [ "${{ needs.data-cache.outputs.cache_hash }}" != "$new_hash" ]; then
+            echo "Error: Cache directory hash has changed!"
+            exit 1
+          fi
 
   osx_arm:
     needs: [check, data-cache]

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -298,7 +298,7 @@ jobs:
           echo "    cache_dir: .github_cache/ASPIRE-data" >> config.yaml
       - name: Build Sphinx docs
         run: |
-          export ASPIREDIR=..
+          export ASPIREDIR=${{ github.workspace }}
           make distclean
           sphinx-apidoc -f -o ./source ../src -H Modules
           make html

--- a/gallery/tutorials/pipeline_demo.py
+++ b/gallery/tutorials/pipeline_demo.py
@@ -17,11 +17,10 @@ reconstruction pipeline using synthetic data generated with ASPIRE's
 # sphinx_gallery_start_ignore
 # flake8: noqa
 # sphinx_gallery_end_ignore
-from aspire.downloader import emdb_2660, emdb_8012
+from aspire.downloader import emdb_2660
 
 # Load 80s Ribosome as a ``Volume`` object.
 original_vol = emdb_2660()
-test_vol = emdb_8012()
 
 # Downsample the volume
 res = 41

--- a/gallery/tutorials/pipeline_demo.py
+++ b/gallery/tutorials/pipeline_demo.py
@@ -18,6 +18,7 @@ reconstruction pipeline using synthetic data generated with ASPIRE's
 # flake8: noqa
 # sphinx_gallery_end_ignore
 from aspire.downloader import emdb_2660
+from aspire.downloader.data_fetcher import _data_fetcher
 
 # Load 80s Ribosome as a ``Volume`` object.
 original_vol = emdb_2660()
@@ -25,6 +26,7 @@ original_vol = emdb_2660()
 # Downsample the volume
 res = 41
 vol = original_vol.downsample(res)
+print(_data_fetcher.path)
 
 # %%
 # .. note::

--- a/gallery/tutorials/pipeline_demo.py
+++ b/gallery/tutorials/pipeline_demo.py
@@ -18,7 +18,6 @@ reconstruction pipeline using synthetic data generated with ASPIRE's
 # flake8: noqa
 # sphinx_gallery_end_ignore
 from aspire.downloader import emdb_2660
-from aspire.downloader.data_fetcher import _data_fetcher
 
 # Load 80s Ribosome as a ``Volume`` object.
 original_vol = emdb_2660()
@@ -26,7 +25,6 @@ original_vol = emdb_2660()
 # Downsample the volume
 res = 41
 vol = original_vol.downsample(res)
-print(_data_fetcher.path)
 
 # %%
 # .. note::

--- a/gallery/tutorials/pipeline_demo.py
+++ b/gallery/tutorials/pipeline_demo.py
@@ -17,10 +17,11 @@ reconstruction pipeline using synthetic data generated with ASPIRE's
 # sphinx_gallery_start_ignore
 # flake8: noqa
 # sphinx_gallery_end_ignore
-from aspire.downloader import emdb_2660
+from aspire.downloader import emdb_2660, emdb_8012
 
 # Load 80s Ribosome as a ``Volume`` object.
 original_vol = emdb_2660()
+test_vol = emdb_8012()
 
 # Downsample the volume
 res = 41


### PR DESCRIPTION
Turns out the docs CI job was not accessing the cache. Found this out by getting throttled on our gallery downloads. This patch fixes that and adds a cache directory hash validation step.

I confirmed that cache is actually being accessed now and that adding a new download file to the gallery will break CI during the hash validation step.

Still need to follow up and reduce the repeated CI steps: #1229 