### PR TITLE
`confuse` missing runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 
 dependencies = [
     "click",
-    "confuse >= 2.0.0",
+    "confuse == 2.1.0",
     "cvxpy",
     "finufft==2.4.0 ; sys_platform!='darwin'",
     "finufft==2.3.0 ; sys_platform=='darwin'",


### PR DESCRIPTION
Pin to `confuse==2.1.0` to avoid missing runtime dependency. See issue #1358 