### PR TITLE
ImageSource.save Optics Block

### DIFF
--- a/gallery/experiments/save_simulation_relion_reconstruct.py
+++ b/gallery/experiments/save_simulation_relion_reconstruct.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 # Configuration
 # -------------
 # We set a few parameters to initialize the Simulation.
-# You can safely alter ``n_particles`` (or change the voltages, etc.) when
+# You can safely alter ``n_particles`` (or change the defocus values, etc.) when
 # trying this interactively; the defaults here are chosen for demonstrative purposes.
 
 output_dir = Path("relion_save_demo")

--- a/gallery/experiments/save_simulation_relion_reconstruct.py
+++ b/gallery/experiments/save_simulation_relion_reconstruct.py
@@ -74,7 +74,7 @@ sim.save(star_path, overwrite=True)
 # Running ``relion_reconstruct``
 # ------------------------------
 # ``relion_reconstruct`` is an external RELION command, so we just show the call.
-# Run this, for the output directory, in a RELION-enabled shell after generating
+# Run this, from the output directory, in a RELION-enabled shell after generating
 # the STAR file above.
 
 logger.info(f"relion_reconstruct --i {star_file} " f"--o 'relion_recon.mrc' --ctf")

--- a/gallery/experiments/save_simulation_relion_reconstruct.py
+++ b/gallery/experiments/save_simulation_relion_reconstruct.py
@@ -38,7 +38,9 @@ output_dir.mkdir(exist_ok=True)
 
 n_particles = 512
 snr = 0.5
-defocus = np.linspace(15000, 25000, 7)  # defocus values for the radial CTF filters (angstroms)
+defocus = np.linspace(
+    15000, 25000, 7
+)  # defocus values for the radial CTF filters (angstroms)
 star_file = f"sim_n{n_particles}.star"
 star_path = output_dir / star_file
 
@@ -75,7 +77,4 @@ sim.save(star_path, overwrite=True)
 # Run this, for the output directory, in a RELION-enabled shell after generating
 # the STAR file above.
 
-logger.info(
-    f"relion_reconstruct --i {star_file} "
-    f"--o 'relion_recon.mrc' --ctf"
-)
+logger.info(f"relion_reconstruct --i {star_file} " f"--o 'relion_recon.mrc' --ctf")

--- a/gallery/experiments/save_simulation_relion_reconstruct.py
+++ b/gallery/experiments/save_simulation_relion_reconstruct.py
@@ -21,7 +21,7 @@ import numpy as np
 from aspire.downloader import emdb_2660
 from aspire.noise import WhiteNoiseAdder
 from aspire.operators import RadialCTFFilter
-from aspire.source import RelionSource, Simulation
+from aspire.source import Simulation
 
 logger = logging.getLogger(__name__)
 
@@ -83,5 +83,4 @@ relion_cmd = [
     "--ctf",
 ]
 
-print(" ".join(relion_cmd))
-
+logger.info(" ".join(relion_cmd))

