### PR TITLE
Pixel Size/Scaling Cleanup

### DIFF
--- a/src/aspire/image/xform.py
+++ b/src/aspire/image/xform.py
@@ -217,19 +217,10 @@ class Downsample(LinearXform):
         super().__init__()
 
     def _forward(self, im, indices):
-        original_stack_shape = im.stack_shape
-        data = im.stack_reshape(-1)._data
-        im_ds = Image._downsample(
-            data,
+        return im.downsample(
             self.resolution,
             zero_nyquist=self.zero_nyquist,
             centered_fft=self.centered_fft,
-        )
-
-        # pixel_size needs to be maintained correctly
-        scale = im.resolution / self.resolution
-        return Image(im_ds, pixel_size=im.pixel_size * scale).stack_reshape(
-            original_stack_shape
         )
 
     def _adjoint(self, im, indices):

--- a/src/aspire/image/xform.py
+++ b/src/aspire/image/xform.py
@@ -226,9 +226,9 @@ class Downsample(LinearXform):
             centered_fft=self.centered_fft,
         )
 
-        # pixel_size has already been adjusted in the ImageSource and passed
-        # to `im`, so we instantiate the new Image with im.pixel_size.
-        return Image(im_ds, pixel_size=im.pixel_size).stack_reshape(
+        # pixel_size needs to be maintained correctly
+        scale = im.resolution / self.resolution
+        return Image(im_ds, pixel_size=im.pixel_size * scale).stack_reshape(
             original_stack_shape
         )
 

--- a/src/aspire/operators/filters.py
+++ b/src/aspire/operators/filters.py
@@ -888,6 +888,12 @@ class CTFFilter(Filter):
 
         return np.all(self._ctf_params() == other._ctf_params())
 
+    def scale(self, c=1):
+        """
+        Override internal scaling for CTFFilter because they are passed pixel size explicitly.
+        """
+        return self
+
 
 class RadialCTFFilter(CTFFilter):
     def __init__(self, voltage=200, defocus=15000, Cs=2.26, alpha=0.07, B=0):

--- a/src/aspire/source/image.py
+++ b/src/aspire/source/image.py
@@ -773,12 +773,6 @@ class ImageSource(ABC):
         :param filters: A list of `Filter` objects
         :param indices: A list of indices indicating the corresponding filter in `filters`
         """
-        if not isinstance(im_orig, Image):
-            logger.warning(
-                f"_apply_filters() passed {type(im_orig)} instead of Image instance"
-            )
-            # for now just convert it
-            im_orig = Image(im_orig, pixel_size=self.pixel_size)
 
         im = im_orig.copy()
 

--- a/src/aspire/source/simulation.py
+++ b/src/aspire/source/simulation.py
@@ -316,7 +316,6 @@ class Simulation(ImageSource):
         if not clean_images and self.noise_adder is not None:
             im = self.noise_adder.forward(im, indices=indices)
 
-        # scaling pixel_size in source, scaling filter, and scaling in IMage.downsample in conflict...
         # Finally, apply transforms to resulting Image
         return self.generation_pipeline.forward(im, indices)
 
@@ -326,9 +325,6 @@ class Simulation(ImageSource):
             self.sim_filters,
             self.filter_indices[indices],
         )
-
-        # Assign correct pixel_size
-        im.pixel_size = self.pixel_size
 
         return im
 

--- a/tests/test_downsample.py
+++ b/tests/test_downsample.py
@@ -98,7 +98,9 @@ def test_downsample_2d_case(L, L_ds):
     assert checkCenterPoint(imgs_org, imgs_ds)
     # Confirm default `pixel_size`
     assert np.allclose(imgs_org.pixel_size, 1.0)
-    assert np.allclose(imgs_ds.pixel_size, imgs_org.pixel_size * (L / L_ds)), f"{imgs_ds.pixel_size}, {imgs_org.pixel_size*(L / L_ds)}"
+    assert np.allclose(
+        imgs_ds.pixel_size, imgs_org.pixel_size * (L / L_ds)
+    ), f"{imgs_ds.pixel_size}, {imgs_org.pixel_size*(L / L_ds)}"
 
 
 @pytest.mark.parametrize("L", [65, 66])

--- a/tests/test_downsample.py
+++ b/tests/test_downsample.py
@@ -98,7 +98,7 @@ def test_downsample_2d_case(L, L_ds):
     assert checkCenterPoint(imgs_org, imgs_ds)
     # Confirm default `pixel_size`
     assert np.allclose(imgs_org.pixel_size, 1.0)
-    assert np.allclose(imgs_ds.pixel_size, imgs_org.pixel_size * (L / L_ds))
+    assert np.allclose(imgs_ds.pixel_size, imgs_org.pixel_size * (L / L_ds)), f"{imgs_ds.pixel_size}, {imgs_org.pixel_size*(L / L_ds)}"
 
 
 @pytest.mark.parametrize("L", [65, 66])

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -5,6 +5,7 @@ from unittest import TestCase
 import numpy as np
 import pytest
 
+from aspire.downloader import emdb_2660
 from aspire.operators import (
     ArrayFilter,
     CTFFilter,
@@ -19,6 +20,7 @@ from aspire.operators import (
     ScaledFilter,
     ZeroFilter,
 )
+from aspire.source import ArrayImageSource, Simulation
 from aspire.utils import utest_tolerance
 
 logger = logging.getLogger(__name__)
@@ -562,3 +564,66 @@ def test_batching_eval():
         ref_eval = filter_stack[i].evaluate_grid(L, pixel_size=px)
         # compare singleton evaluation with __getitem__ from stack
         np.testing.assert_allclose(stack_eval[i], ref_eval)
+
+def testCTFdownsample():
+    """
+    Compare CTF Phaseflip -> Downsample vs Downsample -> Phaseflip
+    """
+    n = 10  # number of filters in stack
+    K = 179  # simulation pixel downsampled
+    SEED = 707
+
+    angs = np.linspace(0, 2 * np.pi, n)
+    filter_stack = [
+        CTFFilter(defocus_u=10000, defocus_v=15000, defocus_ang=ang) for ang in angs
+    ]
+
+    vol = emdb_2660().astype(np.float64)
+    sim = Simulation(
+        n=n,
+        vols=vol,
+        offsets=0,
+        amplitudes=1,
+        unique_filters=filter_stack,
+        filter_indices=np.arange(n),
+        seed=707,
+    )
+    # Reduce possibility of simulation generation code interacting with the test.
+    src = ArrayImageSource(sim.images[:])
+    src.unique_filters = sim.unique_filters
+    src.filter_indices = sim.filter_indices
+
+    sim_pf_ds = src.phase_flip().downsample(K).images[:]
+    print("----------------------------------")
+    sim_ds_pf = src.downsample(K).phase_flip().images[:]
+    print("2----------------------------------")
+
+    np.testing.assert_allclose(sim_ds_pf, sim_pf_ds)
+
+    sim_dsc_pf = src.downsample(K).cache().phase_flip().images[:]
+    np.testing.assert_allclose(sim_dsc_pf, sim_pf_ds)
+
+
+def testdownsamplecache():
+    """
+    Compare Downsample Cache vs Downsample
+    """
+    n = 10  # number of filters in stack
+    K = 179  # simulation pixel downsampled
+    SEED = 707
+
+    vol = emdb_2660().astype(np.float64)
+    src = Simulation(
+        n=n,
+        vols=vol,
+        offsets=0,
+        amplitudes=1,
+        seed=707,
+    )
+
+    sim_ds = src.downsample(K).images[:]
+    print("----------------------------------")
+    sim_dsc = src.downsample(K).cache().images[:]
+
+    np.testing.assert_allclose(sim_dsc, sim_ds)
+

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -585,9 +585,7 @@ def testCTFdownsample():
     K = 179  # simulation pixel downsampled
 
     angs = np.linspace(0, 2 * np.pi, n)
-    filter_stack = [
-        CTFFilter(defocus_u=10000, defocus_v=15000, defocus_ang=ang) for ang in angs
-    ]
+    filter_stack = CTFFilter(defocus_u=10000, defocus_v=15000, defocus_ang=angs)
 
     vol = emdb_2660().astype(np.float64)
     sim = Simulation(
@@ -595,13 +593,13 @@ def testCTFdownsample():
         vols=vol,
         offsets=0,
         amplitudes=1,
-        unique_filters=filter_stack,
+        filter_stack=filter_stack,
         filter_indices=np.arange(n),
         seed=SEED,
     )
     # Reduce possibility of simulation generation code interacting with the test.
     src = ArrayImageSource(sim.images[:])
-    src.unique_filters = sim.unique_filters
+    src.filter_stack = sim.filter_stack
     src.filter_indices = sim.filter_indices
 
     sim_pf_ds = src.phase_flip().downsample(K).images[:]

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -594,17 +594,14 @@ def testCTFdownsample():
     src.filter_indices = sim.filter_indices
 
     sim_pf_ds = src.phase_flip().downsample(K).images[:]
-    print("----------------------------------")
     sim_ds_pf = src.downsample(K).phase_flip().images[:]
-    print("2----------------------------------")
-
     np.testing.assert_allclose(sim_ds_pf, sim_pf_ds)
 
     sim_dsc_pf = src.downsample(K).cache().phase_flip().images[:]
     np.testing.assert_allclose(sim_dsc_pf, sim_pf_ds)
 
 
-def testdownsamplecache():
+def test_downsample_cache():
     """
     Compare Downsample Cache vs Downsample
     """
@@ -622,7 +619,6 @@ def testdownsamplecache():
     )
 
     sim_ds = src.downsample(K).images[:]
-    print("----------------------------------")
     sim_dsc = src.downsample(K).cache().images[:]
 
     np.testing.assert_allclose(sim_dsc, sim_ds)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -26,6 +26,7 @@ from aspire.utils import utest_tolerance
 logger = logging.getLogger(__name__)
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "saved_test_data")
+SEED = 707
 
 
 class SimTestCase(TestCase):
@@ -575,13 +576,13 @@ def test_batching_eval():
         # compare singleton evaluation with __getitem__ from stack
         np.testing.assert_allclose(stack_eval[i], ref_eval)
 
+
 def testCTFdownsample():
     """
     Compare CTF Phaseflip -> Downsample vs Downsample -> Phaseflip
     """
     n = 10  # number of filters in stack
     K = 179  # simulation pixel downsampled
-    SEED = 707
 
     angs = np.linspace(0, 2 * np.pi, n)
     filter_stack = [
@@ -596,7 +597,7 @@ def testCTFdownsample():
         amplitudes=1,
         unique_filters=filter_stack,
         filter_indices=np.arange(n),
-        seed=707,
+        seed=SEED,
     )
     # Reduce possibility of simulation generation code interacting with the test.
     src = ArrayImageSource(sim.images[:])
@@ -617,7 +618,6 @@ def test_downsample_cache():
     """
     n = 10  # number of filters in stack
     K = 179  # simulation pixel downsampled
-    SEED = 707
 
     vol = emdb_2660().astype(np.float64)
     src = Simulation(
@@ -625,11 +625,10 @@ def test_downsample_cache():
         vols=vol,
         offsets=0,
         amplitudes=1,
-        seed=707,
+        seed=SEED,
     )
 
     sim_ds = src.downsample(K).images[:]
     sim_dsc = src.downsample(K).cache().images[:]
 
     np.testing.assert_allclose(sim_dsc, sim_ds)
-

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -146,10 +146,20 @@ class SimTestCaseCTFFilter(SimTestCase):
         result1 = filt.evaluate(self.omega, **self.filter_eval_kwargs)
         scale_value = 2.5
         filt = filt.scale(scale_value)
-        # scaling a CTFFilter scales the pixel size which cancels out
-        # a corresponding scaling in omega
-        result2 = filt.evaluate(self.omega * scale_value, **self.filter_eval_kwargs)
+        # Scaling a CTFFilter is a no op; as of v15.0 scaling controlled by the pixel size.
+        result2 = filt.evaluate(self.omega, **self.filter_eval_kwargs)
         self.assertTrue(np.allclose(result1, result2, atol=utest_tolerance(self.dtype)))
+
+        # However, we can still test scaling pixel_size against scaling omega grid
+        px_sz = self.filter_eval_kwargs["pixel_size"]
+        # Scaling a CTFFilter pixel size should match a corresponding scaling in omega.
+        result3 = filt.evaluate(
+            self.omega / scale_value, pixel_size=px_sz
+        )  # scale omega
+        result4 = filt.evaluate(
+            self.omega, pixel_size=px_sz * scale_value
+        )  # scale pixel size
+        self.assertTrue(np.allclose(result4, result3, atol=utest_tolerance(self.dtype)))
 
 
 DTYPES = [np.float32, np.float64]


### PR DESCRIPTION
Cleans up multiple issues with pixel size across the image/xform/filter/source components.

Resolves #1318 and fixes the introduced bugs, closing #1395 .

Adds unit tests covering the triggering situations of the bugs.

This should probably be rebased after the larger PR 1388.


---

Ironically, it was the single `# Assign correct pixel_size` line in `Simulation` that caused all the original problems, because it was assigning the wrong pixel_size under downsampling. 

This caused some bugs (the math error in 1395) to be cancelled out, and workarounds to be added in other components... most of which I think only worked for `Simulation`s, not real data.... Hopefully that's better now.