### PR TITLE
Rewrite RelionSource `_image` method

### DIFF
--- a/src/aspire/source/relion.py
+++ b/src/aspire/source/relion.py
@@ -302,7 +302,7 @@ def _optimize_contiguous_slice(inds):
     Given an iterable of indices `inds`,
     determine if `inds` is a contiguous slice,
     and in that case return an equivalent `slice` object,
-    otherwise return inds and an array.
+    otherwise return `inds` as an array.
 
     :param inds: iterable of indices
     :return: slice or array


### PR DESCRIPTION
Avoid reloading entire MRCS for each _image call.