### PR TITLE
Validate Downsample

### DIFF
--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -516,9 +516,9 @@ class Image:
 
         :param ds_res: int - new resolution, should be <= the current resolution
             of this Image
-        :param zero_nyquist: Option to keep or remove Nyquist frequency for even resolution.
-            Defaults to zero_nyquist=True, removing the Nyquist frequency.
-        :param legacy: Option to match legacy Matlab downsample method.
+        :param zero_nyquist: Option to keep or remove Nyquist frequency for even
+            resolution (boolean). Defaults to zero_nyquist=True, removing the Nyquist frequency.
+        :param legacy: Option to match legacy Matlab downsample method (boolean).
             Default of False uses `centered_fft` to maintain ASPIRE-Python centering conventions.
         :return: The downsampled Image object.
         """

--- a/src/aspire/image/xform.py
+++ b/src/aspire/image/xform.py
@@ -199,12 +199,26 @@ class Downsample(LinearXform):
     A Xform that downsamples an Image object to a resolution specified by this Xform's resolution.
     """
 
-    def __init__(self, resolution):
+    def __init__(self, resolution, zero_nyquist=True, legacy=False):
+        """
+        Initialize Xform to downsample Image to a specific resolution.
+
+        :param resolution: int - new resolution, should be <= the current resolution
+            of this Image
+        :param zero_nyquist: Option to keep or remove Nyquist frequency for even
+            resolution (boolean). Defaults to zero_nyquist=True, removing the Nyquist frequency.
+        :param legacy: Option to match legacy Matlab downsample method (boolean).
+            Default of False uses `centered_fft` to maintain ASPIRE-Python centering conventions.
+        """
         self.resolution = resolution
+        self.zero_nyquist = zero_nyquist
+        self.legacy = legacy
         super().__init__()
 
     def _forward(self, im, indices):
-        return im.downsample(self.resolution)
+        return im.downsample(
+            self.resolution, zero_nyquist=self.zero_nyquist, legacy=self.legacy
+        )
 
     def _adjoint(self, im, indices):
         # TODO: Implement up-sampling with zero-padding

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -769,14 +769,16 @@ class ImageSource(ABC):
         """
 
     @_as_copy
-    def downsample(self, L):
+    def downsample(self, L, zero_nyquist=True, legacy=False):
         if L > self.L:
             raise ValueError(
                 "Max desired resolution {L} should be less than the current resolution {self.L}."
             )
         logger.info(f"Setting max. resolution of source = {L}")
 
-        self.generation_pipeline.add_xform(Downsample(resolution=L))
+        self.generation_pipeline.add_xform(
+            Downsample(resolution=L, zero_nyquist=zero_nyquist, legacy=legacy)
+        )
 
         ds_factor = self.L / L
         self.unique_filters = [f.scale(ds_factor) for f in self.unique_filters]

--- a/src/aspire/volume/volume.py
+++ b/src/aspire/volume/volume.py
@@ -517,7 +517,7 @@ class Volume:
             symmetry_group=symmetry,
         )
 
-    def downsample(self, ds_res, mask=None, zero_nyquist=True):
+    def downsample(self, ds_res, mask=None, zero_nyquist=True, legacy=False):
         """
         Downsample each volume to a desired resolution (only cubic supported).
 
@@ -525,19 +525,25 @@ class Volume:
         :param zero_nyquist: Option to keep or remove Nyquist frequency for even resolution.
             Defaults to zero_nyquist=True, removing the Nyquist frequency.
         :param mask: Optional NumPy array mask to multiply in Fourier space.
+        :param legacy: Option to match legacy Matlab downsample method.
+            Default of False uses `centered_fft` to maintain ASPIRE-Python centering conventions.
+        :return: The downsampled Volume object.
         """
 
         original_stack_shape = self.stack_shape
         v = self.stack_reshape(-1)
 
         # take 3D Fourier transform of each volume in the stack
-        fx = fft.centered_fftn(xp.asarray(v._data))
+        if legacy:
+            fx = fft.fftshift(fft.fftn(xp.asarray(v._data)))
+        else:
+            fx = fft.centered_fftn(xp.asarray(v._data))
 
         # crop each volume to the desired resolution in frequency space
         fx = crop_pad_3d(fx, ds_res)
 
         # If downsample resolution is even, optionally zero out the nyquist frequency.
-        if ds_res % 2 == 0 and zero_nyquist is True:
+        if ds_res % 2 == 0 and zero_nyquist and not legacy:
             fx[:, 0, :, :] = 0
             fx[:, :, 0, :] = 0
             fx[:, :, :, 0] = 0
@@ -547,7 +553,10 @@ class Volume:
             fx = fx * xp.asarray(mask)
 
         # inverse Fourier transform of each volume
-        out = fft.centered_ifftn(fx)
+        if legacy:
+            out = fft.ifftn(fft.ifftshift(fx))
+        else:
+            out = fft.centered_ifftn(fx)
         out = out.real * (ds_res**3 / self.resolution**3)
 
         # Optionally scale pixel size

--- a/src/aspire/volume/volume.py
+++ b/src/aspire/volume/volume.py
@@ -522,10 +522,10 @@ class Volume:
         Downsample each volume to a desired resolution (only cubic supported).
 
         :param ds_res: Desired resolution.
-        :param zero_nyquist: Option to keep or remove Nyquist frequency for even resolution.
-            Defaults to zero_nyquist=True, removing the Nyquist frequency.
+        :param zero_nyquist: Option to keep or remove Nyquist frequency for even
+            resolution (boolean). Defaults to zero_nyquist=True, removing the Nyquist frequency.
         :param mask: Optional NumPy array mask to multiply in Fourier space.
-        :param legacy: Option to match legacy Matlab downsample method.
+        :param legacy: Option to match legacy Matlab downsample method (boolean).
             Default of False uses `centered_fft` to maintain ASPIRE-Python centering conventions.
         :return: The downsampled Volume object.
         """

--- a/tests/test_downsample.py
+++ b/tests/test_downsample.py
@@ -170,10 +170,10 @@ def test_downsample_project(volume, res_ds, legacy):
     tol = 1e-09
     if volume.dtype == np.float32:
         tol = 1e-07
-        if legacy:
-            # project does not enforce legacy centering convention,
-            # so this property will not hold up to allclose tolerance.
-            tol = 1e-03
+    if legacy:
+        # project does not enforce legacy centering convention,
+        # so this property will not hold up to allclose tolerance.
+        tol = 1e-03
 
     np.testing.assert_allclose(im_ds_proj, im_proj_ds, atol=tol)
 

--- a/tests/test_downsample.py
+++ b/tests/test_downsample.py
@@ -171,6 +171,8 @@ def test_downsample_project(volume, res_ds, legacy):
     if volume.dtype == np.float32:
         tol = 1e-07
         if legacy:
+            # project does not enforce legacy centering convention,
+            # so this property will not hold up to allclose tolerance.
             tol = 1e-03
 
     np.testing.assert_allclose(im_ds_proj, im_proj_ds, atol=tol)


### PR DESCRIPTION
Validates downsample against Matlab to address #1244

This PR creates a `legacy` flag for `Image.downsample`/`Volume.downsample` that reproduces the Matlab downsample output up to `np.allclose` tolerances.

I will upload notebooks, with matlab invocations documented, that demonstrate these results. I still need add a legacy flag test and check whether some desired properties hold.