### PR TITLE
Fix CoordinateSource (allow rectangular micrographs)

### DIFF
--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -598,6 +598,10 @@ class Image:
         if self.stack_ndim > 1:
             raise NotImplementedError("`save` is currently limited to 1D image stacks.")
 
+        data = self._data.astype(np.float32)
+        if self.n_images == 1:
+            data = data[0]
+
         if overwrite is None and os.path.exists(mrcs_filepath):
             # If the file exists, append a timestamp to the old file and rename it
             _ = rename_with_timestamp(mrcs_filepath)
@@ -606,7 +610,7 @@ class Image:
 
         with mrcfile.new(mrcs_filepath, overwrite=overwrite) as mrc:
             # original input format (the image index first)
-            mrc.set_data(self._data.astype(np.float32))
+            mrc.set_data(data)
             # Note assigning voxel_size must come after `set_data`
             if self.pixel_size is not None:
                 mrc.voxel_size = self.pixel_size

--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -612,7 +612,7 @@ class Image:
                 mrc.voxel_size = self.pixel_size
 
     @staticmethod
-    def load(filepath, dtype=None):
+    def _load(filepath, dtype=None):
         """
         Load raw data from supported files.
 
@@ -621,7 +621,9 @@ class Image:
         :param filepath: File path (string).
         :param dtype: Optionally force cast to `dtype`.
              Default dtype is inferred from the file contents.
-        :return: numpy array of image data.
+        :returns:
+            - numpy array of image data.
+            - pixel size
         """
 
         # Get the file extension
@@ -639,6 +641,23 @@ class Image:
         # Attempt casting when user provides dtype
         if dtype is not None:
             im = im.astype(dtype, copy=False)
+
+        return im, pixel_size
+
+    @staticmethod
+    def load(filepath, dtype=None):
+        """
+        Load raw data from supported files.
+
+        Currently MRC and TIFF are supported.
+
+        :param filepath: File path (string).
+        :param dtype: Optionally force cast to `dtype`.
+             Default dtype is inferred from the file contents.
+        :return: Image instance
+        """
+        # Load raw data from filepath with pixel size
+        im, pixel_size = Image._load(filepath, dtype=dtype)
 
         # Return as Image instance
         return Image(im, pixel_size=pixel_size)

--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -616,7 +616,7 @@ class Image:
                 mrc.voxel_size = self.pixel_size
 
     @staticmethod
-    def _load(filepath, dtype=None):
+    def _load_raw(filepath, dtype=None):
         """
         Load raw data from supported files.
 
@@ -661,7 +661,7 @@ class Image:
         :return: Image instance
         """
         # Load raw data from filepath with pixel size
-        im, pixel_size = Image._load(filepath, dtype=dtype)
+        im, pixel_size = Image._load_raw(filepath, dtype=dtype)
 
         # Return as Image instance
         return Image(im, pixel_size=pixel_size)

--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -886,7 +886,7 @@ class Image:
         #   checks uniformity.
         if isinstance(vx, np.recarray):
             if vx.x != vx.y:
-                raise ValueError(f"Voxel sizes are not uniform: {vx}")
+                logger.warning(f"Voxel sizes are not uniform: {vx}")
             vx = vx.x
 
         # Convert `0` to `None`

--- a/src/aspire/source/coordinates.py
+++ b/src/aspire/source/coordinates.py
@@ -308,7 +308,7 @@ class CoordinateSource(ImageSource, ABC):
 
         mrc_shapes = np.zeros((self.num_micrographs, 2), dtype=int)
         for i, mrc in enumerate(self.mrc_paths):
-            mrc_shapes[i, :] = Image._load(mrc)[0].shape
+            mrc_shapes[i, :] = Image._load_raw(mrc)[0].shape
 
         return mrc_shapes
 
@@ -469,7 +469,7 @@ class CoordinateSource(ImageSource, ABC):
         # their origin micrograph
         for mrc_index, coord_list in grouped.items():
             # Load file as 2D numpy array.
-            arr = Image._load(self.mrc_paths[mrc_index])[0]
+            arr = Image._load_raw(self.mrc_paths[mrc_index])[0]
 
             # create iterable of the coordinates in this mrc
             # we don't need to worry about exhausting this iter

--- a/src/aspire/source/coordinates.py
+++ b/src/aspire/source/coordinates.py
@@ -308,7 +308,7 @@ class CoordinateSource(ImageSource, ABC):
 
         mrc_shapes = np.zeros((self.num_micrographs, 2), dtype=int)
         for i, mrc in enumerate(self.mrc_paths):
