### PR TITLE
Add molecules for cryosym work

### DIFF
--- a/src/aspire/downloader/data_fetcher.py
+++ b/src/aspire/downloader/data_fetcher.py
@@ -288,6 +288,104 @@ def emdb_6458():
     return vol
 
 
+def emdb_14803():
+    """
+    Downloads the EMDB-14803 volume map and returns the file path.
+
+    This molecule exhibits D3 symmetry.
+
+    :return: A 'Volume' instance.
+    """
+    file_path = fetch_data("emdb_14803.map")
+    vol = Volume.load(file_path, symmetry_group="D3")
+
+    return vol
+
+
+def emdb_3952():
+    """
+    Downloads the EMDB-3952 volume map and returns the file path.
+
+    This molecule exhibits I symmetry.
+
+    :return: A 'Volume' instance.
+    """
+    file_path = fetch_data("emdb_3952.map")
+    vol = Volume.load(file_path, symmetry_group="I")
+
+    return vol
+
+
+def emdb_22308():
+    """
+    Downloads the EMDB-22308 volume map and returns the file path.
+
+    This molecule exhibits D4 symmetry.
+
+    :return: A 'Volume' instance.
+    """
+    file_path = fetch_data("emdb_22308.map")
+    vol = Volume.load(file_path, symmetry_group="D4")
+
+    return vol
+
+
+def emdb_28025():
+    """
+    Downloads the EMDB-28025 volume map and returns the file path.
+
+    This molecule exhibits D5 symmetry.
+
+    :return: A 'Volume' instance.
+    """
+    file_path = fetch_data("emdb_28025.map")
+    vol = Volume.load(file_path, symmetry_group="D5")
+
+    return vol
+
+
+def emdb_22358():
+    """
+    Downloads the EMDB-22358 volume map and returns the file path.
+
+    This molecule exhibits D6 symmetry.
+
+    :return: A 'Volume' instance.
+    """
+    file_path = fetch_data("emdb_22358.map")
+    vol = Volume.load(file_path, symmetry_group="D6")
+
+    return vol
+
+
+def emdb_9571():
+    """
+    Downloads the EMDB-9571 volume map and returns the file path.
+
+    This molecule exhibits D8 symmetry.
+
+    :return: A 'Volume' instance.
+    """
+    file_path = fetch_data("emdb_9571.map")
+    vol = Volume.load(file_path, symmetry_group="D8")
+
+    return vol
+
+
+def emdb_10920():
+    """
+    Downloads the EMDB-10920 volume map and returns the file path.
+
+    This molecule exhibits D10 symmetry.
+
+    :return: A 'Volume' instance.
+    """
+    file_path = fetch_data("emdb_10920.map")
+    vol = Volume.load(file_path, symmetry_group="D10")
+
+    return vol
+
+
 def simulated_channelspin():
     """
     Downloads the Simulated ChannelSpin dataset and returns the file path.

--- a/src/aspire/downloader/data_fetcher.py
+++ b/src/aspire/downloader/data_fetcher.py
@@ -64,18 +64,18 @@ def fetch_data(dataset_name):
 
 def download_all():
     """
-    Download all ASPIRE example data and return a dictionary of filepaths.
+    Download all ASPIRE example data and return a dictionary of files.
 
-    :return: A dictionary of method names and associated file paths.
+    :return: A dictionary of method names and associated files.
     """
 
-    file_paths = {}
+    items = {}
     for data_set in registry:
-        path = fetch_data(data_set)
+        item = fetch_data(data_set)
         name = file_to_method_map[data_set]
-        file_paths[name] = path
+        items[name] = item
 
-    return file_paths
+    return items
 
 
 def remove_downloads():
@@ -111,7 +111,7 @@ def emdb_2660():
 
 def emdb_8012():
     """
-    Downloads the EMDB-8012 volume map and returns the file path.
+    Downloads the EMDB-8012 volume map and returns a `Volume` instance.
 
     The overall structure of the yeast spliceosomal U4/U6.U5 tri-snRNP at 3.7 Angstrom.
 
@@ -125,7 +125,7 @@ def emdb_8012():
 
 def emdb_2984():
     """
-    Downloads the EMDB-2984 volume map and returns the file path.
+    Downloads the EMDB-2984 volume map and returns a `Volume` instance.
 
     2.2 A resolution cryo-EM structure of beta-galactosidase in complex with a cell-permeant inhibitor.
     This molecule exhibits D2 symmetry.
@@ -140,7 +140,7 @@ def emdb_2984():
 
 def emdb_8511():
     """
-    Downloads the EMDB-8511 volume map and returns the file path.
+    Downloads the EMDB-8511 volume map and returns a `Volume` instance.
 
     Structure of the human HCN1 hyperpolarization-activated cyclic nucleotide-gated ion channel.
     This molecule exhibits C4 symmetry.
@@ -155,7 +155,7 @@ def emdb_8511():
 
 def emdb_3645():
     """
-    Downloads the EMDB-3645 volume map and returns the file path.
+    Downloads the EMDB-3645 volume map and returns a `Volume` instance.
 
     CryoEM density of TcdA1 in prepore state (SPHIRE tutorial).
     This molecule exhibits C5 symmetry.
@@ -170,7 +170,7 @@ def emdb_3645():
 
 def emdb_4905():
     """
