### PR TITLE
workaround troubled cupy 12x package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
 "Source" = "https://github.com/ComputationalCryoEM/ASPIRE-Python"
 
 [project.optional-dependencies]
-gpu-12x = ["cupy-cuda12x", "cufinufft==2.4.0"]
+gpu-12x = ["cupy-cuda12x<14", "cufinufft==2.4.0"]
 dev = [
     "black",
     "bumpversion",


### PR DESCRIPTION
This will work around the most recent (14.0.0 and 14.0.1) `cupy-cuda12x` having issues.  It was released end of Feb 2026, so the package version enforced in this PR is actually what was running for the entirety of the 12x timeline.

Plan is to move up to CUDA 13x for 2026 in a separate PR and deal with any issues relating to that (hopefully none, alas) specifically there.