### PR TITLE
Use scipy create_group for SymmetryGroups

### DIFF
--- a/src/aspire/abinitio/commonline_d2.py
+++ b/src/aspire/abinitio/commonline_d2.py
@@ -82,7 +82,7 @@ class CLSymmetryD2(CLOrient3D):
         # Rearrange in order Identity, about_x, about_y, about_z.
         # This ordering is necessary for reproducing MATLAB code results.
         self.gs = DnSymmetryGroup(order=2).matrices.astype(self.dtype, copy=False)[
-            [0, 3, 2, 1]
+            [0, 2, 3, 1]
         ]
 
     def estimate_rotations(self):

--- a/src/aspire/volume/__init__.py
+++ b/src/aspire/volume/__init__.py
@@ -10,6 +10,7 @@ from .symmetry_groups import (
 from .volume import Volume, qr_vols_forward, rotated_grids, rotated_grids_3d
 
 from .volume_synthesis import (  # isort:skip
+    ISymmetricVolume,
     TSymmetricVolume,
     OSymmetricVolume,
     CnSymmetricVolume,

--- a/src/aspire/volume/symmetry_groups.py
+++ b/src/aspire/volume/symmetry_groups.py
@@ -126,8 +126,8 @@ class CnSymmetryGroup(SymmetryGroup):
 
         :return: Rotation object containing the Cn symmetry group and the identity.
         """
-        angles = np.linspace(0, 2 * np.pi, self.order, endpoint=False)
-        return Rotation.about_axis("z", angles, dtype=self.dtype)
+        rots = R.create_group("C" + str(self.order)).as_matrix()
+        return Rotation(rots.astype(self.dtype, copy=False))
 
 
 class IdentitySymmetryGroup(CnSymmetryGroup):
@@ -174,18 +174,8 @@ class DnSymmetryGroup(SymmetryGroup):
 
         :return: Rotation object containing the Dn symmetry group and the identity.
         """
-
-        # Rotations to induce cyclic symmetry
-        angles = np.linspace(0, 2 * np.pi, self.order, endpoint=False)
-        rot_z = Rotation.about_axis("z", angles, dtype=self.dtype).matrices
-
-        # Perpendicular rotation to induce dihedral symmetry
-        rot_perp = Rotation.about_axis("y", np.pi, dtype=self.dtype).matrices
-
-        # Full set of rotations.
-        rots = np.concatenate((rot_z, rot_z @ rot_perp[0]))
-
-        return Rotation(rots)
+        rots = R.create_group("D" + str(self.order)).as_matrix()
+        return Rotation(rots.astype(self.dtype, copy=False))
 
 
 class TSymmetryGroup(SymmetryGroup):

--- a/src/aspire/volume/symmetry_groups.py
+++ b/src/aspire/volume/symmetry_groups.py
@@ -201,30 +201,12 @@ class TSymmetryGroup(SymmetryGroup):
         """
         A tetrahedron has C3 symmetry along the 4 axes through each vertex and
         perpendicular to the opposite face, and C2 symmetry along the axes through
-        the midpoints of opposite edges. We convert from axis-angle representation of
-        the symmetry group elements into rotation vectors to generate the rotation
-        matrices via the `from_rotvec()` method.
+        the midpoints of opposite edges.
 
         :return: Rotation object containing the tetrahedral symmetry group and the identity.
         """
-        # C3 rotation vectors, ie. angle * axis.
-        axes_C3 = np.array(
-            [[1.0, 1.0, 1.0], [-1.0, -1.0, 1.0], [1.0, -1.0, -1.0], [-1.0, 1.0, -1.0]],
-        )
-        axes_C3 /= np.linalg.norm(axes_C3, axis=-1)[..., np.newaxis]
-        angles_C3 = np.array([2 * np.pi / 3, 4 * np.pi / 3])
-        rot_vecs_C3 = np.concatenate([angle * axes_C3 for angle in angles_C3])
-
-        # C2 rotation vectors.
-        axes_C2 = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
-        rot_vecs_C2 = np.pi * axes_C2
-
-        # The full set of rotation vectors inducing tetrahedral symmetry.
-        rot_vec_I = np.zeros((1, 3))
-        rot_vecs = np.concatenate((rot_vec_I, rot_vecs_C3, rot_vecs_C2))
-
-        # Return rotations.
-        return Rotation.from_rotvec(rot_vecs, dtype=self.dtype)
+        rots = R.create_group("T").as_matrix()
+        return Rotation(rots.astype(self.dtype, copy=False))
 
 
 class OSymmetryGroup(SymmetryGroup):
@@ -257,44 +239,8 @@ class OSymmetryGroup(SymmetryGroup):
 
         :return: Rotation object containing the octahedral symmetry group and the identity.
         """
-
-        # C4 rotation vectors, ie angle * axis
-        axes_C4 = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
-        angles_C4 = np.array([np.pi / 2, np.pi, 3 * np.pi / 2])
-        rot_vecs_C4 = np.array(
-            [angle * axes_C4 for angle in angles_C4],
-        ).reshape((9, 3))
-
-        # C3 rotation vectors
-        axes_C3 = np.array(
-            [[1.0, 1.0, 1.0], [-1.0, 1.0, 1.0], [1.0, -1.0, 1.0], [1.0, 1.0, -1.0]]
-        )
-        axes_C3 /= np.linalg.norm(axes_C3, axis=-1)[..., np.newaxis]
-        angles_C3 = np.array([2 * np.pi / 3, 4 * np.pi / 3])
-        rot_vecs_C3 = np.array(
-            [angle * axes_C3 for angle in angles_C3],
-        ).reshape((8, 3))
-
-        # C2 rotation vectors
-        axes_C2 = np.array(
-            [
-                [1.0, 1.0, 0.0],
-                [-1.0, 1.0, 0.0],
-                [1.0, 0.0, 1.0],
-                [-1.0, 0.0, 1.0],
-                [0.0, 1.0, 1.0],
-                [0.0, -1.0, 1.0],
-            ],
-        )
-        axes_C2 /= np.linalg.norm(axes_C2, axis=-1)[..., np.newaxis]
-        rot_vecs_C2 = np.pi * axes_C2
-
-        # The full set of rotation vectors inducing octahedral symmetry.
-        rot_vec_I = np.zeros((1, 3))
-        rot_vecs = np.concatenate((rot_vec_I, rot_vecs_C4, rot_vecs_C3, rot_vecs_C2))
-
-        # Return rotations.
-        return Rotation.from_rotvec(rot_vecs, dtype=self.dtype)
+        rots = R.create_group("O").as_matrix()
+        return Rotation(rots.astype(self.dtype, copy=False))
 
 
 class ISymmetryGroup(SymmetryGroup):
@@ -327,5 +273,5 @@ class ISymmetryGroup(SymmetryGroup):
 
         :return: Rotation object containing the icosahedral symmetry group and the identity.
         """
-        scipy_rotations = R.create_group("I").as_matrix()
-        return Rotation(scipy_rotations)
+        rots = R.create_group("I").as_matrix()
+        return Rotation(rots.astype(self.dtype, copy=False))

--- a/src/aspire/volume/symmetry_groups.py
+++ b/src/aspire/volume/symmetry_groups.py
@@ -126,7 +126,7 @@ class CnSymmetryGroup(SymmetryGroup):
 
         :return: Rotation object containing the Cn symmetry group and the identity.
         """
-        rots = R.create_group("C" + str(self.order)).as_matrix()
+        rots = R.create_group(self.to_string).as_matrix()
         return Rotation(rots.astype(self.dtype, copy=False))
 
 
@@ -174,7 +174,7 @@ class DnSymmetryGroup(SymmetryGroup):
 
         :return: Rotation object containing the Dn symmetry group and the identity.
         """
-        rots = R.create_group("D" + str(self.order)).as_matrix()
+        rots = R.create_group(self.to_string).as_matrix()
         return Rotation(rots.astype(self.dtype, copy=False))
 
 

--- a/src/aspire/volume/symmetry_groups.py
+++ b/src/aspire/volume/symmetry_groups.py
@@ -1,5 +1,5 @@
 import logging
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractproperty
 
 import numpy as np
 from scipy.spatial.transform import Rotation as R
@@ -21,11 +21,12 @@ class SymmetryGroup(ABC):
         self.dtype = np.float64
         self.rotations = self.generate_rotations()
 
-    @abstractmethod
     def generate_rotations(self):
         """
         Method for generating a Rotation object for the symmetry group.
         """
+        rots = R.create_group(self.to_string).as_matrix()
+        return Rotation(rots.astype(self.dtype, copy=False))
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
@@ -126,8 +127,7 @@ class CnSymmetryGroup(SymmetryGroup):
 
         :return: Rotation object containing the Cn symmetry group and the identity.
         """
-        rots = R.create_group(self.to_string).as_matrix()
-        return Rotation(rots.astype(self.dtype, copy=False))
+        return super().generate_rotations()
 
 
 class IdentitySymmetryGroup(CnSymmetryGroup):
@@ -174,8 +174,7 @@ class DnSymmetryGroup(SymmetryGroup):
 
         :return: Rotation object containing the Dn symmetry group and the identity.
         """
-        rots = R.create_group(self.to_string).as_matrix()
-        return Rotation(rots.astype(self.dtype, copy=False))
+        return super().generate_rotations()
 
 
 class TSymmetryGroup(SymmetryGroup):
@@ -205,8 +204,7 @@ class TSymmetryGroup(SymmetryGroup):
 
         :return: Rotation object containing the tetrahedral symmetry group and the identity.
         """
-        rots = R.create_group("T").as_matrix()
-        return Rotation(rots.astype(self.dtype, copy=False))
+        return super().generate_rotations()
 
 
 class OSymmetryGroup(SymmetryGroup):
@@ -239,8 +237,7 @@ class OSymmetryGroup(SymmetryGroup):
 
         :return: Rotation object containing the octahedral symmetry group and the identity.
         """
-        rots = R.create_group("O").as_matrix()
-        return Rotation(rots.astype(self.dtype, copy=False))
+        return super().generate_rotations()
 
 
 class ISymmetryGroup(SymmetryGroup):
@@ -273,5 +270,4 @@ class ISymmetryGroup(SymmetryGroup):
 
         :return: Rotation object containing the icosahedral symmetry group and the identity.
         """
-        rots = R.create_group("I").as_matrix()
-        return Rotation(rots.astype(self.dtype, copy=False))
+        return super().generate_rotations()

--- a/src/aspire/volume/volume_synthesis.py
+++ b/src/aspire/volume/volume_synthesis.py
@@ -9,6 +9,7 @@ from aspire.volume import (
     CnSymmetryGroup,
     DnSymmetryGroup,
     IdentitySymmetryGroup,
+    ISymmetryGroup,
     OSymmetryGroup,
     TSymmetryGroup,
     Volume,
@@ -251,6 +252,19 @@ class OSymmetricVolume(GaussianBlobsVolume):
     @property
     def n_blobs(self):
         return 24 * self.K
+
+
+class ISymmetricVolume(GaussianBlobsVolume):
+    """
+    A Volume object with Icosahedral symmetry constructed of random 3D Gaussian blobs.
+    """
+
+    def _set_symmetry_group(self):
+        self._symmetry_group = ISymmetryGroup()
+
+    @property
+    def n_blobs(self):
+        return 60 * self.K
 
 
 class AsymmetricVolume(CnSymmetricVolume):

--- a/tests/test_orient_d2.py
+++ b/tests/test_orient_d2.py
@@ -405,7 +405,7 @@ def g_sync_d2(rots, rots_gt):
     n_img = len(rots)
     dtype = rots.dtype
 
-    rots_symm = DnSymmetryGroup(2).matrices.astype(dtype, copy=False)
+    rots_symm = DnSymmetryGroup(2).matrices.astype(dtype, copy=False)[[0, 2, 1, 3]]
     order = len(rots_symm)
 
     A_g = np.zeros((n_img, n_img), dtype=complex)
@@ -438,7 +438,6 @@ def g_sync_d2(rots, rots_gt):
     # Diagonal elements correspond to exp(-i*0) so put 1.
     # This is important only for verification purposes that spectrum is (K,0,0,0...,0).
     A_g += np.conj(A_g).T + np.eye(n_img)
-
     _, eig_vecs = np.linalg.eigh(A_g)
     leading_eig_vec = eig_vecs[:, -1]
 

--- a/tests/test_synthetic_volume.py
+++ b/tests/test_synthetic_volume.py
@@ -10,6 +10,7 @@ from aspire.volume import (
     AsymmetricVolume,
     CnSymmetricVolume,
     DnSymmetricVolume,
+    ISymmetricVolume,
     LegacyVolume,
     OSymmetricVolume,
     TSymmetricVolume,
@@ -55,6 +56,12 @@ PARAMS_Cn_Dn = [
     (DnSymmetricVolume, 65, 6),
 ]
 
+# Parameters for icosahedral volumes need higher resolution to give accurate
+# results for test_volume)symmetry.
+PARAMS_I = [
+    pytest.param((ISymmetricVolume, 70), marks=pytest.mark.expensive),
+    pytest.param((ISymmetricVolume, 71), marks=pytest.mark.expensive),
+]
 
 # Parameters for tetrahedral, octahedral, asymmetric, and legacy volumes.
 # These volumes do not have an `order` parameter.
@@ -74,7 +81,7 @@ def vol_fixture_id(params):
 
 
 # Create SyntheticVolume fixture for the set of parameters.
-@pytest.fixture(params=PARAMS_Cn_Dn + PARAMS, ids=vol_fixture_id)
+@pytest.fixture(params=PARAMS_Cn_Dn + PARAMS_I + PARAMS, ids=vol_fixture_id)
 def vol_fixture(request, dtype_fixture):
     params = request.param
     vol_class = params[0]
@@ -156,4 +163,4 @@ def test_volume_symmetry(vol_fixture, dtype_fixture):
         corr = np.dot(rot_vol[0].flatten(), vol[0].flatten()) / np.dot(
             vol[0].flatten(), vol[0].flatten()
         )
-        assert abs(corr - 1) < 1.1e-5
+        assert abs(corr - 1) < 1e-3

--- a/tests/test_synthetic_volume.py
+++ b/tests/test_synthetic_volume.py
@@ -57,7 +57,7 @@ PARAMS_Cn_Dn = [
 ]
 
 # Parameters for icosahedral volumes need higher resolution to give accurate
-# results for test_volume)symmetry.
+# results for test_volume_symmetry.
 PARAMS_I = [
     pytest.param((ISymmetricVolume, 70), marks=pytest.mark.expensive),
     pytest.param((ISymmetricVolume, 71), marks=pytest.mark.expensive),


### PR DESCRIPTION
Resolves #1275

Refactors SymmetryGroup's to use scipy create_group. Also adds icosahedral volume to synthetic volumes.