### PR TITLE
Remove scipy face dataset from testing

### DIFF
--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -9,7 +9,6 @@ import numpy as np
 import pytest
 from PIL import Image as PILImage
 from pytest import raises
-from scipy.datasets import face
 
 from aspire.image import Image, compute_fastrotate_interp_tables, fastrotate, sp_rotate
 from aspire.utils import Rotation, gaussian_2d, grid_2d, powerset, utest_tolerance

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -44,9 +44,16 @@ def dtype(request):
 def get_images(parity, dtype):
     size = 768 - parity
     # numpy array for top-level functions that directly expect it
-    im_np = face(gray=True).astype(dtype)[np.newaxis, :size, :size]
+    g = grid_2d(size)
+    im_np = (
+        2 * gaussian_2d(size, sigma=size/5)
+        + np.sin(7 * np.pi * g["x"]) * np.cos(3 * np.pi * g["y"])
+    ).astype(dtype)[np.newaxis]
+
+    # Normalize test image data to 0,1
+    im_np -= im_np.min()
     denom = np.max(np.abs(im_np))
-    im_np /= denom  # Normalize test image data to 0,1
+    im_np /= denom
 
     # Independent Image object for testing Image methods
     im = Image(im_np.copy(), pixel_size=1.23)

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -45,7 +45,7 @@ def get_images(parity, dtype):
     # numpy array for top-level functions that directly expect it
     g = grid_2d(size)
     im_np = (
-        2 * gaussian_2d(size, sigma=size/5)
+        2 * gaussian_2d(size, sigma=size / 5)
         + np.sin(7 * np.pi * g["x"]) * np.cos(3 * np.pi * g["y"])
     ).astype(dtype)[np.newaxis]
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -45,7 +45,7 @@ def get_images(parity, dtype):
     # numpy array for top-level functions that directly expect it
     g = grid_2d(size)
     im_np = (
-        2 * gaussian_2d(size, sigma=size / 5)
+        2 * gaussian_2d(size, mu=(size / 10, size / 10), sigma=size / 5)
         + np.sin(7 * np.pi * g["x"]) * np.cos(3 * np.pi * g["y"])
     ).astype(dtype)[np.newaxis]
 

--- a/tests/test_starfileio.py
+++ b/tests/test_starfileio.py
@@ -5,7 +5,6 @@ from itertools import zip_longest
 from unittest import TestCase
 
 import numpy as np
-from scipy.datasets import face
 
 import tests.saved_test_data
 from aspire.image import Image
@@ -45,18 +44,6 @@ class StarFileTestCase(TestCase):
             tests.saved_test_data, "sample_particles_relion31.star"
         ) as path:
             self.particles31 = path
-        # Independent Image object for testing Image source methods
-        L = 768
-        self.im = Image(face(gray=True).astype("float64")[:L, :L])
-        self.img_src = ArrayImageSource(self.im, pixel_size=1.0)
-
-        # We also want to flex the stack logic.
-        self.n = 21
-        im_stack = np.broadcast_to(self.im.asnumpy(), (self.n, L, L))
-        # make each image methodically different
-        im_stack = np.multiply(im_stack, np.arange(self.n)[:, None, None])
-        self.im_stack = Image(im_stack)
-        self.img_src_stack = ArrayImageSource(self.im_stack, pixel_size=1.0)
 
         # Create a tmpdir object for this test instance
         self._tmpdir = tempfile.TemporaryDirectory()

--- a/tests/test_starfileio.py
+++ b/tests/test_starfileio.py
@@ -7,8 +7,6 @@ from unittest import TestCase
 import numpy as np
 
 import tests.saved_test_data
-from aspire.image import Image
-from aspire.source import ArrayImageSource
 from aspire.storage import StarFile, StarFileError
 from aspire.utils import RelionStarFile, importlib_path
 


### PR DESCRIPTION
Remove scipy's `face` image from testing in favor of a generated image.

1. Replaced `face` with generated image in test_image.py
2. Removed unused import of `face` in test_starfileio.py, along with other unused code
3. There is still one remaining use of `face` in a gallery tutorial

Resolves #1372