### PR TITLE
`pixel_size` from STAR file

### DIFF
--- a/src/aspire/source/relion.py
+++ b/src/aspire/source/relion.py
@@ -28,7 +28,7 @@ class RelionSource(ImageSource):
         self,
         filepath,
         data_folder=None,
-        pixel_size=1,
+        pixel_size=None,
         B=0,
         n_workers=-1,
         max_rows=None,
@@ -42,7 +42,8 @@ class RelionSource(ImageSource):
         :param filepath: Absolute or relative path to STAR file
         :param data_folder: Path to folder w.r.t which all relative paths to .mrcs files are resolved.
             If None, the folder corresponding to filepath is used.
-        :param pixel_size: the pixel size of the images in angstroms (Default 1)
+        :param pixel_size: The pixel size of the images in angstroms. By default, pixel size is
+            populated from the STAR file if relevant metadata fields exist, otherwise set to 1.
         :param B: the envelope decay of the CTF in inverse square angstrom (Default 0)
         :param n_workers: Number of threads to spawn to read referenced .mrcs files (Default -1 to auto detect)
         :param max_rows: Maximum number of rows in STAR file to read. If None, all rows are read.
@@ -113,6 +114,18 @@ class RelionSource(ImageSource):
             memory=memory,
             pixel_size=pixel_size,
         )
+
+        # Populate pixel_size with metadata if possible.
+        if pixel_size is None:
+            if self.has_metadata(["_rlnImagePixelSize"]):
+                pixel_size = self.get_metadata(["_rlnImagePixelSize"])[0]
+            elif self.has_metadata(["_rlnDetectorPixelSize", "_rlnMagnification"]):
+                detector_pixel_size = self.get_metadata(["_rlnDetectorPixelSize"])[0]
+                magnification = self.get_metadata(["_rlnMagnification"])[0]
+                pixel_size = 10000 * detector_pixel_size / magnification
+            else:
+                pixel_size = 1.0
+        self.pixel_size = float(pixel_size)
 
         # CTF estimation parameters coming from Relion
         CTF_params = [

--- a/src/aspire/source/relion.py
+++ b/src/aspire/source/relion.py
@@ -124,6 +124,9 @@ class RelionSource(ImageSource):
                 magnification = self.get_metadata(["_rlnMagnification"])[0]
                 pixel_size = 10000 * detector_pixel_size / magnification
             else:
+                logger.warning(
+                    "No pixel size found in STAR file. Defaulting to 1.0 Angstrom"
+                )
                 pixel_size = 1.0
         self.pixel_size = float(pixel_size)
 

--- a/src/aspire/utils/relion_interop.py
+++ b/src/aspire/utils/relion_interop.py
@@ -20,6 +20,7 @@ relion_metadata_fields = {
     "_rlnDetectorPixelSize": float,
     "_rlnCtfFigureOfMerit": float,
     "_rlnMagnification": float,
+    "_rlnImagePixelSize": float,
     "_rlnAmplitudeContrast": float,
     "_rlnImageName": str,
     "_rlnOriginalName": str,

--- a/tests/test_relion_source.py
+++ b/tests/test_relion_source.py
@@ -59,7 +59,7 @@ def test_symmetry_group(caplog):
     assert str(src_override_sym.symmetry_group) == "C6"
 
 
-def test_pixel_size():
+def test_pixel_size(caplog):
     """
     Instantiate RelionSource from starfiles containing the following pixel size
     field variations:
@@ -92,5 +92,8 @@ def test_pixel_size():
     np.testing.assert_equal(src.pixel_size, pix_size)
 
     # Check pixel size defaults to 1 if not provided.
-    src = RelionSource(starfile_no_pix_size)
-    np.testing.assert_equal(src.pixel_size, 1.0)
+    with caplog.at_level(logging.WARNING):
+        msg = "No pixel size found in STAR file. Defaulting to 1.0 Angstrom"
+        src = RelionSource(starfile_no_pix_size)
+        assert msg in caplog.text
+        np.testing.assert_equal(src.pixel_size, 1.0)

--- a/tests/test_relion_source.py
+++ b/tests/test_relion_source.py
@@ -59,7 +59,7 @@ def test_symmetry_group(caplog):
     assert str(src_override_sym.symmetry_group) == "C6"
 
 
-def test_pixel_size(caplog):
+def test_pixel_size():
     """
     Instantiate RelionSource from starfiles containing the following pixel size
     field variations:

--- a/tests/test_relion_source.py
+++ b/tests/test_relion_source.py
@@ -79,16 +79,16 @@ def test_pixel_size(caplog):
     src = RelionSource(starfile_im_pix_size)
     np.testing.assert_equal(src.pixel_size, 1.4)
 
-    # Check pixel size calculated from _rlnDetectorPixelSize and _rlnMagnification
+    # Check pixel size calculated from _rlnDetectorPixelSize and _rlnMagnification.
     src = RelionSource(starfile_detector_pix_size)
     det_pix_size = src.get_metadata(["_rlnDetectorPixelSize"])[0]
     mag = src.get_metadata("_rlnMagnification")[0]
     pix_size = 10000 * det_pix_size / mag
     np.testing.assert_equal(src.pixel_size, pix_size)
 
-    # Check user provided pixel size
+    # Check user provided pixel size.
     pix_size = 1.234
-    src = RelionSource(starfile_no_pix_size, pixel_size=pix_size)
+    src = RelionSource(starfile_im_pix_size, pixel_size=pix_size)
     np.testing.assert_equal(src.pixel_size, pix_size)
 
     # Check pixel size defaults to 1 if not provided.


### PR DESCRIPTION
Adding a branch to `RelionSource` to check the STAR file for relevant fields when populating the `pixel_size` attribute.

Resolves #322 