### PR TITLE
cvxpy bug patch

### DIFF
--- a/src/aspire/abinitio/commonline_sdp.py
+++ b/src/aspire/abinitio/commonline_sdp.py
@@ -153,9 +153,15 @@ class CommonlineSDP(CLOrient3D):
                 message=r"invalid value encountered in reduce",
                 category=RuntimeWarning,
             )
+            warnings.filterwarnings(
+                "ignore",
+                message=r"overflow encountered in reduce",
+                category=RuntimeWarning,
+            )
+
             constraints += [cp.trace(A[i] @ G) == b[i] for i in range(3 * self.n_img)]
             prob = cp.Problem(cp.Minimize(cp.trace(-S @ G)), constraints)
-        prob.solve()
+            prob.solve()
 
         return G.value.astype(self.dtype, copy=False)
 


### PR DESCRIPTION
It looks like `cvxpy` does a lazy evaluation and recomputes some array shapes by summing some uninitialized arrays. This tickles the same bug from #1402. I've moved thoe `solve` inside the filter and filtered out an additional overflow warning that is sometimes triggered in addition to the invalid values warning. Ran the failing test 200 times using the same ampere testing environment. Should be all good now.