### PR TITLE
Remove Numpy2 warning

### DIFF
--- a/src/aspire/__init__.py
+++ b/src/aspire/__init__.py
@@ -87,16 +87,3 @@ def __getattr__(attr):
         return importlib.import_module(f"aspire.{attr}")
     else:
         raise AttributeError(f"module `{__name__}` has no attribute `{attr}`.")
-
-
-if parse_version(np.version.version) >= parse_version("2.0.0"):
-    # ImportWarnings are generally filtered, but raise this one for now.
-    with warnings.catch_warnings():
-        warnings.simplefilter("default")
-        warnings.warn(
-            "ASPIRE's Numpy 2 support is in beta.  If you experience a runtime"
-            " crash relating to mismatched dtypes or a Numpy call please try"
-            ' `pip install "numpy<2"` and report to ASPIRE developers.',
-            ImportWarning,
-            stacklevel=1,
-        )


### PR DESCRIPTION
No additional problems reported for Numpy2 in the last release cycle.  Remove the warning added around #1133 .