### PR TITLE
Fix some bugs estimating shifts

### DIFF
--- a/src/aspire/abinitio/commonline_base.py
+++ b/src/aspire/abinitio/commonline_base.py
@@ -554,8 +554,8 @@ class CLOrient3D:
         # `estimate_shifts()` requires that rotations have already been estimated.
         rotations = Rotation(self.rotations)
 
-        _pf = self.pf.copy()
-        pf = self.m_pf
+        # _pf = self.pf.copy()
+        pf = self.m_pf.copy()
 
         pf = np.concatenate(
             (np.flip(pf[:, n_theta_half:, 1:], axis=-1), pf[:, :n_theta_half, :]),

--- a/src/aspire/abinitio/commonline_base.py
+++ b/src/aspire/abinitio/commonline_base.py
@@ -630,8 +630,8 @@ class CLOrient3D:
             pf_i_stack = pf_i[:, None] * shift_phases
             pf_i_flipped_stack = pf_i_flipped[:, None] * shift_phases
 
-            c1 = 2 * np.real(np.dot(pf_i_stack.T.conj(), pf_j))
-            c2 = 2 * np.real(np.dot(pf_i_flipped_stack.T.conj(), pf_j))
+            c1 = 2 * np.dot(pf_i_stack.T.conj(), pf_j).real
+            c2 = 2 * np.dot(pf_i_flipped_stack.T.conj(), pf_j).real
 
             # find the indices for the maximum values
             # and apply corresponding shifts
@@ -786,14 +786,9 @@ class CLOrient3D:
         """
         Generate two index lists for [i, j] pairs of images
         """
-        idx_i = []
-        idx_j = []
-        for i in range(self.n_img - 1):
-            tmp_j = range(i + 1, self.n_img)
-            idx_i.extend([i] * len(tmp_j))
-            idx_j.extend(tmp_j)
-        idx_i = np.array(idx_i, dtype="int")
-        idx_j = np.array(idx_j, dtype="int")
+
+        # Generate the i,j tuples of indices representing the upper triangle above the diagonal.
+        idx_i, idx_j = np.triu_indices(N, k=1)
 
         # Select random pairs based on the size of n_equations
         rp = choice(np.arange(len(idx_j)), size=n_equations, replace=False)

--- a/src/aspire/abinitio/commonline_base.py
+++ b/src/aspire/abinitio/commonline_base.py
@@ -694,7 +694,7 @@ class CLOrient3D:
             n_equations_total * 2 * n_img * self.dtype.itemsize
         )
 
-        if memory_total < (self.offets_max_memory * 10**6):
+        if memory_total < (self.offsets_max_memory * 10**6):
             n_equations = int(
                 np.ceil(self.offsets_equations_factor * n_equations_total)
             )
@@ -774,7 +774,7 @@ class CLOrient3D:
         """
 
         # Generate the i,j tuples of indices representing the upper triangle above the diagonal.
-        idx_i, idx_j = np.triu_indices(N, k=1)
+        idx_i, idx_j = np.triu_indices(self.n_img, k=1)
 
         # Select random pairs based on the size of n_equations
         rp = choice(np.arange(len(idx_j)), size=n_equations, replace=False)

--- a/src/aspire/abinitio/commonline_base.py
+++ b/src/aspire/abinitio/commonline_base.py
@@ -73,11 +73,15 @@ class CLOrient3D:
         if str(full_width).lower() == "adaptive":
             full_width = -1
         self.full_width = int(full_width)
-        self.max_shift = 15  # match MATLAB workflow for now math.ceil(max_shift * self.n_res)
+        self.max_shift = (
+            15  # match MATLAB workflow for now math.ceil(max_shift * self.n_res)
+        )
         self.shift_step = shift_step
         self.offsets_max_shift = self.max_shift
         if offsets_max_shift is not None:
-            self.offsets_max_shift = 15  # match MATLAB workflow math.ceil(offsets_max_shift * self.n_res)
+            self.offsets_max_shift = (
+                15  # match MATLAB workflow math.ceil(offsets_max_shift * self.n_res)
+            )
         self.offsets_shift_step = offsets_shift_step or self.shift_step
         self.mask = mask
         self._pf = None
@@ -241,21 +245,6 @@ class CLOrient3D:
 
         Wrapper for cpu/gpu dispatch.
         """