--- a/gallery/experiments/save_simulation_relion_reconstruct.py
+++ b/gallery/experiments/save_simulation_relion_reconstruct.py
@@ -1,6 +1,6 @@
 """
-Simulated Stack → RELION Reconstruction
-=======================================
+Simulated Stack to RELION Reconstruction
+========================================
 
 This experiment shows how to:
 
@@ -37,10 +37,10 @@ output_dir = Path("relion_save_demo")
 output_dir.mkdir(exist_ok=True)
 
 n_particles = 512
-snr = 0.25
-voltages = np.linspace(200, 300, 3)  # kV settings for the radial CTF filters
-star_path = output_dir / f"sim_n{n_particles}.star"
-
+snr = 0.5
+defocus = np.linspace(15000, 25000, 7)  # defocus values for the radial CTF filters (angstroms)
+star_file = f"sim_n{n_particles}.star"
+star_path = output_dir / star_file
 
 # %%
 # Volume and Filters
@@ -49,7 +49,7 @@ star_path = output_dir / f"sim_n{n_particles}.star"
 # that RELION will recover as optics groups.
 
 vol = emdb_2660()
-ctf_filters = [RadialCTFFilter(voltage=kv) for kv in voltages]
+ctf_filters = [RadialCTFFilter(defocus=d) for d in defocus]
 
 
 # %%
@@ -72,15 +72,10 @@ sim.save(star_path, overwrite=True)
 # Running ``relion_reconstruct``
 # ------------------------------
 # ``relion_reconstruct`` is an external RELION command, so we just show the call.
-# Run this in a RELION-enabled shell after generating the STAR file above.
+# Run this, for the output directory, in a RELION-enabled shell after generating
+# the STAR file above.
 
-relion_cmd = [
-    "relion_reconstruct",
-    "--i",
-    str(star_path),
-    "--o",
-    str(output_dir / "relion_recon.mrc"),
-    "--ctf",
-]
-
-logger.info(" ".join(relion_cmd))
+logger.info(
+    f"relion_reconstruct --i {star_file} "
+    f"--o 'relion_recon.mrc' --ctf"
+)

--- a/gallery/experiments/save_simulation_relion_reconstruct.py
+++ b/gallery/experiments/save_simulation_relion_reconstruct.py
@@ -1,0 +1,87 @@
+"""
+Simulated Stack → RELION Reconstruction
+=======================================
+
+This experiment shows how to:
+
+1. build a synthetic dataset with ASPIRE,
+2. write the stack via ``ImageSource.save`` so RELION can consume it, and
+3. call :code:`relion_reconstruct` on the saved STAR file.
+"""
+
+# %%
+# Imports
+# -------
+
+import logging
+from pathlib import Path
+
+import numpy as np
+
+from aspire.downloader import emdb_2660
+from aspire.noise import WhiteNoiseAdder
+from aspire.operators import RadialCTFFilter
+from aspire.source import RelionSource, Simulation
+
+logger = logging.getLogger(__name__)
+
+
+# %%
+# Configuration
+# -------------
+# We set a few parameters to initialize the Simulation.
+# You can safely alter ``n_particles`` (or change the voltages, etc.) when
+# trying this interactively; the defaults here are chosen for demonstrative purposes.
+
+output_dir = Path("relion_save_demo")
+output_dir.mkdir(exist_ok=True)
+
+n_particles = 512
+snr = 0.25
+voltages = np.linspace(200, 300, 3)  # kV settings for the radial CTF filters
+star_path = output_dir / f"sim_n{n_particles}.star"
+
+
+# %%
+# Volume and Filters
+# ------------------
+# Start from the EMDB-2660 ribosome map and build a small set of radial CTF filters
+# that RELION will recover as optics groups.
+
+vol = emdb_2660()
+ctf_filters = [RadialCTFFilter(voltage=kv) for kv in voltages]
+
+
+# %%
+# Simulate, Add Noise, Save
+# -------------------------
+# Initialize the Simulation:
+# mix the CTFs across the stack, add white noise at a target SNR,
+# and write the particles and metadata to a RELION-compatible STAR/MRC stack.
+
+sim = Simulation(
+    n=n_particles,
+    vols=vol,
+    unique_filters=ctf_filters,
+    noise_adder=WhiteNoiseAdder.from_snr(snr),
+)
+sim.save(star_path, overwrite=True)
+
+
+# %%
+# Running ``relion_reconstruct``
+# ------------------------------
+# ``relion_reconstruct`` is an external RELION command, so we just show the call.
+# Run this in a RELION-enabled shell after generating the STAR file above.
+
+relion_cmd = [
+    "relion_reconstruct",
+    "--i",
+    str(star_path),
+    "--o",
+    str(output_dir / "relion_recon.mrc"),
+    "--ctf",
+]
+
+print(" ".join(relion_cmd))
+

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -1316,16 +1316,22 @@ class ImageSource(ABC):
         # with a dummy value if not.
         n_rows = len(metadata["_rlnImageName"])
 
+        missing_fields = []
+
         def _ensure_column(field, value):
             if field not in metadata:
+                missing_fields.append(field)
                 logger.warning(
                     f"Optics field {field} not found, populating with default value {value}"
                 )
                 metadata[field] = np.full(n_rows, value)
 
-        _ensure_column("_rlnSphericalAberration", 2.0)
-        _ensure_column("_rlnVoltage", 300)
-        _ensure_column("_rlnAmplitudeContrast", 0.1)
+        _ensure_column("_rlnSphericalAberration", 0)
+        _ensure_column("_rlnVoltage", 0)
+        _ensure_column("_rlnAmplitudeContrast", 0)
+
+        if missing_fields:
+            metadata["_aspireMetadata"] = np.full(n_rows, "no_ctf", dtype=object)
 
         # Restrict to the optics columns that are actually present on this source.
         optics_value_fields = [

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -1330,9 +1330,6 @@ class ImageSource(ABC):
         _ensure_column("_rlnVoltage", 0)
         _ensure_column("_rlnAmplitudeContrast", 0)
 
-        if missing_fields:
-            metadata["_aspireMetadata"] = np.full(n_rows, "no_ctf", dtype=object)
-
         # Restrict to the optics columns that are actually present on this source.
         optics_value_fields = [
             field for field in all_optics_fields if field in metadata
@@ -1358,6 +1355,10 @@ class ImageSource(ABC):
             optics_block["_rlnOpticsGroupName"].append(f"opticsGroup{group_id}")
             for field, value in zip(optics_value_fields, signature):
                 optics_block[field].append(value)
+
+        # Tag dummy optics if we had to synthesize any fields
+        if missing_fields:
+            optics_block["_aspireNoCTF"] = ["." for _ in range(len(group_lookup))]
 
         # Everything not lifted into the optics block stays with the particle metadata.
         particle_block = OrderedDict()

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -1499,6 +1499,8 @@ class ImageSource(ABC):
                 #   for large arrays.
                 stats.update_header(mrc)
 
+                # Add pixel size to header
+                mrc.voxel_size = self.pixel_size
         else:
             # save all images into multiple mrc files in batch size
             for i_start in np.arange(0, self.n, batch_size):
@@ -1512,6 +1514,7 @@ class ImageSource(ABC):
                     f"Saving ImageSource[{i_start}-{i_end-1}] to {mrcs_filepath}"
                 )
                 im = self.images[i_start:i_end]
+                im.pixel_size = self.pixel_size
                 im.save(mrcs_filepath, overwrite=overwrite)
 
     def estimate_signal_mean_energy(

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -483,21 +483,16 @@ class ImageSource(ABC):
 
     @property
     def amplitudes(self):
-        if self.has_metadata("__amplitude"):
-            values = self.get_metadata("__amplitude")
-        else:
-            values = self.get_metadata(
-                "_rlnAmplitude",
-                default_value=np.array(1.0, dtype=np.float64),
-            )
+        values = self.get_metadata(
+            "_aspireAmplitude",
+            default_value=np.array(1.0, dtype=np.float64),
+        )
         return np.atleast_1d(np.asarray(values, dtype=np.float64))
 
     @amplitudes.setter
     def amplitudes(self, values):
         values = np.asarray(values, dtype=np.float64)
-        self.set_metadata("__amplitude", values)
-        # Drop the legacy field if we encountered it while loading a STAR file.
-        self._metadata.pop("_rlnAmplitude", None)
+        self.set_metadata("_aspireAmplitude", values)
 
     @property
     def angles(self):

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -1306,11 +1306,18 @@ class ImageSource(ABC):
             "_rlnMicrographPixelSize",
             "_rlnSphericalAberration",
             "_rlnVoltage",
-            "_rlnImageSize",
             "_rlnAmplitudeContrast",
+            "_rlnImageSize",
+            "_rlnImageDimensionality",
         ]
 
-        required_fields = ["_rlnSphericalAberration", "_rlnVoltage", "_rlnImageSize"]
+        required_fields = [
+            "_rlnSphericalAberration",
+            "_rlnVoltage",
+            "_rlnAmplitudeContrast",
+            "_rlnImageSize",
+            "_rlnImageDimensionality",
+        ]
         pixel_fields = ["_rlnImagePixelSize", "_rlnMicrographPixelSize"]
 
         has_required = all(field in metadata for field in required_fields)
@@ -1396,9 +1403,12 @@ class ImageSource(ABC):
             for x in np.char.split(metadata["_rlnImageName"].astype(np.str_), sep="@")
         ]
 
-        # Populate _rlnImageSize column, required for optics_block below
+        # Populate _rlnImageSize, _rlnImageDimensionality columns, required for optics_block below
         if "_rlnImageSize" not in metadata:
             metadata["_rlnImageSize"] = np.full(self.n, self.L, dtype=int)
+
+        if "_rlnImageDimensionality" not in metadata:
+            metadata["_rlnImageDimensionality"] = np.full(self.n, 2, dtype=int)
 
         # Separate metadata into optics and particle blocks
         optics_block, particle_block = self._prepare_relion_optics_blocks(metadata)

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -1325,7 +1325,7 @@ class ImageSource(ABC):
         optics_value_fields = [
             field for field in all_optics_fields if field in metadata
         ]
-        n_rows = len(metadata["_rlnImagePixelSize"])
+        n_rows = len(metadata["_rlnImageName"])
 
         group_lookup = OrderedDict()  # Stores distinct optics groups
         optics_groups = np.empty(n_rows, dtype=int)

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -491,6 +491,7 @@ class ImageSource(ABC):
 
     @amplitudes.setter
     def amplitudes(self, values):
+        # Keep amplitudes float64 so downstream filters/metadata retain precision.
         values = np.asarray(values, dtype=np.float64)
         self.set_metadata("_aspireAmplitude", values)
 

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -1310,8 +1310,7 @@ class ImageSource(ABC):
             "_rlnAmplitudeContrast",
         ]
 
-        # TODO: Need to add _rlnImageSize here and above
-        required_fields = ["_rlnSphericalAberration", "_rlnVoltage"]
+        required_fields = ["_rlnSphericalAberration", "_rlnVoltage", "_rlnImageSize"]
         pixel_fields = ["_rlnImagePixelSize", "_rlnMicrographPixelSize"]
 
         has_required = all(field in metadata for field in required_fields)
@@ -1396,6 +1395,10 @@ class ImageSource(ABC):
             x[1]
             for x in np.char.split(metadata["_rlnImageName"].astype(np.str_), sep="@")
         ]
+
+        # Populate _rlnImageSize column, required for optics_block below
+        if "_rlnImageSize" not in metadata:
+            metadata["_rlnImageSize"] = np.full(self.n, self.L, dtype=int)
 
         # Separate metadata into optics and particle blocks
         optics_block, particle_block = self._prepare_relion_optics_blocks(metadata)

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -483,15 +483,21 @@ class ImageSource(ABC):
 
     @property
     def amplitudes(self):
-        return np.atleast_1d(
-            self.get_metadata(
-                "_rlnAmplitude", default_value=np.array(1.0, dtype=self.dtype)
+        if self.has_metadata("__amplitude"):
+            values = self.get_metadata("__amplitude")
+        else:
+            values = self.get_metadata(
+                "_rlnAmplitude",
+                default_value=np.array(1.0, dtype=np.float64),
             )
-        )
+        return np.atleast_1d(np.asarray(values, dtype=np.float64))
 
     @amplitudes.setter
     def amplitudes(self, values):
-        return self.set_metadata("_rlnAmplitude", np.array(values, dtype=self.dtype))
+        values = np.asarray(values, dtype=np.float64)
+        self.set_metadata("__amplitude", values)
+        # Drop the legacy field if we encountered it while loading a STAR file.
+        self._metadata.pop("_rlnAmplitude", None)
 
     @property
     def angles(self):

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -3,7 +3,7 @@ import functools
 import logging
 import os.path
 from abc import ABC, abstractmethod
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 from collections.abc import Iterable
 
 import mrcfile
@@ -1350,11 +1350,7 @@ class ImageSource(ABC):
         metadata["_rlnOpticsGroup"] = optics_groups
 
         # Build the optics block rows and assign group names.
-        optics_block = OrderedDict()
-        optics_block["_rlnOpticsGroup"] = []
-        optics_block["_rlnOpticsGroupName"] = []
-        for field in optics_value_fields:
-            optics_block[field] = []
+        optics_block = defaultdict(list)
 
         for signature, group_id in group_lookup.items():
             optics_block["_rlnOpticsGroup"].append(group_id)

--- a/src/aspire/source/relion.py
+++ b/src/aspire/source/relion.py
@@ -195,10 +195,6 @@ class RelionSource(ImageSource):
 
         metadata = RelionStarFile(self.filepath).get_merged_data_block()
 
-        # Promote legacy _rlnAmplitude column to the ASPIRE-specific name.
-        if "_rlnAmplitude" in metadata and "_aspireAmplitude" not in metadata:
-            metadata["_aspireAmplitude"] = metadata.pop("_rlnAmplitude")
-
         # particle locations are stored as e.g. '000001@first_micrograph.mrcs'
         # in the _rlnImageName column. here, we're splitting this information
         # so we can get the particle's index in the .mrcs stack as an int

--- a/src/aspire/source/relion.py
+++ b/src/aspire/source/relion.py
@@ -126,10 +126,7 @@ class RelionSource(ImageSource):
                 del self._metadata[key]
 
         # Detect ASPIRE-generated dummy variables
-        aspire_metadata = metadata.get("_aspireMetadata")
-        dummy_ctf = isinstance(aspire_metadata, (list, np.ndarray)) and np.all(
-            np.asarray(aspire_metadata) == "no_ctf"
-        )
+        no_ctf_flag = "_aspireNoCTF" in metadata
 
         # CTF estimation parameters coming from Relion
         CTF_params = [
@@ -169,7 +166,7 @@ class RelionSource(ImageSource):
             self.filter_indices = filter_indices
 
         # If we detect ASPIRE added dummy variables, log and initialize identity filter
-        elif dummy_ctf:
+        elif no_ctf_flag:
             logger.info(
                 "Detected ASPIRE-generated dummy optics; initializing identity filters."
             )

--- a/src/aspire/source/relion.py
+++ b/src/aspire/source/relion.py
@@ -195,6 +195,10 @@ class RelionSource(ImageSource):
 
         metadata = RelionStarFile(self.filepath).get_merged_data_block()
 
+        # Promote legacy _rlnAmplitude column to the ASPIRE-specific name.
+        if "_rlnAmplitude" in metadata and "_aspireAmplitude" not in metadata:
+            metadata["_aspireAmplitude"] = metadata.pop("_rlnAmplitude")
+
         # particle locations are stored as e.g. '000001@first_micrograph.mrcs'
         # in the _rlnImageName column. here, we're splitting this information
         # so we can get the particle's index in the .mrcs stack as an int

--- a/src/aspire/source/relion.py
+++ b/src/aspire/source/relion.py
@@ -168,7 +168,8 @@ class RelionSource(ImageSource):
                 f"Found partially populated CTF Params."
                 f"  To automatically populate CTFFilters provide {CTF_params}"
             )
-
+            self.unique_filters = [IdentityFilter()]
+            self.filter_indices = np.zeros(self.n, dtype=int)
         # If no CTF info in STAR, we initialize the filter values of metadata with default values
         else:
             self.unique_filters = [IdentityFilter()]

--- a/src/aspire/storage/starfile.py
+++ b/src/aspire/storage/starfile.py
@@ -135,7 +135,6 @@ class StarFile:
         # create an empty Document
         _doc = cif.Document()
         filepath = str(filepath)
-
         for name, block in self.blocks.items():
             # construct new empty block
             _block = _doc.add_new_block(name)

--- a/src/aspire/storage/starfile.py
+++ b/src/aspire/storage/starfile.py
@@ -135,6 +135,7 @@ class StarFile:
         # create an empty Document
         _doc = cif.Document()
         filepath = str(filepath)
+
         for name, block in self.blocks.items():
             # construct new empty block
             _block = _doc.add_new_block(name)

--- a/src/aspire/utils/relion_interop.py
+++ b/src/aspire/utils/relion_interop.py
@@ -12,7 +12,8 @@ logger = logging.getLogger(__name__)
 # of certain key fields used in the codebase,
 # which are originally read from Relion STAR files.
 relion_metadata_fields = {
-    "__amplitude": float,
+    "_aspireAmplitude": float,
+    "_rlnAmplitude": float,
     "_rlnVoltage": float,
     "_rlnDefocusU": float,
     "_rlnDefocusV": float,

--- a/src/aspire/utils/relion_interop.py
+++ b/src/aspire/utils/relion_interop.py
@@ -20,6 +20,7 @@ relion_metadata_fields = {
     "_rlnDetectorPixelSize": float,
     "_rlnCtfFigureOfMerit": float,
     "_rlnMagnification": float,
+    "_rlnImageDimensionality": int,
     "_rlnImagePixelSize": float,
     "_rlnImageSize": int,
     "_rlnAmplitudeContrast": float,

--- a/src/aspire/utils/relion_interop.py
+++ b/src/aspire/utils/relion_interop.py
@@ -12,8 +12,6 @@ logger = logging.getLogger(__name__)
 # of certain key fields used in the codebase,
 # which are originally read from Relion STAR files.
 relion_metadata_fields = {
-    "_aspireAmplitude": float,
-    "_rlnAmplitude": float,
     "_rlnVoltage": float,
     "_rlnDefocusU": float,
     "_rlnDefocusV": float,

--- a/src/aspire/utils/relion_interop.py
+++ b/src/aspire/utils/relion_interop.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 # of certain key fields used in the codebase,
 # which are originally read from Relion STAR files.
 relion_metadata_fields = {
+    "__amplitude": float,
     "_rlnVoltage": float,
     "_rlnDefocusU": float,
     "_rlnDefocusV": float,

--- a/src/aspire/utils/relion_interop.py
+++ b/src/aspire/utils/relion_interop.py
@@ -21,6 +21,7 @@ relion_metadata_fields = {
     "_rlnCtfFigureOfMerit": float,
     "_rlnMagnification": float,
     "_rlnImagePixelSize": float,
+    "_rlnImageSize": int,
     "_rlnAmplitudeContrast": float,
     "_rlnImageName": str,
     "_rlnOriginalName": str,

--- a/tests/test_array_image_source.py
+++ b/tests/test_array_image_source.py
@@ -323,10 +323,10 @@ def test_dtype_passthrough(dtype):
     # Check dtypes
     np.testing.assert_equal(src.dtype, dtype)
     np.testing.assert_equal(src.images[:].dtype, dtype)
-    np.testing.assert_equal(src.amplitudes.dtype, dtype)
 
-    # offsets are always stored as doubles
+    # offsets and amplitudes are always stored as doubles
     np.testing.assert_equal(src.offsets.dtype, np.float64)
+    np.testing.assert_equal(src.amplitudes.dtype, np.float64)
 
 
 def test_stack_1d_only():

--- a/tests/test_coordinate_source.py
+++ b/tests/test_coordinate_source.py
@@ -526,7 +526,7 @@ class CoordinateSourceTestCase(TestCase):
         # load saved particle stack
         saved_star = StarFile(star_path)
         # we want to read the saved mrcs file from the STAR file
-        image_name_column = saved_star.get_block_by_index(0)["_rlnImageName"]
+        image_name_column = saved_star.get_block_by_index(1)["_rlnImageName"]
         # we're reading a string of the form 0000X@mrcs_path.mrcs
         _particle, mrcs_path = image_name_column[0].split("@")
         saved_mrcs_stack = mrcfile.open(os.path.join(self.data_folder, mrcs_path)).data
@@ -537,15 +537,28 @@ class CoordinateSourceTestCase(TestCase):
         self.assertEqual(
             list(saved_star["particles"].keys()),
             [
-                "_rlnImagePixelSize",
+                "_rlnOpticsGroup",
                 "_rlnSymmetryGroup",
                 "_rlnImageName",
                 "_rlnCoordinateX",
                 "_rlnCoordinateY",
+            ],
+        )
+
+        self.assertEqual(
+            list(saved_star["optics"].keys()),
+            [
+                "_rlnOpticsGroup",
+                "_rlnOpticsGroupName",
+                "_rlnImagePixelSize",
+                "_rlnSphericalAberration",
+                "_rlnVoltage",
+                "_rlnAmplitudeContrast",
                 "_rlnImageSize",
                 "_rlnImageDimensionality",
             ],
         )
+
         # assert that all the correct coordinates were saved
         for i in range(10):
             self.assertEqual(

--- a/tests/test_coordinate_source.py
+++ b/tests/test_coordinate_source.py
@@ -542,7 +542,6 @@ class CoordinateSourceTestCase(TestCase):
                 "_rlnImageName",
                 "_rlnCoordinateX",
                 "_rlnCoordinateY",
-                "_aspireMetadata",
             ],
         )
 
@@ -557,6 +556,7 @@ class CoordinateSourceTestCase(TestCase):
                 "_rlnAmplitudeContrast",
                 "_rlnImageSize",
                 "_rlnImageDimensionality",
+                "_aspireNoCTF",
             ],
         )
 

--- a/tests/test_coordinate_source.py
+++ b/tests/test_coordinate_source.py
@@ -543,6 +543,7 @@ class CoordinateSourceTestCase(TestCase):
                 "_rlnCoordinateX",
                 "_rlnCoordinateY",
                 "_rlnImageSize",
+                "_rlnImageDimensionality",
             ],
         )
         # assert that all the correct coordinates were saved

--- a/tests/test_coordinate_source.py
+++ b/tests/test_coordinate_source.py
@@ -535,7 +535,7 @@ class CoordinateSourceTestCase(TestCase):
             self.assertTrue(np.array_equal(imgs.asnumpy()[i], saved_mrcs_stack[i]))
         # assert that the star file has the correct metadata
         self.assertEqual(
-            list(saved_star[""].keys()),
+            list(saved_star["particles"].keys()),
             [
                 "_rlnImagePixelSize",
                 "_rlnSymmetryGroup",

--- a/tests/test_coordinate_source.py
+++ b/tests/test_coordinate_source.py
@@ -542,6 +542,7 @@ class CoordinateSourceTestCase(TestCase):
                 "_rlnImageName",
                 "_rlnCoordinateX",
                 "_rlnCoordinateY",
+                "_rlnImageSize",
             ],
         )
         # assert that all the correct coordinates were saved

--- a/tests/test_coordinate_source.py
+++ b/tests/test_coordinate_source.py
@@ -542,6 +542,7 @@ class CoordinateSourceTestCase(TestCase):
                 "_rlnImageName",
                 "_rlnCoordinateX",
                 "_rlnCoordinateY",
+                "_aspireMetadata",
             ],
         )
 

--- a/tests/test_relion_source.py
+++ b/tests/test_relion_source.py
@@ -70,6 +70,7 @@ def test_prepare_relion_optics_blocks_warns(caplog):
         "_rlnImagePixelSize": np.array([1.234]),
         "_rlnImageSize": np.array([32]),
         "_rlnImageDimensionality": np.array([2]),
+        "_rlnImageName": np.array(["000001@stack.mrcs"]),
     }
 
     caplog.clear()
@@ -78,9 +79,21 @@ def test_prepare_relion_optics_blocks_warns(caplog):
             metadata.copy()
         )
 
-    assert optics_block is None
-    assert particle_block == metadata
-    assert "Optics metadata incomplete" in caplog.text
+    # We should get and optics block
+    assert optics_block is not None
+
+    # Verify defaults were injected.
+    np.testing.assert_allclose(optics_block["_rlnImagePixelSize"], [1.234])
+    np.testing.assert_array_equal(optics_block["_rlnImageSize"], [32])
+    np.testing.assert_array_equal(optics_block["_rlnImageDimensionality"], [2])
+    np.testing.assert_allclose(optics_block["_rlnVoltage"], [300.0])
+    np.testing.assert_allclose(optics_block["_rlnSphericalAberration"], [2.0])
+    np.testing.assert_allclose(optics_block["_rlnAmplitudeContrast"], [0.1])
+
+    # Caplog should contain the warnings about the three missing fields.
+    assert "Optics field _rlnSphericalAberration not found" in caplog.text
+    assert "Optics field _rlnVoltage not found" in caplog.text
+    assert "Optics field _rlnAmplitudeContrast not found" in caplog.text
 
 
 def test_pixel_size(caplog):

--- a/tests/test_relion_source.py
+++ b/tests/test_relion_source.py
@@ -5,7 +5,7 @@ import os
 import numpy as np
 import pytest
 
-from aspire.source import RelionSource, Simulation
+from aspire.source import ImageSource, RelionSource, Simulation
 from aspire.utils import RelionStarFile
 from aspire.volume import SymmetryGroup
 
@@ -59,6 +59,28 @@ def test_symmetry_group(caplog):
 
     assert isinstance(src_override_sym.symmetry_group, SymmetryGroup)
     assert str(src_override_sym.symmetry_group) == "C6"
+
+
+def test_prepare_relion_optics_blocks_warns(caplog):
+    """
+    Test we warn when optics group metadata is missing.
+    """
+    # metadata dict with no CTF values
+    metadata = {
+        "_rlnImagePixelSize": np.array([1.234]),
+        "_rlnImageSize": np.array([32]),
+        "_rlnImageDimensionality": np.array([2]),
+    }
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        optics_block, particle_block = ImageSource._prepare_relion_optics_blocks(
+            metadata.copy()
+        )
+
+    assert optics_block is None
+    assert particle_block == metadata
+    assert "Optics metadata incomplete" in caplog.text
 
 
 def test_pixel_size(caplog):

--- a/tests/test_relion_source.py
+++ b/tests/test_relion_source.py
@@ -86,9 +86,9 @@ def test_prepare_relion_optics_blocks_warns(caplog):
     np.testing.assert_allclose(optics_block["_rlnImagePixelSize"], [1.234])
     np.testing.assert_array_equal(optics_block["_rlnImageSize"], [32])
     np.testing.assert_array_equal(optics_block["_rlnImageDimensionality"], [2])
-    np.testing.assert_allclose(optics_block["_rlnVoltage"], [300.0])
-    np.testing.assert_allclose(optics_block["_rlnSphericalAberration"], [2.0])
-    np.testing.assert_allclose(optics_block["_rlnAmplitudeContrast"], [0.1])
+    np.testing.assert_allclose(optics_block["_rlnVoltage"], [0])
+    np.testing.assert_allclose(optics_block["_rlnSphericalAberration"], [0])
+    np.testing.assert_allclose(optics_block["_rlnAmplitudeContrast"], [0])
 
     # Caplog should contain the warnings about the three missing fields.
     assert "Optics field _rlnSphericalAberration not found" in caplog.text

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -653,12 +653,16 @@ def test_simulation_save_optics_block(tmp_path):
         "_rlnImagePixelSize",
         "_rlnSphericalAberration",
         "_rlnVoltage",
-        "_rlnImageSize",
         "_rlnAmplitudeContrast",
+        "_rlnImageSize",
+        "_rlnImageDimensionality",
     ]
+
+    # Check all required fields are present
     for field in expected_optics_fields:
         assert field in optics
 
+    # Optics group and group name should 1-indexed
     np.testing.assert_array_equal(
         optics["_rlnOpticsGroup"], np.arange(1, kv_ct + 1, dtype=int)
     )
@@ -666,11 +670,17 @@ def test_simulation_save_optics_block(tmp_path):
         optics["_rlnOpticsGroupName"],
         np.array([f"opticsGroup{i}" for i in range(1, kv_ct + 1)], dtype=object),
     )
+
+    # Check image size and image dimensionality
     np.testing.assert_array_equal(optics["_rlnImageSize"], np.full(kv_ct, res))
+
+    optics_dim = np.array(optics["_rlnImageDimensionality"], dtype=int)
+    np.testing.assert_array_equal(optics_dim, np.full(len(optics_dim), 2))
 
     # Depending on Simulation random indexing, voltages will be unordered
     np.testing.assert_allclose(np.sort(optics["_rlnVoltage"]), voltages)
 
+    # Check that each row of the data_particles block has an associated optics group
     particles = star["particles"]
     assert "_rlnOpticsGroup" in particles
     assert len(particles["_rlnOpticsGroup"]) == sim.n

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -663,7 +663,7 @@ def test_simulation_save_optics_block(tmp_path):
     for field in expected_optics_fields:
         assert field in optics
 
-    # Optics group and group name should 1-indexed
+    # Optics group and group name should be 1-indexed
     np.testing.assert_array_equal(
         optics["_rlnOpticsGroup"], np.arange(1, kv_ct + 1, dtype=int)
     )

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -8,7 +8,7 @@ import pytest
 
 from aspire.noise import WhiteNoiseAdder
 from aspire.operators import RadialCTFFilter
-from aspire.source import ImageSource, RelionSource, Simulation, _LegacySimulation
+from aspire.source import RelionSource, Simulation, _LegacySimulation
 from aspire.utils import RelionStarFile, utest_tolerance
 from aspire.volume import LegacyVolume, SymmetryGroup, Volume
 

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -689,6 +689,12 @@ def test_simulation_save_optics_block(tmp_path):
         np.arange(1, kv_ct + 1, dtype=int),
     )
 
+    # Test phase_flip after save/load round trip to ensure correct optics group mapping
+    rln_src = RelionSource(starpath)
+    np.testing.assert_allclose(
+        sim.phase_flip().images[:], rln_src.phase_flip().images[:]
+    )
+
 
 def test_default_symmetry_group():
     # Check that default is "C1".

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -644,7 +644,7 @@ def test_simulation_save_optics_block(tmp_path):
 
     star = RelionStarFile(str(starpath))
     assert star.relion_version == "3.1"
-    assert set(star.blocks.keys()) == {"optics", "particles"}
+    assert star.blocks.keys() == {"optics", "particles"}
 
     optics = star["optics"]
     expected_optics_fields = [
@@ -668,16 +668,16 @@ def test_simulation_save_optics_block(tmp_path):
     )
     np.testing.assert_array_equal(
         optics["_rlnOpticsGroupName"],
-        np.array([f"opticsGroup{i}" for i in range(1, kv_ct + 1)], dtype=object),
+        np.array([f"opticsGroup{i}" for i in range(1, kv_ct + 1)]),
     )
 
-    # Check image size and image dimensionality
+    # Check image size (res) and image dimensionality (2)
     np.testing.assert_array_equal(optics["_rlnImageSize"], np.full(kv_ct, res))
+    np.testing.assert_array_equal(
+        optics["_rlnImageDimensionality"], np.full(len(optics_dim), 2)
+    )
 
-    optics_dim = np.array(optics["_rlnImageDimensionality"], dtype=int)
-    np.testing.assert_array_equal(optics_dim, np.full(len(optics_dim), 2))
-
-    # Depending on Simulation random indexing, voltages will be unordered
+    # Due to Simulation random indexing, voltages will be unordered
     np.testing.assert_allclose(np.sort(optics["_rlnVoltage"]), voltages)
 
     # Check that each row of the data_particles block has an associated optics group

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -926,18 +926,13 @@ def test_save_load_dummy_ctf_values(tmp_path, caplog):
 
     # STAR file should contain our fallback tag
     star = RelionStarFile(star_path)
-    particles_block = star.get_block_by_index(1)
-    np.testing.assert_array_equal(
-        particles_block["_aspireMetadata"], np.full(sim.n, "no_ctf", dtype=object)
-    )
+    optics_block = star.get_block_by_index(0)
+    assert "_aspireNoCTF" in optics_block
 
     # Tag should survive round-trip
     caplog.clear()
     reloaded = RelionSource(star_path)
-    np.testing.assert_array_equal(
-        reloaded._metadata["_aspireMetadata"],
-        np.full(reloaded.n, "no_ctf", dtype=object),
-    )
+    assert "_aspireNoCTF" in reloaded._metadata
 
     # Check message is logged about detecting dummy variables
     assert "Detected ASPIRE-generated dummy optics" in caplog.text

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -673,9 +673,7 @@ def test_simulation_save_optics_block(tmp_path):
 
     # Check image size (res) and image dimensionality (2)
     np.testing.assert_array_equal(optics["_rlnImageSize"], np.full(kv_ct, res))
-    np.testing.assert_array_equal(
-        optics["_rlnImageDimensionality"], np.full(len(optics_dim), 2)
-    )
+    np.testing.assert_array_equal(optics["_rlnImageDimensionality"], np.full(kv_ct, 2))
 
     # Due to Simulation random indexing, voltages will be unordered
     np.testing.assert_allclose(np.sort(optics["_rlnVoltage"]), voltages)

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -882,8 +882,6 @@ def check_metadata(sim_src, relion_src):
     those in a RelionSource.
     """
     for k, v in sim_src._metadata.items():
