### PR TITLE
better handle case where no hist bin is returned from _vote_ij

### DIFF
--- a/src/aspire/abinitio/commonline_sync3n.cu
+++ b/src/aspire/abinitio/commonline_sync3n.cu
@@ -502,9 +502,13 @@ void estimate_all_angles2(int j,
   } /* fixed width */
 
   /* Divide accumulated angles (resulting in the mean alpha angle) */
-  // (todo, can we have cnt = 0?)
   /* convert degree to radian */
-  angles[pair_idx*3 + 1] *= M_PI / (180*cnt);
+  if(cnt>0){
+    angles[pair_idx*3 + 1] *= M_PI / (180*cnt);
+  } else /* cnt 0 case */
+  {
+    angles[pair_idx*3 + 1] = 0;
+  }
 
 } /* estimate_all_angles2 kernel */
 

--- a/src/aspire/abinitio/sync_voting.py
+++ b/src/aspire/abinitio/sync_voting.py
@@ -43,7 +43,8 @@ def _syncmatrix_ij_vote_3n(
 
     angles = np.zeros(3)
 
-    if alphas is not None:
+    # Note, len(alphas) case covers when no acceptable hist bin was found.
+    if (alphas is not None) and len(alphas) > 0:
         angles[0] = clmatrix[i, j] * 2 * np.pi / n_theta + np.pi / 2
         angles[1] = np.mean(alphas)
         angles[2] = -np.pi / 2 - clmatrix[j, i] * 2 * np.pi / n_theta


### PR DESCRIPTION
avoids nan Rij0, which can become nan entries in S mat later. 

Particularly bad in the weighted S case.
In the weighted S case, a nan will propagate from an entry to S becoming entirely nans during D @ (S*W ) @ D.
This nans matrix is fed into eigsh, which in older codes returns nan eigvals and random eigvecs. Ultimately just returning 4 random vectors.  More recent lapack code has the audacity to error and crash our CL code instead of just silently marching on with the random vectors.