### PR TITLE
CoordinateSource pixel_size handling

### DIFF
--- a/src/aspire/source/coordinates.py
+++ b/src/aspire/source/coordinates.py
@@ -52,7 +52,7 @@ class CoordinateSource(ImageSource, ABC):
     ):
         """
         :param files: A list of tuples of the form (path_to_mrc, path_to_coord)
-        :particle_size: Desired size of cropped particles (will override the size specified in coordinate file)
+        :param particle_size: Desired size of cropped particles (will override the size specified in coordinate file)
         :param max_rows: Maximum number of particles to read. (If `None`, will attempt to load all particles)
         :param B: CTF envelope decay factor
         :param symmetry_group: A `SymmetryGroup` object or string corresponding to the symmetry of the molecule.
@@ -417,13 +417,14 @@ class CoordinateSource(ImageSource, ABC):
                 stacklevel=2,
             )
         # When source is not assigned we can try to assign it from CTF,
-        #   but only do this if all the CTFFilter pixel_sizes are consistent
         elif self.pixel_size is None:
+            # but only do this if all the CTFFilter pixel_sizes are consistent
             if len(ctf_pixel_sizes) == 1:
                 self.pixel_size = ctf_pixel_sizes[0]  # take the unique single element
                 logger.info(
                     f"Assigning source pixel_size={self.pixel_size} from CTFFilters."
                 )
+            # otherwise let the user know
             elif len(ctf_pixel_sizes) > 1:
                 logger.warning(
                     "Unable to assign source pixel_size from CTFFilters, multiple pixel_sizes found."
@@ -564,7 +565,7 @@ class BoxesCoordinateSource(CoordinateSource):
     ):
         """
         :param files: A list of tuples of the form (path_to_mrc, path_to_coord)
-        :particle_size: Desired size of cropped particles (will override the size specified in coordinate file)
+        :param particle_size: Desired size of cropped particles (will override the size specified in coordinate file)
         :param max_rows: Maximum number of particles to read. (If `None`, will attempt to load all particles)
         :param B: CTF envelope decay factor
         :param symmetry_group: A `SymmetryGroup` object or string corresponding to the symmetry of the molecule.
@@ -693,7 +694,7 @@ class CentersCoordinateSource(CoordinateSource):
     ):
         """
         :param files: A list of tuples of the form (path_to_mrc, path_to_coord)
-        :particle_size: Desired size of cropped particles (mandatory)
+        :param particle_size: Desired size of cropped particles (mandatory)
         :param max_rows: Maximum number of particles to read. (If `None`, will
         attempt to load all particles)
         :param B: CTF envelope decay factor

--- a/src/aspire/source/coordinates.py
+++ b/src/aspire/source/coordinates.py
@@ -56,7 +56,9 @@ class CoordinateSource(ImageSource, ABC):
         :param max_rows: Maximum number of particles to read. (If `None`, will attempt to load all particles)
         :param B: CTF envelope decay factor
         :param symmetry_group: A `SymmetryGroup` object or string corresponding to the symmetry of the molecule.
-        :param pixel_size: Pixel size of the images in angstroms, default `None`.
+        :param pixel_size: Pixel size of the images in angstroms.
+            Default `None` will attempt to infer `pixel_size` from
+            `CTFFilter` objects when available.
         """
         mrc_paths, coord_paths = [f[0] for f in files], [f[1] for f in files]
         # the particle_size parameter is the *user-specified* argument
@@ -569,7 +571,9 @@ class BoxesCoordinateSource(CoordinateSource):
         :param max_rows: Maximum number of particles to read. (If `None`, will attempt to load all particles)
         :param B: CTF envelope decay factor
         :param symmetry_group: A `SymmetryGroup` object or string corresponding to the symmetry of the molecule.
-        :param pixel_size: Pixel size of the images in angstroms, default `None`.
+        :param pixel_size: Pixel size of the images in angstroms.
+            Default `None` will attempt to infer `pixel_size` from
+            `CTFFilter` objects when available.
         """
         # instantiate super
         CoordinateSource.__init__(
@@ -699,7 +703,9 @@ class CentersCoordinateSource(CoordinateSource):
         attempt to load all particles)
         :param B: CTF envelope decay factor
         :param symmetry_group: A `SymmetryGroup` object or string corresponding to the symmetry of the molecule.
-        :param pixel_size: Pixel size of the images in angstroms, default `None`.
+        :param pixel_size: Pixel size of the images in angstroms.
+            Default `None` will attempt to infer `pixel_size` from
+            `CTFFilter` objects when available.
         """
         # instantiate super
         CoordinateSource.__init__(

--- a/src/aspire/source/coordinates.py
+++ b/src/aspire/source/coordinates.py
@@ -405,7 +405,7 @@ class CoordinateSource(ImageSource, ABC):
 
         # Check pixel_size
         # Get pixel_sizes from CTFFilters
-        ctf_pixel_sizes = list(set(filter_params[:, 6]))
+        ctf_pixel_sizes = np.unique(filter_params[:, 6])
         # Compare with source.pixel_size if assigned
         if (self.pixel_size is not None) and (
             not np.allclose(ctf_pixel_sizes, self.pixel_size)

--- a/tests/test_coordinate_source.py
+++ b/tests/test_coordinate_source.py
@@ -727,7 +727,7 @@ class CoordinateSourceTestCase(TestCase):
         # Capture and compare warning message
         with pytest.warns(UserWarning, match=r".*Pixel size mismatch.*"):
             src.import_relion_ctf(self.relion_ctf_file)
-            assert src.pixel_size == manual_pixel_size
+            np.testing.assert_approx_equal(src.pixel_size, manual_pixel_size)
 
     def testPixelSize(self):
         """
@@ -735,7 +735,7 @@ class CoordinateSourceTestCase(TestCase):
         """
         src = BoxesCoordinateSource(self.files_box, pixel_size=self.pixel_size)
         src.import_relion_ctf(self.relion_ctf_file)
-        assert src.pixel_size == self.pixel_size
+        np.testing.assert_approx_equal(src.pixel_size, self.pixel_size)
 
     def testPixelSizeNone(self):
         """
@@ -743,7 +743,7 @@ class CoordinateSourceTestCase(TestCase):
         """
         src = BoxesCoordinateSource(self.files_box)
         src.import_relion_ctf(self.relion_ctf_file)
-        assert src.pixel_size == self.pixel_size
+        np.testing.assert_approx_equal(src.pixel_size, self.pixel_size)
 
 
 def create_test_rectangular_micrograph_and_star(tmp_path, voxel_size=(2.0, 2.0, 1.0)):

--- a/tests/test_coordinate_source.py
+++ b/tests/test_coordinate_source.py
@@ -736,7 +736,7 @@ class CoordinateSourceTestCase(TestCase):
 
     def testPixelSizeWarning(self):
         """
-        Test source haveing a pixel size that conflicts with the CTFFilter instances.
+        Test source having a pixel size that conflicts with the CTFFilter instances.
         """
         manual_pixel_size = 0.789
         src = BoxesCoordinateSource(self.files_box, pixel_size=manual_pixel_size)
@@ -747,7 +747,7 @@ class CoordinateSourceTestCase(TestCase):
 
     def testMultiplePixelSizeWarning(self):
         """
-        Test source haveing a multiple pixel sizes in CTFFilter instances.
+        Test source having multiple pixel sizes in CTFFilter instances.
         """
         src = BoxesCoordinateSource(self.files_box)  # pixel_size=None
         # Capture and compare warning message


### PR DESCRIPTION
Adds `pixel_size` to initializer for CoordinateSources.  Also add basic test for the explicit, None, and mismatch case.