-        if k.startswith("__"):
-            continue
         try:
             np.testing.assert_array_equal(v, relion_src._metadata[k])
         except AssertionError:

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -882,6 +882,8 @@ def check_metadata(sim_src, relion_src):
     those in a RelionSource.
     """
     for k, v in sim_src._metadata.items():
+        if k.startswith("__"):
+            continue
         try:
             np.testing.assert_array_equal(v, relion_src._metadata[k])
         except AssertionError:

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -8,7 +8,7 @@ import pytest
 
 from aspire.noise import WhiteNoiseAdder
 from aspire.operators import RadialCTFFilter
-from aspire.source import RelionSource, Simulation, _LegacySimulation
+from aspire.source import ImageSource, RelionSource, Simulation, _LegacySimulation
 from aspire.utils import RelionStarFile, utest_tolerance
 from aspire.volume import LegacyVolume, SymmetryGroup, Volume
 


### PR DESCRIPTION
Save `ImageSource`'s with Relion >= 3.1 convention for starfiles, with separate `data_optics` and `data_particle` blocks.

Some other additions in this PR are:

- Always store `amplitudes` in doubles
- Rename `_rlnAmplitude` metadata field to `_aspireAmplitude`, since `_rlnAmplitude` is not a valid Relion field name
- Save `ImageSource` mrcs files with pixel/voxel size in header. Some Relion command line tools extract pixel size (`angpix`) from here.
-  Save with optics block required fields `_rlnImageSize` and `_rlnImageDimensionality`
- Testing for added features
- Loading new file format in Relion was verified using several Relion CLI tools with Relion version 5.0.1