### PR TITLE
resolve ambiguous dtype in Downsample

### DIFF
--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -564,6 +564,7 @@ class Image:
         # differs between Numpy 1, 2, and CuPy.
         # At time of writing CuPy is consistent with Numpy1.
         # The additional parenths yield consistent out.dtype.
+        # See #1298 for relevant debugger output.
         out = xp.asnumpy(out.real * (ds_res**2 / self.resolution**2))
 
         # Optionally scale pixel size

--- a/src/aspire/image/image.py
+++ b/src/aspire/image/image.py
@@ -559,7 +559,12 @@ class Image:
             out = fft.ifft2(fft.ifftshift(crop_fx))
         else:
             out = fft.centered_ifft2(crop_fx)
-        out = xp.asnumpy(out.real * ds_res**2 / self.resolution**2)
+
+        # The parenths are required because dtype casting semantics
+        # differs between Numpy 1, 2, and CuPy.
+        # At time of writing CuPy is consistent with Numpy1.
+        # The additional parenths yield consistent out.dtype.
+        out = xp.asnumpy(out.real * (ds_res**2 / self.resolution**2))
 
         # Optionally scale pixel size
         ds_pixel_size = self.pixel_size


### PR DESCRIPTION
It's a brave new world out there.

```
(Pdb) out.real.dtype
dtype('float32')
(Pdb) out.real.get().dtype
dtype('float32')
(Pdb) (out.real * ds_res**2 / self.resolution**2).dtype
dtype('float64')
(Pdb) type(out)
<class 'cupy.ndarray'>
(Pdb) (out.real.get() * ds_res**2 / self.resolution**2).dtype
dtype('float32')
```

There are other ways to handle, but this seemed minimally invasive. Resolves the problem I was seeing in the pipeline demo.