### PR TITLE
Mrc src filt inds

### DIFF
--- a/src/aspire/source/micrograph.py
+++ b/src/aspire/source/micrograph.py
@@ -402,10 +402,19 @@ class MicrographSimulation(MicrographSource):
                     f" {acceptable_lens[1]}, or {acceptable_lens[2]}."
                 )
 
-            # Generate explicit filter indices (zero-indexed).
-            self.filter_indices = np.arange(self.total_particle_count) % len(
-                ctf_filters
-            )
+            # Generate explicit total_particle_count filter_indices
+            # Note these indices are zero-indexed.
+            if len(ctf_filters) == self.micrograph_count:
+                # creates mapping [0,0,0..., 1,1,1,... ,micrograph_count-1]
+                self.filter_indices = np.repeat(
+                    np.arange(self.micrograph_count, dtype=int),
+                    self.particles_per_micrograph,
+                )
+            else:
+                # single CTF or per particle CTF
+                self.filter_indices = np.arange(
+                    self.total_particle_count, dtype=int
+                ) % len(ctf_filters)
 
         self.ctf_filters = ctf_filters
 

--- a/src/aspire/source/micrograph.py
+++ b/src/aspire/source/micrograph.py
@@ -410,11 +410,10 @@ class MicrographSimulation(MicrographSource):
                     np.arange(self.micrograph_count, dtype=int),
                     self.particles_per_micrograph,
                 )
-            else:
-                # single CTF or per particle CTF
-                self.filter_indices = np.arange(
-                    self.total_particle_count, dtype=int
-                ) % len(ctf_filters)
+            elif len(ctf_filters) == self.total_particle_count:
+                self.filter_indices = np.arange(self.total_particle_count, dtype=int)
+            elif len(ctf_filters) == 1:
+                self.filter_indices = np.zeros(self.total_particle_count, dtype=int)
 
         self.ctf_filters = ctf_filters
 


### PR DESCRIPTION
Fixes a user reported bug in one (ctf per micrograph) case of comparing `MicrographSimulation` with `Simulation`.

Attached are scripts and supporting files that demonstrate the three cases for the user.

[micrograph-script-simpler_per-micrograph-ctf.py](https://github.com/user-attachments/files/25213191/micrograph-script-simpler_per-micrograph-ctf.py)
[micrograph-script-simpler_singleCTF.py](https://github.com/user-attachments/files/25213193/micrograph-script-simpler_singleCTF.py)
[micrograph-script-simpler_per-particle-ctf.py](https://github.com/user-attachments/files/25213194/micrograph-script-simpler_per-particle-ctf.py)
[supporting_files.tgz](https://github.com/user-attachments/files/25213222/supporting_files.tgz)