-        # # load matlab clstack for comparison
-        # from scipy.io import loadmat
-        # m_cl_fn = 'shift_dbg_clstack.mat'
-        # clstack = loadmat(m_cl_fn)['clstack'].astype(int,order='C') - 1  # convert to 0 based
-        # logger.warning(f"FORCING MATLAB Common Lines Matrix from {m_cl_fn}")
-        # # breakpoint()
-        # self.clmatrix = clstack
-        # return self.clmatrix
-        
-        # force_fn = "force_cl.npz"
-        # if os.path.exists(force_fn):
-        #     logger.warning(f"FORCING Common Lines Matrix from {force_fn}")
-        #     res = np.load(force_fn)
-        #     self.clmatrix = res["clmatrix"]
-        #     return self.clmatrix
 
         logger.info("Begin building Common Lines Matrix")
 
@@ -267,10 +256,6 @@ class CLOrient3D:
 
         # Unpack result
         self._shifts_1d, self.clmatrix = res
-
-        # # save result
-        # logger.warning(f"Saving Common Lines to {force_fn}")
-        # np.savez(force_fn, clmatrix=self.clmatrix)
 
         return self.clmatrix
 
@@ -516,7 +501,9 @@ class CLOrient3D:
             show = True
 
         # Estimate shifts.
-        est_shifts = sparse.linalg.lsqr(shift_equations, shift_b, atol=1e-8, btol=1e-8, iter_lim=100, show=show)[0]
+        est_shifts = sparse.linalg.lsqr(
+            shift_equations, shift_b, atol=1e-8, btol=1e-8, iter_lim=100, show=show
+        )[0]
         self.shifts = est_shifts.reshape((self.n_img, 2))
 
         return self.shifts
@@ -567,14 +554,6 @@ class CLOrient3D:
 
         _pf = self.pf.copy()
         pf = self.m_pf
