### PR TITLE
Flake8 Release Patch

### DIFF
--- a/src/aspire/nufft/__init__.py
+++ b/src/aspire/nufft/__init__.py
@@ -115,8 +115,6 @@ def all_backends():
 
     :return: A list of strings representing available NFFT backends
     """
-    global backends
-
     if backends is None:
         check_backends(raise_errors=False)
     return [k for k, v in backends.items() if v is not None]


### PR DESCRIPTION
Resolves #1255 by removing the `global` declaration for a read only use of the module-level variable `backends` in the `all_backends()` method in `src/aspire/nufft/__init__.py`. This declaration is only necessary when assigning to a global variable.