### PR TITLE
Cls indices fix

### DIFF
--- a/gallery/tutorials/tutorials/class_averaging.py
+++ b/gallery/tutorials/tutorials/class_averaging.py
@@ -226,6 +226,7 @@ est_rotations = avgs.averager.rotations
 est_shifts = avgs.averager.shifts
 est_dot_products = avgs.averager.dot_products
 
+# These are dictionaries mapping each class to arrays of attributes.
 print(f"Estimated Rotations: {est_rotations}")
 print(f"Estimated Shifts: {est_shifts}")
 print(f"Estimated Dot Products: {est_dot_products}")
@@ -241,7 +242,12 @@ original_img_0 = noisy_src.images[original_img_0_idx].asnumpy()[0]
 original_img_nbr = noisy_src.images[original_img_nbr_idx].asnumpy()[0]
 
 # Rotate using estimated rotations.
-angle = est_rotations[0, nbr] * 180 / np.pi
+# First retrieve all angles for the `review_class` (original_img_0_idx),
+#   then lookup the specific neighbor `nbr`
+assert (
+    original_img_0_idx == review_class
+), "DebugClassAvgSource should retain original source image ordering"
+angle = est_rotations[original_img_0_idx][nbr] * 180 / np.pi
 if reflections[nbr]:
     print("Reflection reported.")
     original_img_nbr = np.flipud(original_img_nbr)

--- a/src/aspire/classification/averager2d.py
+++ b/src/aspire/classification/averager2d.py
@@ -249,8 +249,8 @@ class AligningAverager2D(Averager2D):
             # Averaging in composite_basis
             return self.image_stacker(neighbors_coefs.asnumpy())
 
-        desc = f"Stacking and evaluating class averages from {self.composite_basis.__class__.__name__} to Cartesian"
-        for start in trange(0, n_classes, self.batch_size, desc=desc):
+        desc = f"Stacking and evaluating batch of class averages from {self.composite_basis.__class__.__name__} to Cartesian"
+        for start in trange(0, n_classes, self.batch_size, desc=desc, leave=False):
             end = min(start + self.batch_size, n_classes)
             for i, cls in enumerate(
                 trange(start, end, desc="Stacking batch", leave=False)
@@ -378,7 +378,7 @@ class BFSRAverager2D(AligningAverager2D):
         # This is done primarily in case of a tie later, we would take unshifted.
         test_shifts = self._shift_search_grid(self.src.L, self.radius, roll_zero=True)
 
-        for k in trange(n_classes, desc="Rotationally aligning classes"):
+        for k in trange(n_classes, desc="Rotationally aligning classes", leave=False):
             # We want to locally cache the original images,
             #  because we will mutate them with shifts in the next loop.
             #  This avoids recomputing them before each shift
@@ -580,7 +580,7 @@ class ReddyChatterjiAverager2D(AligningAverager2D):
                 dtype=self.dtype,
             )
 
-        for k in trange(n_classes, desc="Rotationally aligning classes"):
+        for k in trange(n_classes, desc="Rotationally aligning classes", leave=False):
             rotations[k], shifts[k], dot_products[k] = _innerloop(k)
 
         return rotations, shifts, dot_products
@@ -633,7 +633,7 @@ class ReddyChatterjiAverager2D(AligningAverager2D):
             # Averaging in composite_basis
             return self.image_stacker(neighbors_coefs.asnumpy())
 
-        for i in trange(n_classes, desc="Stacking class averages"):
+        for i in trange(n_classes, desc="Stacking class averages", leave=False):
             b_avgs[i] = _innerloop(i)
 
         # Now we convert the averaged images from Basis to Cartesian.
@@ -752,7 +752,7 @@ class BFSReddyChatterjiAverager2D(ReddyChatterjiAverager2D):
 
             return _rotations, _shifts, _dot_products
 
-        for k in trange(n_classes, desc="Rotationally aligning classes"):
+        for k in trange(n_classes, desc="Rotationally aligning classes", leave=False):
             rotations[k], shifts[k], dot_products[k] = _innerloop(k)
 
         return rotations, shifts, dot_products
@@ -900,7 +900,7 @@ class BFTAverager2D(AligningAverager2D):
         )
         _images = xp.empty((n_nbor - 1, self.src.L, self.src.L), dtype=self.dtype)
 
-        for k in trange(n_classes, desc="Rotationally aligning classes"):
+        for k in trange(n_classes, desc="Rotationally aligning classes", leave=False):
             # We want to locally cache the original images,
             #  because we will mutate them with shifts in the next loop.
             #  This avoids recomputing them before each shift

--- a/src/aspire/denoising/class_avg.py
+++ b/src/aspire/denoising/class_avg.py
@@ -223,6 +223,7 @@ class ClassAvgSource(ImageSource):
             self._classify()
 
         # Perform class selection
+        logger.info("Performing class selection")
         _selection_indices = self.class_selector.select(
             self.class_indices,
             self.class_refl,


### PR DESCRIPTION
Small patch. Mainly to address storing the alignment results someone may need for their project...

- Fixes bug introduced with class source batching that was only saving the most recently aligned batch results (vars were just for potential reference).
- Sets several progress bars to `leave=False`, less spammy
- Couple minor string/logger updates