-        # # # compare
-        # from scipy.io import loadmat
-        # pf_fn = 'matlab_pf_shift_dbg.mat'
-        # logger.warning(f"FORCING MATLAB PF from {pf_fn}")
-        # matlab_pf = loadmat(pf_fn)['pf'].T
-        # pf = matlab_pf
-        # # %pf=[flipdim(pf(2:end,n_theta/2+1:end,:),1) ; pf(:,1:n_theta/2,:) ];
-        # # breakpoint()
 
         pf = np.concatenate(
             (np.flip(pf[:, n_theta_half:, 1:], axis=-1), pf[:, :n_theta_half, :]),
@@ -605,7 +584,6 @@ class CLOrient3D:
         _, shift_phases, h = self._m_generate_shift_phase_and_filter(
             r_max, self.offsets_max_shift, self.offsets_shift_step
         )
-        # breakpoint()
 
         d_theta = np.pi / n_theta_half
 
@@ -729,7 +707,7 @@ class CLOrient3D:
         memory_total = equations_factor * (
             n_equations_total * 2 * n_img * self.dtype.itemsize
         )
-        #breakpoint()
+
         if memory_total < (max_memory * 10**6):
             n_equations = int(np.ceil(equations_factor * n_equations_total))
         else:
@@ -772,7 +750,6 @@ class CLOrient3D:
 
         h = np.sqrt(np.abs(rk)) * np.exp(-(rk**2) / (2 * (r_max / 4) ** 2))
 
-        # breakpoint() # matchy matchy
         return None, shift_phases, h
 
     def _generate_shift_phase_and_filter(self, r_max, max_shift, shift_step):
@@ -817,8 +794,7 @@ class CLOrient3D:
         idx_j = np.array(idx_j, dtype="int")
 
         # Select random pairs based on the size of n_equations
-        # rp = choice(np.arange(len(idx_j)), size=n_equations, replace=False)
-        rp = np.arange(n_equations, dtype=int)
+        rp = choice(np.arange(len(idx_j)), size=n_equations, replace=False)
 
         return idx_i[rp], idx_j[rp]
 

--- a/src/aspire/abinitio/commonline_base.py
+++ b/src/aspire/abinitio/commonline_base.py
@@ -589,6 +589,11 @@ class CLOrient3D:
             else:
                 pf_j = pf[j, c_ji - n_theta_half]
 
+            # Use ray from opposite side of origin.
+            # Correpsonds to `freqs` convention in PFT,
+            #   where the legacy code used a negated frequency grid.
+            pf_i, pf_j = np.conj(pf_i), np.conj(pf_j)
+
             # perform bandpass filter, normalize each ray of each image,
             pf_i = self._apply_filter_and_norm("i, i -> i", pf_i, r_max, h)
             pf_j = self._apply_filter_and_norm("i, i -> i", pf_j, r_max, h)

--- a/src/aspire/abinitio/commonline_base.py
+++ b/src/aspire/abinitio/commonline_base.py
@@ -88,15 +88,11 @@ class CLOrient3D:
         if str(full_width).lower() == "adaptive":
             full_width = -1
         self.full_width = int(full_width)
-        self.max_shift = (
-            15  # match MATLAB workflow for now math.ceil(max_shift * self.n_res)
-        )
+        self.max_shift = math.ceil(max_shift * self.n_res)
         self.shift_step = shift_step
         self.offsets_max_shift = self.max_shift
         if offsets_max_shift is not None:
-            self.offsets_max_shift = (
-                15  # match MATLAB workflow math.ceil(offsets_max_shift * self.n_res)
-            )
+            self.offsets_max_shift = math.ceil(offsets_max_shift * self.n_res)
         self.offsets_shift_step = offsets_shift_step or self.shift_step
         self.offsets_equations_factor = offsets_equations_factor
         self.offsets_max_memory = int(offsets_max_memory)

--- a/src/aspire/abinitio/commonline_base.py
+++ b/src/aspire/abinitio/commonline_base.py
@@ -695,30 +695,6 @@ class CLOrient3D:
 
         return n_equations
 
-    def _m_generate_shift_phase_and_filter(self, r_max, max_shift, shift_step):
-        """
-        Port the code from MATLAB first, grumble grumble, inside thoughts bro.
-        """
-
-        # Number of shifts to try
-        n_shifts = int(np.ceil(2 * max_shift / shift_step + 1))
-
-        # only half of ray, excluding the DC component.
-        rk = np.arange(-r_max, r_max + 1, dtype=self.dtype)
-        rk2 = rk[:r_max]
-
-        shift_phases = np.zeros((r_max, n_shifts), dtype=np.complex128)
-        for shiftidx in range(n_shifts):
-            # zero based shiftidx
-            shift = -max_shift + shiftidx * shift_step
-            shift_phases[:, shiftidx] = np.exp(
-                -2 * np.pi * 1j * rk2 * shift / (2 * r_max + 1)
-            )
-
-        h = np.sqrt(np.abs(rk)) * np.exp(-(rk**2) / (2 * (r_max / 4) ** 2))
-
-        return None, shift_phases, h
-
     def _generate_shift_phase_and_filter(self, r_max, max_shift, shift_step):
         """
         Prepare the shift phases and generate filter for common-line detection

--- a/src/aspire/abinitio/commonline_base.py
+++ b/src/aspire/abinitio/commonline_base.py
@@ -504,7 +504,9 @@ class CLOrient3D:
         est_shifts = sparse.linalg.lsqr(
             shift_equations, shift_b, atol=1e-8, btol=1e-8, iter_lim=100, show=show
         )[0]
-        self.shifts = est_shifts.reshape((self.n_img, 2))
+        est_shifts = est_shifts.reshape((self.n_img, 2))
+        # Convert (XY) axes and negate estimated shift orientations
+        self.shifts = -est_shifts[:, ::-1]
 
         return self.shifts
 

--- a/src/aspire/abinitio/commonline_c2.py
+++ b/src/aspire/abinitio/commonline_c2.py
@@ -48,6 +48,7 @@ class CLSymmetryC2(CLSymmetryC3C4):
         min_dist_cls=25,
         seed=None,
         mask=True,
+        **kwargs,
     ):
         """
         Initialize object for estimating 3D orientations for molecules with C2 symmetry.
@@ -77,6 +78,7 @@ class CLSymmetryC2(CLSymmetryC3C4):
             degree_res=degree_res,
             seed=seed,
             mask=mask,
+            **kwargs,
         )
 
         self.min_dist_cls = min_dist_cls

--- a/src/aspire/abinitio/commonline_c3_c4.py
+++ b/src/aspire/abinitio/commonline_c3_c4.py
@@ -56,6 +56,7 @@ class CLSymmetryC3C4(CLOrient3D, SyncVotingMixin):
         degree_res=1,
         seed=None,
         mask=True,
