### PR TITLE
Apple argument error

### DIFF
--- a/src/aspire/apple/apple.py
+++ b/src/aspire/apple/apple.py
@@ -174,9 +174,7 @@ class Apple:
         with futures.ProcessPoolExecutor(self.n_processes) as executor:
             to_do = []
             for filename in filenames:
-                future = executor.submit(
-                    self.process_micrograph, filename, False, create_jpg
-                )
+                future = executor.submit(self.process_micrograph, filename, create_jpg)
                 to_do.append(future)
 
             for future in futures.as_completed(to_do):

--- a/src/aspire/apple/apple.py
+++ b/src/aspire/apple/apple.py
@@ -4,19 +4,13 @@ from concurrent import futures
 from glob import glob
 
 import numpy as np
-from PIL import Image
+from PIL import Image as PILImage
 
 from aspire.apple.picking import Picker
+from aspire.image import Image
 from aspire.utils import tqdm
 
 logger = logging.getLogger(__name__)
-
-
-# Add mrc extensions to PIL Image extensions
-def _micrograph_extensions():
-    extensions = set(Image.registered_extensions())
-    extensions.update({".mrc", ".mrcs"})
-    return extensions
 
 
 class Apple:
@@ -165,7 +159,7 @@ class Apple:
     def process_folder(self, folder, create_jpg=False):
         # Gather matches for multiple possible file types.
         filenames = []
-        for ext in _micrograph_extensions():
+        for ext in Image.extensions:
             filenames.extend(glob(f"{folder}/*{ext}"))
         logger.info(f"converting {len(filenames)} input files")
         logger.info(f"launching {self.n_processes} processes")
@@ -283,7 +277,7 @@ class Apple:
 
         if create_jpg:
             # Create the image
-            image_out = Image.fromarray((particle_image).astype(np.uint8))
+            image_out = PILImage.fromarray((particle_image).astype(np.uint8))
 
             # Construct filename
             base = os.path.splitext(os.path.basename(picker.filename))[0]

--- a/src/aspire/apple/apple.py
+++ b/src/aspire/apple/apple.py
@@ -165,16 +165,25 @@ class Apple:
         logger.info(f"launching {self.n_processes} processes")
 
         pbar = tqdm(total=len(filenames))
-        with futures.ProcessPoolExecutor(self.n_processes) as executor:
-            to_do = []
-            for filename in filenames:
-                future = executor.submit(self.process_micrograph, filename, create_jpg)
-                to_do.append(future)
 
-            for future in futures.as_completed(to_do):
-                # Retrieve (None) result, since this operation re-raises Exceptions, if any.
-                _ = future.result()
+        if self.n_processes == 1:
+            for filename in filenames:
+                self.process_micrograph(filename, create_jpg)
                 pbar.update(1)
+        else:
+            with futures.ProcessPoolExecutor(self.n_processes) as executor:
+                to_do = []
+                for filename in filenames:
+                    future = executor.submit(
+                        self.process_micrograph, filename, create_jpg
+                    )
+                    to_do.append(future)
+
+                for future in futures.as_completed(to_do):
+                    # Retrieve (None) result, since this operation re-raises Exceptions, if any.
+                    _ = future.result()
+                    pbar.update(1)
+
         pbar.close()
 
     def process_micrograph_centers(

--- a/src/aspire/apple/apple.py
+++ b/src/aspire/apple/apple.py
@@ -12,6 +12,13 @@ from aspire.utils import tqdm
 logger = logging.getLogger(__name__)
 
 
+# Add mrc extensions to PIL Image extensions
+def _micrograph_extensions():
+    extensions = set(Image.registered_extensions())
+    extensions.update({".mrc", ".mrcs"})
+    return extensions
+
+
 class Apple:
     def __init__(
         self,
@@ -158,7 +165,7 @@ class Apple:
     def process_folder(self, folder, create_jpg=False):
         # Gather matches for multiple possible file types.
         filenames = []
-        for ext in Image.extensions:
+        for ext in _micrograph_extensions():
             filenames.extend(glob(f"{folder}/*{ext}"))
         logger.info(f"converting {len(filenames)} input files")
         logger.info(f"launching {self.n_processes} processes")

--- a/tests/test_apple.py
+++ b/tests/test_apple.py
@@ -1,8 +1,11 @@
 import tempfile
 from unittest import TestCase
 
+from click.testing import CliRunner
+
 import tests.saved_test_data
 from aspire.apple.apple import Apple
+from aspire.commands.apple import apple
 from aspire.utils import importlib_path
 
 
@@ -543,3 +546,25 @@ class ApplePickerTestCase(TestCase):
                 centers_found = apple_picker.process_micrograph_centers(mrc_path)
 
         self.assertTrue(len(centers_found) == 0)
+
+
+def test_apple_command_line_folder(tmp_path):
+    """
+    Ensure folder-mode Apple CLI processes an MRC input without argument errors.
+    See issue #1382 describing argument error.
+    """
+    runner = CliRunner()
+
+    with importlib_path(tests.saved_test_data, "sample.mrc") as sample_mrc:
+        (tmp_path / "sample.mrc").symlink_to(sample_mrc)
+
+        result = runner.invoke(
+            apple,
+            [
+                f"--mrc_path={tmp_path}",
+                f"--output_dir={tmp_path / 'apple_out'}",
+                "--particle_size=78",
+            ],
+        )
+
+    assert result.exit_code == 0

--- a/tests/test_apple.py
+++ b/tests/test_apple.py
@@ -550,8 +550,7 @@ class ApplePickerTestCase(TestCase):
 
 def test_apple_command_line_folder(tmp_path):
     """
-    Ensure folder-mode Apple CLI processes an MRC input without argument errors.
-    See issue #1382 describing argument error.
+    Test apple CLI.
     """
     runner = CliRunner()
 


### PR DESCRIPTION
Resolves #1382 

The bug was caused from an API change to `process_micrograph` that was not updated in the (untested) `process_folder` method that's used in CLI.

To resolve the issue I created a unit test that replicates the error in #1382 and then resolved the bug in `process_folder`. In the process I had to update the use of PIL.Image.extensions which was deprecated.

CI is currently failing on ampere, so I might have to adjust the unit test.