-    Downloads the EMDB-4905 volume map and returns the file path.
+    Downloads the EMDB-4905 volume map and returns a `Volume` instance.
 
     3D structure of horse spleen apoferritin determined using multifunctional
     graphene supports for electron cryomicroscopy. This molecule exhibits octahedral symmetry.
@@ -185,7 +185,7 @@ def emdb_4905():
 
 def emdb_10835():
     """
-    Downloads the EMDB-10835 volume map and returns the file path.
+    Downloads the EMDB-10835 volume map and returns a `Volume` instance.
 
     High resolution cryo-EM structure of urease from the pathogen Yersinia enterocolitica.
     This molecule exhibits tetrahedral symmetry.
@@ -200,7 +200,7 @@ def emdb_10835():
 
 def emdb_5778():
     """
-    Downloads the EMDB-5778 volume map and returns the file path.
+    Downloads the EMDB-5778 volume map and returns a `Volume` instance.
 
     Structure of the capsaicin receptor, TRPV1, determined by single particle electron cryo-microscopy.
     This molecule exhibits C4 symmetry.
@@ -215,7 +215,7 @@ def emdb_5778():
 
 def emdb_6287():
     """
-    Downloads the EMDB-6287 volume map and returns the file path.
+    Downloads the EMDB-6287 volume map and returns a `Volume` instance.
 
     2.8 Angstrom resolution reconstruction of the T20S proteasome.
     This molecule exhibits D7 symmetry.
@@ -230,7 +230,7 @@ def emdb_6287():
 
 def emdb_2824():
     """
-    Downloads the EMDB-2824 volume map and returns the file path.
+    Downloads the EMDB-2824 volume map and returns a `Volume` instance.
 
     Beta-galactosidase reconstruction.
     This molecule exhibits C2 symmetry.
@@ -245,7 +245,7 @@ def emdb_2824():
 
 def emdb_14621():
     """
-    Downloads the EMDB-14621 volume map and returns the file path.
+    Downloads the EMDB-14621 volume map and returns a `Volume` instance.
 
     Map of SARSCoV2 spike protein.
     This molecule exhibits C3 symmetry.
@@ -260,7 +260,7 @@ def emdb_14621():
 
 def emdb_2484():
     """
-    Downloads the EMDB-2484 volume map and returns the file path.
+    Downloads the EMDB-2484 volume map and returns a `Volume` instance.
 
     Pre-fusion structure of trimeric HIV-1 envelope glycoprotein determined by cryo-electron microscopy.
     This molecule exhibits C3 symmetry.
@@ -275,7 +275,7 @@ def emdb_2484():
 
 def emdb_6458():
     """
-    Downloads the EMDB-6458 volume map and returns the file path.
+    Downloads the EMDB-6458 volume map and returns a `Volume` instance.
 
     Cryo-EM Structure of the Activated NAIP2/NLRC4 Inflammasome Reveals Nucleated Polymerization.
     This molecule exhibits C11 symmetry.
@@ -290,7 +290,7 @@ def emdb_6458():
 
 def emdb_14803():
     """
-    Downloads the EMDB-14803 volume map and returns the file path.
+    Downloads the EMDB-14803 volume map and returns a `Volume` instance.
 
     This molecule exhibits D3 symmetry.
 
@@ -304,7 +304,7 @@ def emdb_14803():
 
 def emdb_3952():
     """
-    Downloads the EMDB-3952 volume map and returns the file path.
+    Downloads the EMDB-3952 volume map and returns a `Volume` instance.
 
     This molecule exhibits I symmetry.
 
@@ -318,7 +318,7 @@ def emdb_3952():
 
 def emdb_22308():
     """
-    Downloads the EMDB-22308 volume map and returns the file path.
+    Downloads the EMDB-22308 volume map and returns a `Volume` instance.
 
     This molecule exhibits D4 symmetry.
 
@@ -332,7 +332,7 @@ def emdb_22308():
 
 def emdb_28025():
     """
-    Downloads the EMDB-28025 volume map and returns the file path.
+    Downloads the EMDB-28025 volume map and returns a `Volume` instance.
 
     This molecule exhibits D5 symmetry.
 
@@ -346,7 +346,7 @@ def emdb_28025():
 
 def emdb_22358():
     """
-    Downloads the EMDB-22358 volume map and returns the file path.
+    Downloads the EMDB-22358 volume map and returns a `Volume` instance.
 
     This molecule exhibits D6 symmetry.
 
@@ -360,7 +360,7 @@ def emdb_22358():
 
 def emdb_9571():
     """
-    Downloads the EMDB-9571 volume map and returns the file path.
+    Downloads the EMDB-9571 volume map and returns a `Volume` instance.
 
     This molecule exhibits D8 symmetry.
 
@@ -374,7 +374,7 @@ def emdb_9571():
 
 def emdb_10920():
     """
