### PR TITLE
Bump Python Support Window to 3.10-3.13

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         pip install tox tox-gh-actions
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
@@ -88,15 +88,15 @@ jobs:
     if: ${{ github.event_name == 'push' || github.event.pull_request.draft == false }}    
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         pyenv: [pip]
         exclude:
-          # Exclude 3.9-pip so we can add pre/post tasks to that environment.
-          - python-version: '3.9'
+          # Exclude 3.10-pip so we can add pre/post tasks to that environment.
+          - python-version: '3.10'
             pyenv: pip
         include:
-          # Re-include 3.9 with additional tox tasks.
-          - python-version: '3.9'
+          # Re-include 3.10 with additional tox tasks.
+          - python-version: '3.10'
             pyenv: pip,docs
 
     steps:
@@ -158,7 +158,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, ubuntu-22.04, macOS-latest, macOS-14]
         backend: [default, openblas]
-        python-version: ['3.9']
+        python-version: ['3.10']
         include:
           - os: ubuntu-latest
             backend: intel
@@ -213,7 +213,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.10'
     - name: Install Dependencies
       run: |
         pip install -e ".[dev]"
@@ -279,7 +279,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
@@ -329,7 +329,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: '3.13'
     - name: Complete Install and Log Environment
       run: |
         python --version

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Getting Started - Installation
 ------------------------------
 
 ASPIRE is a pip-installable package for Linux/Mac/Windows, and
-requires Python 3.9-3.12. The recommended method of installation for
+requires Python 3.10-3.13. The recommended method of installation for
 getting started is to use Anaconda (64-bit) for your platform to
 install Python. Python's package manager `pip` can then be used to
 install `aspire` safely in that environment.
@@ -49,7 +49,7 @@ git clone https://github.com/ComputationalCryoEM/ASPIRE-Python.git
 cd ASPIRE-Python
 
 # Create a fresh environment
-conda create --name aspire python=3.9 pip
+conda create --name aspire python=3.10 pip
 
 # Enable the environment
 conda activate aspire
@@ -59,7 +59,7 @@ conda activate aspire
 pip install -e ".[dev]"
 ```
 
-If you prefer not to use Anaconda, or have other preferences for managing environments, you should be able to directly use `pip` with Python >= 3.9 from the local checkout or via PyPI.
+If you prefer not to use Anaconda, or have other preferences for managing environments, you should be able to directly use `pip` with Python >= 3.10 from the local checkout or via PyPI.
 Please see the full documentation for details and advanced instructions.
 
 ### Installation Testing

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -37,8 +37,8 @@ to view Conda's installation instructions.
 Getting Started - Installation
 ************************************
 
-Python 3.9 is used as an example, but the same procedure should work
-for any of our supported Python versions 3.9-3.12. Below we pip install
+Python 3.10 is used as an example, but the same procedure should work
+for any of our supported Python versions 3.10-3.13. Below we pip install
 the ``aspire`` package using the ``-e`` flag to install the project in
 editable mode. The ``".[dev]"`` command installs ``aspire`` from the local
 path with additional development tools such as pytest and Jupyter Notebook.
@@ -53,7 +53,7 @@ for more details on using pip install.
    cd ASPIRE-Python
 
    # Create a fresh environment
-   conda create --name aspire python=3.9 pip
+   conda create --name aspire python=3.10 pip
 
    # Enable the environment
    conda activate aspire

--- a/environment-accelerate.yml
+++ b/environment-accelerate.yml
@@ -6,7 +6,7 @@ channels:
 
 dependencies:
   - pip
-  - python=3.9
+  - python=3.10
   - numpy=1.25.0
   - scipy=1.13.1
   - scikit-learn

--- a/environment-default.yml
+++ b/environment-default.yml
@@ -6,7 +6,7 @@ channels:
 
 dependencies:
   - pip
-  - python=3.9
+  - python=3.10
   - numpy=1.25.0
   - scipy=1.13.1
   - scikit-learn

--- a/environment-intel.yml
+++ b/environment-intel.yml
@@ -6,7 +6,7 @@ channels:
 
 dependencies:
   - pip
-  - python=3.9
+  - python=3.10
   - numpy=1.25.0
   - scipy=1.13.1
   - scikit-learn

--- a/environment-openblas.yml
+++ b/environment-openblas.yml
@@ -6,7 +6,7 @@ channels:
 
 dependencies:
   - pip
-  - python=3.9
+  - python=3.10
   - numpy=1.25.0
   - scipy=1.13.1
   - scikit-learn

--- a/environment-win64.yml
+++ b/environment-win64.yml
@@ -6,7 +6,7 @@ channels:
 
 dependencies:
   - pip
-  - python=3.9
+  - python=3.10
   - numpy=1.25.0
   - scipy=1.13.1
   - scikit-learn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "aspire"
 version = "0.14.2"
 description = "Algorithms for Single Particle Reconstruction"
 readme = "README.md" # Optional
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "GPL-3.0-only"
 license-files = ["LICENSE"]
 maintainers = [

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     clean
     check
     docs
-    py{3.9,3.10,3.11,3.12}-{pip}
+    py{3.10,3.11,3.12,3.13}-{pip}
 minversion = 3.8.0
 
 [testenv]
@@ -97,10 +97,10 @@ addopts = -m "not expensive and not scheduled"
 
 [gh-actions]
 python =
-    3.9: py3.9
     3.10: py3.10
     3.11: py3.11
     3.12: py3.12
+    3.13: py3.13
 
 [coverage:run]
 relative_files = True


### PR DESCRIPTION
Drop Python 3.9, add 3.13.

Update Docs, CI, and accelerated envs