-            mrc_shapes[i, :] = Image.load(mrc).resolution
+            mrc_shapes[i, :] = Image._load(mrc)[0].shape
 
         return mrc_shapes
 
@@ -469,7 +469,7 @@ class CoordinateSource(ImageSource, ABC):
         # their origin micrograph
         for mrc_index, coord_list in grouped.items():
             # Load file as 2D numpy array.
-            arr = Image.load(self.mrc_paths[mrc_index]).asnumpy()[0]
+            arr = Image._load(self.mrc_paths[mrc_index])[0]
 
             # create iterable of the coordinates in this mrc
             # we don't need to worry about exhausting this iter

--- a/tests/test_coordinate_source.py
+++ b/tests/test_coordinate_source.py
@@ -745,4 +745,4 @@ def test_coordinate_source_pixel_warning(tmp_path, caplog):
     file_list = create_test_rectangular_micrograph_and_star(tmp_path, voxel_size=vx)
     with caplog.at_level(logging.WARNING):
         _ = CentersCoordinateSource(file_list, particle_size=32)
-        assert f"Voxel sizes are not uniform" in caplog.text
+        assert "Voxel sizes are not uniform" in caplog.text

--- a/tests/test_coordinate_source.py
+++ b/tests/test_coordinate_source.py
@@ -744,6 +744,6 @@ def test_coordinate_source_pixel_warning(tmp_path, caplog):
     vx = (2.3, 2.1, 1.0)
     file_list = create_test_rectangular_micrograph_and_star(tmp_path, voxel_size=vx)
     with caplog.at_level(logging.WARNING):
-        caplog.clear()
         _ = CentersCoordinateSource(file_list, particle_size=32)
         assert f"Voxel sizes are not uniform: {vx}" in caplog.text
+        caplog.clear()

--- a/tests/test_coordinate_source.py
+++ b/tests/test_coordinate_source.py
@@ -745,5 +745,4 @@ def test_coordinate_source_pixel_warning(tmp_path, caplog):
     file_list = create_test_rectangular_micrograph_and_star(tmp_path, voxel_size=vx)
     with caplog.at_level(logging.WARNING):
         _ = CentersCoordinateSource(file_list, particle_size=32)
-        assert f"Voxel sizes are not uniform: {vx}" in caplog.text
-        caplog.clear()
+        assert f"Voxel sizes are not uniform" in caplog.text

--- a/tests/test_coordinate_source.py
+++ b/tests/test_coordinate_source.py
@@ -696,3 +696,38 @@ class CoordinateSourceTestCase(TestCase):
         self.assertTrue(result_coord.exit_code == 0)
         self.assertTrue(result_star.exit_code == 0)
         self.assertTrue(result_preprocess.exit_code == 0)
+
+
+def create_test_rectangular_micrograph_and_star(tmp_path):
+    # Create a rectangular micrograph (e.g., 128x256)
+    data = np.random.rand(128, 256).astype(np.float32)
+    mrc_path = tmp_path / "test_micrograph.mrc"
+
+    with mrcfile.new(mrc_path, overwrite=True) as mrc:
+        mrc.set_data(data)
+
+    # Two sample coordinates
+    coordinates = [(50.0, 30.0), (200.0, 100.0)]
+
+    # Write a simple STAR file
+    star_path = tmp_path / "test_coordinates.star"
+    with open(star_path, "w") as f:
+        f.write("data_particles\n\n")
+        f.write("loop_\n")
+        f.write("_rlnCoordinateX #1\n")
+        f.write("_rlnCoordinateY #2\n")
+        for x, y in coordinates:
+            f.write(f"{x:.1f} {y:.1f}\n")
+
+    return mrc_path, star_path
+
+
+def test_restangular_coordinate_source(tmp_path):
+    mrc_file, star_file = create_test_rectangular_micrograph_and_star(tmp_path)
+    file_list = [(mrc_file, star_file)]
+
+    # Check we can instantiate a CoordinateSource with a rectangular micrograph.
+    coord_src = CentersCoordinateSource(file_list, particle_size=32)
+
+    # Check we can access images.
+    _ = coord_src.images[:]


### PR DESCRIPTION
Resolves #1253 by adding a private `Image._load` method that returns a numpy array of data and `pixel_size` and a public `Image.load` that returns an `Image` instance. The private method is used by `CoordinateSource` to load data from mrc/star files, which allows for rectangular micrographs.

Also, replaces a `raise` in `Image._vx_array_to_size()` with a log message to be more permissive of badly formatted headers.