### PR TITLE
permit corrupt MRC files

### DIFF
--- a/src/aspire/source/coordinates.py
+++ b/src/aspire/source/coordinates.py
@@ -77,7 +77,7 @@ class CoordinateSource(ImageSource, ABC):
         dtype = "float32"
         # If file is MRC, we can get dtype from header.
         if self._ext == ".mrc":
-            with mrcfile.open(first_mrc) as mrc:
+            with mrcfile.open(first_mrc, mode="r", permissive=True) as mrc:
                 # get dtype from first micrograph
                 mode = int(mrc.header.mode)
                 dtypes = {0: "int8", 1: "int16", 2: "float32", 6: "uint16"}

--- a/src/aspire/source/relion.py
+++ b/src/aspire/source/relion.py
@@ -72,7 +72,7 @@ class RelionSource(ImageSource):
 
         # Peek into the first image and populate some attributes
         first_mrc_filepath = metadata["__mrc_filepath"][0]
-        mrc = mrcfile.open(first_mrc_filepath)
+        mrc = mrcfile.open(first_mrc_filepath, mode="r", permissive=True)
 
         # Get the 'mode' (data type) - TODO: There's probably a more direct way to do this.
         mode = int(mrc.header.mode)
@@ -247,7 +247,7 @@ class RelionSource(ImageSource):
         logger.debug(f"Indices: {indices}")
 
         def load_single_mrcs(filepath, indices):
-            arr = mrcfile.open(filepath).data
+            arr = mrcfile.open(filepath, mode="r", permissive=True).data
             # if the stack only contains one image, arr will have shape (resolution, resolution)
             # the code below reshapes it to (1, resolution, resolution)
             if len(arr.shape) == 2:


### PR DESCRIPTION
lots of published datasets are full of junk metadata ...

This should allow us to still open them.  We had fixed this in a few places, but I found one more trying to load a new dataset.  Looking around I spotted an additional one as well.