### PR TITLE
Cleanup Duplicate Code

### DIFF
--- a/gallery/tutorials/tutorials/weighted_volume_estimation.py
+++ b/gallery/tutorials/tutorials/weighted_volume_estimation.py
@@ -100,13 +100,13 @@ estimated_volume = estimator.estimate()
 # demonstrate that we are in fact generating spectral volumes that
 # appear reasonably similar to the input volumes.
 
-from aspire.utils import Rotation, uniform_random_angles
+from aspire.utils import Rotation
 
 reference_v = 0  # Actual volume under comparison
 spectral_v = 0  # Estimated spectral volume
 m = 3  # Number of projections
 
-random_rotations = Rotation.from_euler(uniform_random_angles(m, dtype=src.dtype))
+random_rotations = Rotation.generate_random_rotations(m, dtype=src.dtype)
 
 # Estimated volume projections
 estimated_volume[spectral_v].project(random_rotations).show()

--- a/src/aspire/abinitio/commonline_base.py
+++ b/src/aspire/abinitio/commonline_base.py
@@ -7,7 +7,7 @@ import scipy.sparse as sparse
 
 from aspire.image import Image
 from aspire.operators import PolarFT
-from aspire.utils import common_line_from_rots, complex_type, fuzzy_mask, tqdm
+from aspire.utils import Rotation, complex_type, fuzzy_mask, tqdm
 from aspire.utils.random import choice
 
 logger = logging.getLogger(__name__)
@@ -536,7 +536,7 @@ class CLOrient3D:
         n_img = self.n_img
 
         # `estimate_shifts()` requires that rotations have already been estimated.
-        rotations = self.rotations
+        rotations = Rotation(self.rotations)
 
         pf = self.pf.copy()
 
@@ -741,16 +741,14 @@ class CLOrient3D:
         """
         Get common line indices based on the rotations from i and j images
 
-        :param rotations: Array of rotation matrices
+        :param rotations: Rotation object
         :param i: Index for i image
         :param j: Index for j image
         :param n_theta: Total number of common lines
         :return: Common line indices for i and j images
         """
         # get the common line indices based on the rotations from i and j images
-        r_i = rotations[i]
-        r_j = rotations[j]
-        c_ij, c_ji = common_line_from_rots(r_i.T, r_j.T, 2 * n_theta)
+        c_ij, c_ji = rotations.invert().common_lines(i, j, 2 * n_theta)
 
         # To match clmatrix, c_ij is always less than PI
         # and c_ji may be be larger than PI.

--- a/src/aspire/source/simulation.py
+++ b/src/aspire/source/simulation.py
@@ -9,14 +9,7 @@ from aspire.image import Image
 from aspire.noise import NoiseAdder
 from aspire.source import ImageSource
 from aspire.source.image import _ImageAccessor
-from aspire.utils import (
-    Rotation,
-    acorr,
-    ainner,
-    anorm,
-    make_symmat,
-    uniform_random_angles,
-)
+from aspire.utils import Rotation, acorr, ainner, anorm, make_symmat
 from aspire.utils.random import randi, randn, random
 from aspire.volume import AsymmetricVolume, Volume
 
@@ -202,7 +195,12 @@ class Simulation(ImageSource):
 
     def _init_angles(self, angles):
         if angles is None:
-            angles = uniform_random_angles(self.n, seed=self.seed, dtype=self.dtype)
+            angles = Rotation.generate_random_rotations(
+                self.n,
+                seed=self.seed,
+                dtype=self.dtype,
+            ).angles
+
         return angles
 
     def _populate_ctf_metadata(self, filter_indices):

--- a/src/aspire/utils/__init__.py
+++ b/src/aspire/utils/__init__.py
@@ -4,12 +4,9 @@ from .coor_trans import (  # isort:skip
     mean_aligned_angular_distance,
     crop_pad_2d,
     crop_pad_3d,
-    get_aligned_rotations,
-    get_rots_mse,
     grid_1d,
     grid_2d,
     grid_3d,
-    register_rotations,
     rots_to_clmatrix,
 )
 

