### PR TITLE
Make np `where` args explicit with `out=`.

### DIFF
--- a/src/aspire/classification/legacy_implementations.py
+++ b/src/aspire/classification/legacy_implementations.py
@@ -145,7 +145,7 @@ def bispec_2drot_large(coef, freqs, eigval, alpha, sample_n, seed=None):
     #  This became a problem with very noisy images...
     p = np.power(eigval, alpha)
     mask = np.where(p, p, -1)  # taking the log in the next step will yield a 0
-    m = np.exp(o1 * np.log(p, where=(mask > 0)))
+    m = np.exp(o1 * np.log(p, where=(mask > 0), out=None))
     p_m = m / m.sum()
     x = random(size=len(m), seed=seed)
     m_id = np.where(x < sample_n * p_m)[0]

--- a/src/aspire/utils/matrix.py
+++ b/src/aspire/utils/matrix.py
@@ -364,7 +364,7 @@ def fix_signs(u):
     # Create array of sign corrections
     signs = np.take_along_axis(u, np.expand_dims(index_array, axis=0), axis=0).squeeze()
     _abs = np.absolute(signs)
-    signs = np.divide(_abs, signs, where=_abs != 0)
+    np.divide(_abs, signs, out=signs, where=_abs != 0)
 
     # Now we only care about the sign +1/-1.
     #  The following corrects for any numerical division noise,

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -190,7 +190,7 @@ class MatrixTestCase(TestCase):
         """
 
         # Create simple array
-        x = np.arange(25).reshape(5, 5)
+        x = np.arange(25, dtype=np.float32).reshape(5, 5)
         # Set diagonal elements = -1
         x[np.diag_indices_from(x)] *= -1
         # Negate largest elem (last row) of first col


### PR DESCRIPTION
Closes #1355 . The test file change is because the new syntax was then complaining about mixing int with floating point.

Expensive tests running locally, then I'll open it up.