### PR TITLE
Add CUDA 13x extension

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -134,19 +134,21 @@ CUDA driver version, run ``nvidia-smi`` on the intended system.
 
    * - CUDA Version
      - ASPIRE Extension
-   * - >=12
+   * - 12.*
      - gpu-12x
+   * - 13.*
+     - gpu-13x
 
-For example, if you have CUDA 12.3 installed on your system,
+For example, if you have CUDA 13.1 installed on your system,
 the command below would install GPU packages required for ASPIRE.
 
 ::
 
     # From a local git repo
-    pip install -e ".[gpu-12x]"
+    pip install -e ".[gpu-13x]"
 
     # From PyPI
-    pip install "aspire[gpu-12x]"
+    pip install "aspire[gpu-13x]"
 
     
 By default if the required GPU extensions are correctly installed,

--- a/gallery/tutorials/configuration.py
+++ b/gallery/tutorials/configuration.py
@@ -112,7 +112,7 @@ print("Done Loop 2\n")
 # packages and small config changes. Installing the supporting
 # software is most easily accomplished by installing ASPIRE with one
 # of the published GPU extensions, for example ``pip install
-# "aspire[dev,gpu-12x]"``.  Once the packages are installed users
+# "aspire[dev,gpu-13x]"``.  Once the packages are installed users
 # should find that the NUFFT calls are automatically running on the
 # GPU.  Additional acceleration is achieved by enabling `cupy` for
 # `numeric` and `fft` components.

--- a/gallery/tutorials/configuration.py
+++ b/gallery/tutorials/configuration.py
@@ -112,7 +112,7 @@ print("Done Loop 2\n")
 # packages and small config changes. Installing the supporting
 # software is most easily accomplished by installing ASPIRE with one
 # of the published GPU extensions, for example ``pip install
-# "aspire[dev,gpu_12x]"``.  Once the packages are installed users
+# "aspire[dev,gpu-12x]"``.  Once the packages are installed users
 # should find that the NUFFT calls are automatically running on the
 # GPU.  Additional acceleration is achieved by enabling `cupy` for
 # `numeric` and `fft` components.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dependencies = [
 
 [project.optional-dependencies]
 gpu-12x = ["cupy-cuda12x<14", "cufinufft==2.4.0"]
+gpu-13x = ["cupy-cuda13x", "cufinufft==2.4.0"]
 dev = [
     "black",
     "bumpversion",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = [
 
 [project.optional-dependencies]
 gpu-12x = ["cupy-cuda12x<14", "cufinufft==2.4.0"]
-gpu-13x = ["cupy-cuda13x", "cufinufft==2.4.0"]
+gpu-13x = ["cupy-cuda13x", "cufinufft==2.5.0"]
 dev = [
     "black",
     "bumpversion",


### PR DESCRIPTION
Adds CUDA 13 support.  Use latest `cufinufft==2.5.0` for new `gpu_13x` packaging, leave prior `2.4.0` for 12x to maintain that environment the way it was.

Also supports migration of CI environments towards CUDA 13.1.