### PR TITLE
Small 11618 example patch

### DIFF
--- a/gallery/experiments/experimental_abinitio_pipeline_11618.py
+++ b/gallery/experiments/experimental_abinitio_pipeline_11618.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 # and assigning correct path.
 input_dir = "11618/data/particles/"
 starfile_in = f"{input_dir}/J43_particles.star"
-data_folder = f"{input_dir}"
+data_folder = "."
 
 # Config
 n_imgs = None  # Set to None for all images in starfile; set smaller for tests


### PR DESCRIPTION
I noticed running this that it was using an `data_dir` that was unique to our machine's dir/symlinks setup.  This changes it to be the location available after the raw download.