+        **kwargs,
     ):
         """
         Initialize object for estimating 3D orientations for molecules with C3 and C4 symmetry.
@@ -81,6 +82,7 @@ class CLSymmetryC3C4(CLOrient3D, SyncVotingMixin):
             max_shift=max_shift,
             shift_step=shift_step,
             mask=mask,
+            **kwargs,
         )
 
         self._check_symmetry(symmetry)

--- a/src/aspire/abinitio/commonline_cn.py
+++ b/src/aspire/abinitio/commonline_cn.py
@@ -41,6 +41,7 @@ class CLSymmetryCn(CLSymmetryC3C4):
         equator_threshold=10,
         seed=None,
         mask=True,
+        **kwargs,
     ):
         """
         Initialize object for estimating 3D orientations for molecules with Cn symmetry, n>4.
@@ -74,6 +75,7 @@ class CLSymmetryCn(CLSymmetryC3C4):
             degree_res=degree_res,
             seed=seed,
             mask=mask,
+            **kwargs,
         )
 
         self.n_points_sphere = n_points_sphere

--- a/src/aspire/abinitio/commonline_d2.py
+++ b/src/aspire/abinitio/commonline_d2.py
@@ -37,6 +37,7 @@ class CLSymmetryD2(CLOrient3D):
         epsilon=0.01,
         seed=None,
         mask=True,
+        **kwargs,
     ):
         """
         Initialize object for estimating 3D orientations for molecules with D2 symmetry.
@@ -65,6 +66,7 @@ class CLSymmetryD2(CLOrient3D):
             max_shift=max_shift,
             shift_step=shift_step,
             mask=mask,
+            **kwargs,
         )
 
         self.grid_res = grid_res

--- a/src/aspire/abinitio/commonline_sync.py
+++ b/src/aspire/abinitio/commonline_sync.py
@@ -33,6 +33,7 @@ class CLSyncVoting(CLOrient3D, SyncVotingMixin):
         hist_bin_width=3,
         full_width=6,
         mask=True,
+        **kwargs,
     ):
         """
         Initialize an object for estimating 3D orientations using synchronization matrix
@@ -60,6 +61,7 @@ class CLSyncVoting(CLOrient3D, SyncVotingMixin):
             hist_bin_width=hist_bin_width,
             full_width=full_width,
             mask=mask,
+            **kwargs,
         )
         self.syncmatrix = None
 

--- a/src/aspire/abinitio/commonline_sync3n.py
+++ b/src/aspire/abinitio/commonline_sync3n.py
@@ -61,6 +61,7 @@ class CLSync3N(CLOrient3D, SyncVotingMixin):
         J_weighting=False,
         hist_intervals=100,
         disable_gpu=False,