--- a/src/aspire/utils/__init__.py
+++ b/src/aspire/utils/__init__.py
@@ -11,7 +11,6 @@ from .coor_trans import (  # isort:skip
     grid_3d,
     register_rotations,
     rots_to_clmatrix,
-    uniform_random_angles,
 )
 
 from .misc import (  # isort:skip

--- a/src/aspire/utils/__init__.py
+++ b/src/aspire/utils/__init__.py
@@ -1,6 +1,5 @@
 from .types import complex_type, real_type, utest_tolerance  # isort:skip
 from .coor_trans import (  # isort:skip
-    common_line_from_rots,
     mean_aligned_angular_distance,
     crop_pad_2d,
     crop_pad_3d,

--- a/src/aspire/utils/coor_trans.py
+++ b/src/aspire/utils/coor_trans.py
@@ -155,8 +155,10 @@ def mean_aligned_angular_distance(rots_est, rots_gt, degree_tol=None):
     Register estimates to ground truth rotations and compute the
     mean angular distance between them (in degrees).
 
-    :param rots_est: A set of estimated rotations of size nx3x3.
-    :param rots_gt: A set of ground truth rotations of size nx3x3.
+    :param rots_est: A set of estimated rotations. A Rotation object or
+        array of size nx3x3.
+    :param rots_gt: A set of ground truth rotations. A Rotation object or
+        array of size nx3x3.
     :param degree_tol: Option to assert if the mean angular distance is
         less than `degree_tol` degrees. If `None`, returns the mean
         aligned angular distance.

--- a/src/aspire/utils/coor_trans.py
+++ b/src/aspire/utils/coor_trans.py
@@ -164,8 +164,11 @@ def mean_aligned_angular_distance(rots_est, rots_gt, degree_tol=None):
     :return: The mean angular distance between registered estimates
         and the ground truth (in degrees).
     """
-    rots_est = Rotation(rots_est)
-    rots_gt = Rotation(rots_gt)
+    if not isinstance(rots_est, Rotation):
+        rots_est = Rotation(rots_est)
+    if not isinstance(rots_gt, Rotation):
+        rots_gt = Rotation(rots_gt)
+
     Q_mat, flag = rots_est.find_registration(rots_gt)
     logger.debug(f"Registration Q_mat: {Q_mat}\nflag: {flag}")
     regrot = rots_est.apply_registration(Q_mat, flag)

--- a/src/aspire/utils/coor_trans.py
+++ b/src/aspire/utils/coor_trans.py
@@ -180,31 +180,6 @@ def mean_aligned_angular_distance(rots_est, rots_gt, degree_tol=None):
     return mean_ang_dist
 
 
-def common_line_from_rots(r1, r2, ell):
-    """
-    Compute the common line induced by rotation matrices r1 and r2.
-
-    :param r1: The first rotation matrix of 3-by-3 array.
-    :param r2: The second rotation matrix of 3-by-3 array.
-    :param ell: The total number of common lines.
-    :return: The common line indices for both first and second rotations.
-    """
-
-    assert r1.dtype == r2.dtype, "Ambiguous dtypes"
-
-    ut = np.dot(r2, r1.T)
-    alpha_ij = np.arctan2(ut[2, 0], -ut[2, 1]) + np.pi
-    alpha_ji = np.arctan2(-ut[0, 2], ut[1, 2]) + np.pi
-
-    ell_ij = alpha_ij * ell / (2 * np.pi)
-    ell_ji = alpha_ji * ell / (2 * np.pi)
-
-    ell_ij = int(np.mod(np.round(ell_ij), ell))
-    ell_ji = int(np.mod(np.round(ell_ji), ell))
-
-    return ell_ij, ell_ji
-
-
 def rots_to_clmatrix(rots, n_theta):
     """
     Compute the common lines matrix induced by all pairs of rotation

--- a/src/aspire/utils/coor_trans.py
+++ b/src/aspire/utils/coor_trans.py
@@ -12,7 +12,6 @@ from scipy.linalg import svd
 
 from aspire import config
 from aspire.numeric import xp
-from aspire.utils.random import Random
 from aspire.utils.rotation import Rotation
 
 logger = logging.getLogger(__name__)
@@ -151,26 +150,6 @@ def grid_3d(n, shifted=False, normalized=True, indexing="zyx", dtype=np.float32)
     theta = np.pi / 2 - theta
 
     return {"x": x, "y": y, "z": z, "phi": phi, "theta": theta, "r": r}
-
-
-def uniform_random_angles(n, seed=None, dtype=np.float32):
-    """
-    Generate random 3D rotation angles
-
-    :param n: The number of rotation angles to generate
-    :param seed: Random integer seed to use. If None, the current random state is used.
-    :return: A n-by-3 ndarray of rotation angles
-    """
-    # Generate random rotation angles, in radians
-    with Random(seed):
-        angles = np.column_stack(
-            (
-                np.random.random(n) * 2 * np.pi,
-                np.arccos(2 * np.random.random(n) - 1),
-                np.random.random(n) * 2 * np.pi,
-            )
-        )
-    return angles.astype(dtype)
 
 
 def register_rotations(rots, rots_ref):

--- a/src/aspire/utils/coor_trans.py
+++ b/src/aspire/utils/coor_trans.py
@@ -279,9 +279,11 @@ def mean_aligned_angular_distance(rots_est, rots_gt, degree_tol=None):
     :return: The mean angular distance between registered estimates
         and the ground truth (in degrees).
     """
-    Q_mat, flag = register_rotations(rots_est, rots_gt)
+    rots_est = Rotation(rots_est)
+    rots_gt = Rotation(rots_gt)
+    Q_mat, flag = rots_est.find_registration(rots_gt)
     logger.debug(f"Registration Q_mat: {Q_mat}\nflag: {flag}")
-    regrot = get_aligned_rotations(rots_est, Q_mat, flag)
+    regrot = rots_est.apply_registration(Q_mat, flag)
     mean_ang_dist = Rotation.mean_angular_distance(regrot, rots_gt) * 180 / np.pi
 
     if degree_tol is not None:

--- a/src/aspire/utils/rotation.py
+++ b/src/aspire/utils/rotation.py
@@ -233,7 +233,7 @@ class Rotation:
         r2 = self._matrices[j]
         ut = np.dot(r2, r1.T)
         alpha_ij = np.arctan2(ut[2, 0], -ut[2, 1]) + np.pi
-        alpha_ji = np.arctan2(ut[0, 2], -ut[1, 2]) + np.pi
+        alpha_ji = np.arctan2(-ut[0, 2], ut[1, 2]) + np.pi
 
         ell_ij = alpha_ij * ell / (2 * np.pi)
         ell_ji = alpha_ji * ell / (2 * np.pi)

--- a/tests/test_coor_trans.py
+++ b/tests/test_coor_trans.py
@@ -7,11 +7,9 @@ from aspire.utils import (
     Rotation,
     crop_pad_2d,
     crop_pad_3d,
-    get_aligned_rotations,
     grid_2d,
     grid_3d,
     mean_aligned_angular_distance,
-    register_rotations,
 )
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "saved_test_data")
@@ -67,17 +65,6 @@ class UtilsTestCase(TestCase):
                 grid3d["theta"], np.load(os.path.join(DATA_DIR, "grid3d_8_theta.npy"))
             )
         )
-
-    def testRegisterRots(self):
-        rots_ref = Rotation.generate_random_rotations(32, seed=0).matrices
-
-        q_ang = [[np.pi / 4, np.pi / 4, np.pi / 4]]
-        q_mat = Rotation.from_euler(q_ang).matrices[0]
-        flag = 0
-        regrots_ref = get_aligned_rotations(rots_ref, q_mat, flag)
-        q_mat_est, flag_est = register_rotations(rots_ref, regrots_ref)
-
-        self.assertTrue(np.allclose(flag_est, flag) and np.allclose(q_mat_est, q_mat))
 
     def testSquareCrop2D(self):
         # Test even/odd cases based on the convention that the center of a sequence of length n

--- a/tests/test_coor_trans.py
+++ b/tests/test_coor_trans.py
@@ -12,7 +12,6 @@ from aspire.utils import (
     grid_3d,
     mean_aligned_angular_distance,
     register_rotations,
-    uniform_random_angles,
 )
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "saved_test_data")
@@ -70,8 +69,7 @@ class UtilsTestCase(TestCase):
         )
 
     def testRegisterRots(self):
-        angles = uniform_random_angles(32, seed=0)
-        rots_ref = Rotation.from_euler(angles).matrices
+        rots_ref = Rotation.generate_random_rotations(32, seed=0).matrices
 
         q_ang = [[np.pi / 4, np.pi / 4, np.pi / 4]]
         q_mat = Rotation.from_euler(q_ang).matrices[0]

--- a/tests/test_orient_sdp.py
+++ b/tests/test_orient_sdp.py
@@ -4,13 +4,7 @@ import pytest
 from aspire.abinitio import CommonlineSDP
 from aspire.nufft import backend_available
 from aspire.source import Simulation
-from aspire.utils import (
-    Rotation,
-    get_aligned_rotations,
-    mean_aligned_angular_distance,
-    register_rotations,
-    rots_to_clmatrix,
-)
+from aspire.utils import Rotation, mean_aligned_angular_distance, rots_to_clmatrix
 from aspire.volume import AsymmetricVolume
 
 RESOLUTION = [
@@ -189,7 +183,4 @@ def test_deterministic_rounding(src_orient_est_fixture):
     est_rots = orient_est._deterministic_rounding(gt_gram)
 
     # Check that the estimated rotations are close to ground truth after global alignment.
-    Q_mat, flag = register_rotations(est_rots, gt_rots)
-    regrot = get_aligned_rotations(est_rots, Q_mat, flag)
-
-    np.testing.assert_allclose(regrot, gt_rots)
+    mean_aligned_angular_distance(est_rots, gt_rots, degree_tol=1e-5)

--- a/tests/test_rotation.py
+++ b/tests/test_rotation.py
@@ -116,7 +116,7 @@ def test_mse(rot_obj):
 
 def test_common_lines(rot_obj):
     ell_ij, ell_ji = rot_obj.common_lines(8, 11, 360)
-    np.testing.assert_equal([ell_ij, ell_ji], [235, 284])
+    np.testing.assert_equal([ell_ij, ell_ji], [235, 104])
 
 
 def test_string(rot_obj):


### PR DESCRIPTION
Resolves #1233 

Removes duplicate code found in both `src/aspire/utils/coor_trans.py` and `src/aspire/utils/rotation.py`.

Also, I refactored `mean_aligned_angular_distance` to use the alignment code which now resides in the `Rotation` class in a way to not change the API. It might make sense to move this function into the `Rotation` class as well, but it will change the API. 