### PR TITLE
Resolve Package Build Warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.13.2"
 description = "Algorithms for Single Particle Reconstruction"
 readme = "README.md" # Optional
 requires-python = ">=3.9"
-license = "GPL-3.0-or-later"
+license = "GPL-3.0-only"
 license-files = ["LICENSE"]
 maintainers = [
   {name = "ASPIRE Developers", email = "ASPIRE-DEVS@princeton.edu"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ version = "0.13.2"
 description = "Algorithms for Single Particle Reconstruction"
 readme = "README.md" # Optional
 requires-python = ">=3.9"
-license = {file = "LICENSE"}
+license = "GPL-3.0-or-later"
+license-files = ["LICENSE"]
 maintainers = [
   {name = "ASPIRE Developers", email = "ASPIRE-DEVS@princeton.edu"}
 ]
@@ -23,8 +24,7 @@ authors = [
 
 classifiers = [
      "Development Status :: 3 - Alpha",
-     "Programming Language :: Python",
-     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
+     "Programming Language :: Python"
 ]
 
 dependencies = [


### PR DESCRIPTION
Resolves warnings mention in #1249.

Cleans up the deprecation warnings related to "license" syntax in our `pyproject.toml`.

Warnings before cleanup:
```
* Getting build dependencies for sdist...
/private/var/folders/jv/3hrz__0x419bjk70hwzm_pbc0000gp/T/build-env-pm225zzs/lib/python3.11/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
!!

        ********************************************************************************
        Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

        By 2026-Feb-18, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  corresp(dist, value, root_dir)
/private/var/folders/jv/3hrz__0x419bjk70hwzm_pbc0000gp/T/build-env-pm225zzs/lib/python3.11/site-packages/setuptools/config/_apply_pyprojecttoml.py:61: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: GNU General Public License v3 (GPLv3)

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  dist._finalize_license_expression()
/private/var/folders/jv/3hrz__0x419bjk70hwzm_pbc0000gp/T/build-env-pm225zzs/lib/python3.11/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: GNU General Public License v3 (GPLv3)

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  self._finalize_license_expression()
```

 