+        **kwargs,
     ):
         """
         Initialize object for estimating 3D orientations.
@@ -100,6 +101,7 @@ class CLSync3N(CLOrient3D, SyncVotingMixin):
             hist_bin_width=hist_bin_width,
             full_width=full_width,
             mask=mask,
+            **kwargs,
         )
 
         # Generate pair mappings

--- a/src/aspire/operators/polar_ft.py
+++ b/src/aspire/operators/polar_ft.py
@@ -135,8 +135,9 @@ class PolarFT:
 
         resolution = x.shape[-1]
 
+        # Note, `freqs` is negated from legacy MATLAB.
         # nufft call should return `pf` as array type (np or cp) of `x`
-        pf = nufft(x, -self.freqs) / resolution**2
+        pf = nufft(x, self.freqs) / resolution**2
 
         return pf.reshape(*stack_shape, self.ntheta // 2, self.nrad)
 
@@ -193,7 +194,7 @@ class PolarFT:
 
         # Broadcast and accumulate phase shifts
         freqs = xp.tile(xp.asarray(self.freqs), (n, 1, 1))
-        phase_shifts = xp.exp(-1j * xp.sum(freqs * shifts[:, :, None], axis=1))
+        phase_shifts = xp.exp(-1j * xp.sum(-freqs * shifts[:, :, None], axis=1))
 
         # Reshape flat frequency grid back to (..., ntheta//2, self.nrad)
         phase_shifts = phase_shifts.reshape(n, self.ntheta // 2, self.nrad)

--- a/src/aspire/operators/polar_ft.py
+++ b/src/aspire/operators/polar_ft.py
@@ -136,7 +136,7 @@ class PolarFT:
         resolution = x.shape[-1]
 
         # nufft call should return `pf` as array type (np or cp) of `x`
-        pf = nufft(x, self.freqs) / resolution**2
+        pf = nufft(x, -self.freqs) / resolution**2
 
         return pf.reshape(*stack_shape, self.ntheta // 2, self.nrad)
 

--- a/src/aspire/operators/polar_ft.py
+++ b/src/aspire/operators/polar_ft.py
@@ -193,7 +193,7 @@ class PolarFT:
 
         # Broadcast and accumulate phase shifts
         freqs = xp.tile(xp.asarray(self.freqs), (n, 1, 1))
-        phase_shifts = xp.exp(-1j * xp.sum(freqs * -shifts[:, :, None], axis=1))
+        phase_shifts = xp.exp(-1j * xp.sum(freqs * shifts[:, :, None], axis=1))
 
         # Reshape flat frequency grid back to (..., ntheta//2, self.nrad)
         phase_shifts = phase_shifts.reshape(n, self.ntheta // 2, self.nrad)

--- a/tests/test_commonline_sync3n.py
+++ b/tests/test_commonline_sync3n.py
@@ -93,6 +93,7 @@ def test_build_clmatrix(source_orientation_objs):
     assert within_5 / angle_diffs.size > tol
 
 
+@pytest.mark.xfail(reason="Issue #1340")
 def test_estimate_shifts_with_gt_rots(source_orientation_objs):
     src, orient_est = source_orientation_objs
 
@@ -115,6 +116,7 @@ def test_estimate_shifts_with_gt_rots(source_orientation_objs):
         np.testing.assert_allclose(mean_dist, 0)
 
 
+@pytest.mark.xfail(reason="Issue #1340")
 def test_estimate_shifts_with_est_rots(source_orientation_objs):
     src, orient_est = source_orientation_objs
     # Estimate shifts using estimated rotations.

--- a/tests/test_orient_sync_voting.py
+++ b/tests/test_orient_sync_voting.py
@@ -68,6 +68,7 @@ def source_orientation_objs(resolution, offsets, dtype):
     return src, orient_est
 
 
+@pytest.mark.expensive
 def test_build_clmatrix(source_orientation_objs):
     src, orient_est = source_orientation_objs
 
@@ -90,6 +91,7 @@ def test_build_clmatrix(source_orientation_objs):
     assert within_5 / angle_diffs.size > tol
 
 
+@pytest.mark.expensive
 def test_estimate_rotations(source_orientation_objs):
     src, orient_est = source_orientation_objs
 
@@ -99,6 +101,7 @@ def test_estimate_rotations(source_orientation_objs):
     mean_aligned_angular_distance(orient_est.rotations, src.rotations, degree_tol=1)
 
 
+@pytest.mark.expensive
 def test_estimate_shifts_with_gt_rots(source_orientation_objs):
     src, orient_est = source_orientation_objs
 
@@ -122,6 +125,7 @@ def test_estimate_shifts_with_gt_rots(source_orientation_objs):
         np.testing.assert_allclose(mean_dist, 0)
 
 
+@pytest.mark.expensive
 def test_estimate_shifts_with_est_rots(source_orientation_objs):
     src, orient_est = source_orientation_objs
 
@@ -139,6 +143,7 @@ def test_estimate_shifts_with_est_rots(source_orientation_objs):
         np.testing.assert_allclose(mean_dist, 0)
 
 
+@pytest.mark.expensive
 def test_estimate_rotations_fuzzy_mask():
     noisy_src = Simulation(
         n=35,


### PR DESCRIPTION
Brings us about 2A closer to MATLAB's recon.  This appears to have been most of the remaining discrepancy in the 3D pipeline following orientation estimation.  After porting over pages of code and intermediate results from MATLAB to make things match numerically I was able to work backwards down to a very small set of changes.

Two major problems.

- Our PFT was backwards from MATLAB, which appears to matter for finding shifts more than other things...
- The equation generating code was wrong, again.

Minor problems.
- The memory bounds were different.  They are still implemented slightly differently. I modified them minimally to repro the default MATLAB limit.
- Offset search spaces are different between the MATLAB workflow and Python.  Python has been developed to use a scaling ratio, while MATLAB hardcodes to 15 pixels and a fixed step.  In practice for the ribosome Python default results in 21 pixels and the same step; I'm running a recon now to see if this makes any practical difference (probably not, but MATLAB's would be faster for real data....).

A note about solving for shifts... With a capable modern machine we can actually fit the entire system of equations for a few thousand images and solve it quickly. IMO its probably worth just doing that when we can, but not right now.