-    Downloads the EMDB-10920 volume map and returns the file path.
+    Downloads the EMDB-10920 volume map and returns a `Volume` instance.
 
     This molecule exhibits D10 symmetry.
 
@@ -388,7 +388,7 @@ def emdb_10920():
 
 def simulated_channelspin():
     """
-    Downloads the Simulated ChannelSpin dataset and returns the file path.
+    Downloads the Simulated ChannelSpin dataset and returns a `Volume` instance.
 
     This dataset includes a stack of 54 volumes sized (54,54,54)
     and a corresponding stack of 10000 projection images (54,54).

--- a/src/aspire/downloader/registry.py
+++ b/src/aspire/downloader/registry.py
@@ -13,6 +13,13 @@ registry = {
     "emdb_14621.map": "98363ae950229243131025995b5ba0486857ccb1256b3df8d25c1c282155238c",
     "emdb_2484.map": "6a324e23352bea101c191d5e854026162a5a9b0b8fc73ac5a085cc22038e1999",
     "emdb_6458.map": "645208af6d36bbd3d172c549e58d387b81142fd320e064bc66105be0eae540d1",
+    "emdb_14803.map": "sha256:10e1d3bbc11b6660c97b2ef8b654306c0a4c9a0c621386653f2464402ad1d20b",
+    "emdb_3952.map": "sha256:8367cd35fba18806b07b0461505c4588bd61ac6cdced5ebf51fa6f10e71559fa",
+    "emdb_22308.map": "sha256:2feceb32ec0cd645881e8a46957727c076a1711074e874860e94b7c0330c8201",
+    "emdb_28025.map": "sha256:64cd10920048bbd459d791523d65c20712b8fc199bdcdca1ce5cf6e0843d4364",
+    "emdb_22358.map": "sha256:b9dee4a27d92b7fe93ab6aa08087f9b4db8abc68ca553041061ad9c8cea05f54",
+    "emdb_9571.map": "sha256:e399b5a53c23e06e2384b15150ad1f9e6120a4799ea1fdfcaf213948d959bb65",
+    "emdb_10920.map": "sha256:8e08a511903d2f088b5ed69446843dad8214fa34128e513b90a3fc75cf3fa795",
     "simulated_channelspin.npz": "c0752674acb85417f6a77a28ac55280c1926c73fda9e25ce0a9940728b1dfcc8",
 }
 
@@ -30,6 +37,13 @@ registry_urls = {
     "emdb_14621.map": "https://ftp.ebi.ac.uk/pub/databases/emdb/structures/EMD-14621/map/emd_14621.map.gz",
     "emdb_2484.map": "https://ftp.ebi.ac.uk/pub/databases/emdb/structures/EMD-2484/map/emd_2484.map.gz",
     "emdb_6458.map": "https://ftp.ebi.ac.uk/pub/databases/emdb/structures/EMD-6458/map/emd_6458.map.gz",
+    "emdb_14803.map": "https://ftp.ebi.ac.uk/pub/databases/emdb/structures/EMD-14803/map/emd_14803.map.gz",
+    "emdb_3952.map": "https://ftp.ebi.ac.uk/pub/databases/emdb/structures/EMD-3952/map/emd_3952.map.gz",
+    "emdb_22308.map": "https://ftp.ebi.ac.uk/pub/databases/emdb/structures/EMD-22308/map/emd_22308.map.gz",
+    "emdb_28025.map": "https://ftp.ebi.ac.uk/pub/databases/emdb/structures/EMD-28025/map/emd_28025.map.gz",
+    "emdb_22358.map": "https://ftp.ebi.ac.uk/pub/databases/emdb/structures/EMD-22358/map/emd_22358.map.gz",
+    "emdb_9571.map": "https://ftp.ebi.ac.uk/pub/databases/emdb/structures/EMD-9571/map/emd_9571.map.gz",
+    "emdb_10920.map": "https://ftp.ebi.ac.uk/pub/databases/emdb/structures/EMD-10920/map/emd_10920.map.gz",
     "simulated_channelspin.npz": "https://zenodo.org/records/8186548/files/example_FakeKV_dataset.npz",
 }
 
@@ -47,5 +61,12 @@ file_to_method_map = {
     "emdb_14621.map": "emdb_14621",
     "emdb_2484.map": "emdb_2484",
     "emdb_6458.map": "emdb_6458",
+    "emdb_14803.map": "emdb_14803",
+    "emdb_3952.map": "emdb_3952",
+    "emdb_22308.map": "emdb_22308",
+    "emdb_28025.map": "emdb_28025",
+    "emdb_22358.map": "emdb_22358",
+    "emdb_9571.map": "emdb_9571",
+    "emdb_10920.map": "emdb_10920",
     "simulated_channelspin.npz": "simulated_channelspin",
 }


### PR DESCRIPTION
Adds EMDB entries for molecules used by the cryosym project that were missing in ASPIRE-Python registry.

The ids and sym mapping were taken from the index page of that project.  They are high order D and an I symmetry.  It seems we already had the other volumes.

Downloaded all locally.  No other code changes outside downloader.  Will let the CI run then request review.