### PR TITLE
LUD flaky test patch

### DIFF
--- a/tests/test_orient_lud.py
+++ b/tests/test_orient_lud.py
@@ -209,4 +209,4 @@ def test_adjoint_property_A(dtype):
     lhs = np.dot(Au, v)
     rhs = np.dot(u.flatten(), ATv.flatten())
 
-    np.testing.assert_allclose(lhs, rhs)
+    np.testing.assert_allclose(lhs, rhs, rtol=1e-05, atol=1e-08)


### PR DESCRIPTION
The adjoint test I added at the end of #1221 turned out to be flaky and just barely failed when pushed to `develop`. Added Numpy `allclose` default tolerances which resolves the failure.